### PR TITLE
Correct typo in  'Routes' documentation

### DIFF
--- a/md/routes.md
+++ b/md/routes.md
@@ -314,7 +314,7 @@ get("/", (req, rsp, chain) -> {
     // It is OK
     chain.next(req, rsp);
   } else {
-    throw new Route.Err(403);
+    throw new Err(Status.FORBIDDEN);
   }
 });
 ```


### PR DESCRIPTION
`Route.Err` does not seems to exist. It seems that `Err` was meant.