### PR TITLE
Refactor the Request locale API

### DIFF
--- a/coverage-report/src/test/java/org/jooby/issues/Issue273.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue273.java
@@ -1,5 +1,6 @@
 package org.jooby.issues;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import org.jooby.test.ServerFeature;
@@ -12,21 +13,52 @@ public class Issue273 extends ServerFeature {
 
   {
     use(ConfigFactory.empty()
-        .withValue("application.lang", ConfigValueFactory.fromAnyRef("en-us")));
+        .withValue("application.lang",
+          ConfigValueFactory.fromAnyRef("fr-CA,fr-FR,en,en-CA,en-GB,en-US,de")));
 
-    get("/273", req -> {
-      Locale selected = req.locale();
-      Locale noMatch = req.locale(Locale.forLanguageTag("de-at"));
-      Locale match = req.locale(Locale.forLanguageTag("fr"));
-      return selected + ";" + noMatch + ";" + match;
-    });
+    get("/273", req -> req.locale().toLanguageTag());
+  }
+
+  @Test
+  public void noNegotiation() throws Exception {
+    request().get("/273")
+        .expect("fr-CA");
+  }
+
+  @Test
+  public void exactMatch() throws Exception {
+    request().get("/273")
+        .header("Accept-Language", "de")
+        .expect("de");
+
+    request().get("/273")
+        .header("Accept-Language", "en-GB")
+        .expect("en-GB");
+  }
+
+  @Test
+  public void inexactMatch() throws Exception {
+    request().get("/273")
+        .header("Accept-Language", "fr")
+        .expect("fr-CA");
+  }
+
+  @Test
+  public void noMatch() throws Exception {
+    request().get("/273")
+        .header("Accept-Language", "es")
+        .expect("fr-CA");
+
+    request().get("/273")
+        .header("Accept-Language", "en-AU")
+        .expect("fr-CA");
   }
 
   @Test
   public void shouldHanleComplexLocaleExpressions() throws Exception {
     request().get("/273")
         .header("Accept-Language", "de-DE,de;q=0.8,fr-CA;q=0.7,fr;q=0.5,en-CA;q=0.3,en;q=0.2")
-        .expect("de_DE;en_US;fr");
+        .expect("de");
   }
 
 }

--- a/coverage-report/src/test/java/org/jooby/issues/Issue273b.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue273b.java
@@ -16,22 +16,10 @@ public class Issue273b extends ServerFeature {
         .withValue("application.lang",
             ConfigValueFactory.fromAnyRef("fr-CA,fr-FR,en,en-CA,en-GB,en-US,de")));
 
-    get("/locale/def", req -> {
-      req.locales().forEach(l -> System.out.println(l.getCountry()));
-      return req.locales();
-    });
-
     get("/locale/filter", req -> req.locales(Locale::filter));
 
-    get("/locale/lookup",
-        req -> Optional.ofNullable(req.locale((range, locales) -> Locale.lookup(range, locales)))
+    get("/locale/lookup", req -> Optional.ofNullable(req.locale(Locale::lookup))
             .map(Locale::toString).orElse(""));
-  }
-
-  @Test
-  public void deflocales() throws Exception {
-    request().get("/locale/def")
-        .expect("[fr_CA, fr_FR, fr_FX, en, en_CA, en_GB, en_US, de]");
   }
 
   @Test

--- a/jooby/src/main/java/org/jooby/Request.java
+++ b/jooby/src/main/java/org/jooby/Request.java
@@ -195,11 +195,6 @@ public interface Request {
     }
 
     @Override
-    public Locale locale(final Iterable<Locale> locales) {
-      return req.locale(locales);
-    }
-
-    @Override
     public Locale locale(final BiFunction<List<LanguageRange>, List<Locale>, Locale> filter) {
       return req.locale(filter);
     }
@@ -208,11 +203,6 @@ public interface Request {
     public List<Locale> locales(
         final BiFunction<List<LanguageRange>, List<Locale>, List<Locale>> filter) {
       return req.locales(filter);
-    }
-
-    @Override
-    public Locale locale(final Locale... locales) {
-      return req.locale(locales);
     }
 
     @Override
@@ -645,12 +635,13 @@ public interface Request {
   Charset charset();
 
   /**
-   * Get the content of the <code>Accept-Language</code> header. If the request doens't specify
-   * such header, this method return the global locale: <code>application.lang</code>.
+   * Get a list of locale that best matches the current request as per {@link Locale::filter}.
    *
-   * @return List of locale.
+   * @return A list of matching locales.
    */
-  List<Locale> locales();
+  default List<Locale> locales() {
+    return locales(Locale::filter);
+  }
 
   /**
    * Get a list of locale that best matches the current request.
@@ -671,7 +662,7 @@ public interface Request {
   List<Locale> locales(BiFunction<List<Locale.LanguageRange>, List<Locale>, List<Locale>> filter);
 
   /**
-   * Get a list of locale that best matches the current request.
+   * Get a locale that best matches the current request.
    *
    * The first filter argument is the value of <code>Accept-Language</code> as
    * {@link Locale.LanguageRange} and filter while the second argument is a list of supported
@@ -684,42 +675,21 @@ public interface Request {
    * req.locale(Locale::lookup)
    * }</pre>
    *
-   * @return A list of matching locales.
+   * @return A matching locale.
    */
   Locale locale(BiFunction<List<Locale.LanguageRange>, List<Locale>, Locale> filter);
 
   /**
-   * Get the content of the <code>Accept-Language</code> header. If the request doens't specify
-   * such header, this method return the global locale: <code>application.lang</code>.
+   * Get a locale that best matches the current request or the default locale as specified
+   * in <code>application.lang</code>.
    *
-   * @return A locale.
+   * @return A matching locale.
    */
   default Locale locale() {
-    return locales().get(0);
-  }
-
-  /**
-   * Select a locale in the provided <code>collection</code> based on the content of the
-   * <code>Accept-Language</code> header using the lookup algorithm of RFC4647. If the request
-   * doens't specify such header, this method return the global locale:
-   * <code>application.lang</code>.
-   *
-   * @param locales Locales to test for.
-   * @return A locale.
-   */
-  Locale locale(Iterable<Locale> locales);
-
-  /**
-   * Select a locale in the provided <code>collection</code> based on the content of the
-   * <code>Accept-Language</code> header using the lookup algorithm of RFC4647. If the request
-   * doens't specify such header, this method return the global locale:
-   * <code>application.lang</code>.
-   *
-   * @param locales Locales to test for.
-   * @return A locale.
-   */
-  default Locale locale(final Locale... locales) {
-    return locale(Arrays.asList(locales));
+    return locale((ranges, locales) ->
+      Locale.filter(ranges, locales).stream()
+        .findFirst()
+        .orElse(locales.get(0)));
   }
 
   /**

--- a/jooby/src/main/java/org/jooby/internal/RequestImpl.java
+++ b/jooby/src/main/java/org/jooby/internal/RequestImpl.java
@@ -275,11 +275,6 @@ public class RequestImpl implements Request {
   }
 
   @Override
-  public List<Locale> locales() {
-    return lang.map(LocaleUtils::parse).orElse(locales);
-  }
-
-  @Override
   public List<Locale> locales(
       final BiFunction<List<Locale.LanguageRange>, List<Locale>, List<Locale>> filter) {
     return lang.map(h ->  filter.apply(LocaleUtils.range(h), locales))
@@ -290,14 +285,6 @@ public class RequestImpl implements Request {
   public Locale locale(final BiFunction<List<LanguageRange>, List<Locale>, Locale> filter) {
     return lang.map(h ->  filter.apply(LocaleUtils.range(h), locales))
         .orElseGet(() -> filter.apply(ImmutableList.of(), locales));
-  }
-
-  @Override
-  public Locale locale(final Iterable<Locale> locales) {
-    return lang.map(h -> {
-      Collection<Locale> clocale = ImmutableList.<Locale> copyOf(locales);
-      return Locale.lookup(LocaleUtils.range(h), clocale);
-    }).orElse(this.locales.get(0));
   }
 
   @Override

--- a/jooby/src/test/java/org/jooby/RequestForwardingTest.java
+++ b/jooby/src/test/java/org/jooby/RequestForwardingTest.java
@@ -411,30 +411,6 @@ public class RequestForwardingTest {
   }
 
   @Test
-  public void bestLocale() throws Exception {
-    new MockUnit(Request.class)
-        .expect(unit -> {
-          Request req = unit.get(Request.class);
-          expect(req.locale(Locale.CANADA)).andReturn(Locale.getDefault());
-        })
-        .run(unit -> {
-          assertEquals(Locale.getDefault(),
-              new Request.Forwarding(unit.get(Request.class)).locale(Locale.CANADA));
-        });
-
-    new MockUnit(Request.class)
-        .expect(unit -> {
-          Request req = unit.get(Request.class);
-          expect(req.locale(Arrays.asList(Locale.CANADA))).andReturn(Locale.getDefault());
-        })
-        .run(unit -> {
-          assertEquals(Locale.getDefault(),
-              new Request.Forwarding(unit.get(Request.class))
-                  .locale(Arrays.asList(Locale.CANADA)));
-        });
-  }
-
-  @Test
   public void ip() throws Exception {
     new MockUnit(Request.class)
         .expect(unit -> {

--- a/jooby/src/test/java/org/jooby/RequestTest.java
+++ b/jooby/src/test/java/org/jooby/RequestTest.java
@@ -98,11 +98,6 @@ public class RequestTest {
     }
 
     @Override
-    public Locale locale(final Iterable<Locale> locales) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public List<Locale> locales(
         final BiFunction<List<LanguageRange>, List<Locale>, List<Locale>> filter) {
       throw new UnsupportedOperationException();
@@ -110,11 +105,6 @@ public class RequestTest {
 
     @Override
     public Locale locale(final BiFunction<List<LanguageRange>, List<Locale>, Locale> filter) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Locale locale(final Locale... locales) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Following the addition of:
 - `List<Locale> locales(BiFunction<List<Locale.LanguageRange>, List<Locale>, List<Locale>> filter`
 - `Locale locale(BiFunction<List<Locale.LanguageRange>, List<Locale>, Locale> filter)`

`Locale locale(Iterable<Locale> locales)` and `Locale locale(Locale... locales)`
were made redundant by the new two functions. This use case can be implemented
in the following way:

    List<Locale> supportedLocales = ...
    Locale locale = req.locale((ranges, locales) ->
      Locale.lookup(ranges, supportedLocales));

`List<Locale> locales()` is just an shorthand for `locales(Locale::filter)`.

`Locale locale()` simply returns the first element of `locales` or the default
locale as per `app.lang` if there are no matches. This function is expected to
be the most used one.

Issue #273