### PR TITLE
Multiple code improvements - squid:S2275, squid:S1213, squid:S1155

### DIFF
--- a/jooby-hotreload/src/main/java/org/jooby/hotreload/AppModule.java
+++ b/jooby-hotreload/src/main/java/org/jooby/hotreload/AppModule.java
@@ -101,7 +101,7 @@ public class AppModule {
         }
       }
     }
-    if (cp.size() == 0) {
+    if (cp.isEmpty()) {
       cp.add(new File(System.getProperty("user.dir")));
     }
     AppModule launcher = new AppModule(args[0], args[1], args[2], cp.toArray(new File[cp.size()]))
@@ -165,9 +165,9 @@ public class AppModule {
   }
 
   public void run() {
-    System.out.printf("Hotswap available on: %s\n", Arrays.toString(dirs));
-    System.out.printf("  includes: %s\n", includes);
-    System.out.printf("  excludes: %s\n", excludes);
+    System.out.printf("Hotswap available on: %s%n", Arrays.toString(dirs));
+    System.out.printf("  includes: %s%n", includes);
+    System.out.printf("  excludes: %s%n", excludes);
 
     this.scanner.start();
     this.startApp();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava