### PR TITLE
Multiple code improvements - squid:S1192, squid:S1066, squid:S1193

### DIFF
--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyHandler.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyHandler.java
@@ -79,16 +79,14 @@ public class JettyHandler extends AbstractHandler {
             @SuppressWarnings("unchecked")
             @Override
             public <T> T upgrade(final Class<T> type) throws Exception {
-              if (type == NativeWebSocket.class) {
-                if (webSocketServerFactory.isUpgradeRequest(request, response)) {
-                  if (webSocketServerFactory.acceptWebSocket(request, response)) {
-                    String key = JettyWebSocket.class.getName();
-                    NativeWebSocket ws = (NativeWebSocket) request.getAttribute(key);
-                    if (ws != null) {
-                      request.removeAttribute(key);
-                      return (T) ws;
-                    }
-                  }
+              if (type == NativeWebSocket.class
+                  && webSocketServerFactory.isUpgradeRequest(request, response)
+                  && webSocketServerFactory.acceptWebSocket(request, response)) {
+                String key = JettyWebSocket.class.getName();
+                NativeWebSocket ws = (NativeWebSocket) request.getAttribute(key);
+                if (ws != null) {
+                  request.removeAttribute(key);
+                  return (T) ws;
                 }
               }
               throw new UnsupportedOperationException("Not Supported: " + type);

--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyWebSocket.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyWebSocket.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
+  private static final String A_CALLBACK_IS_REQUIRED = "A callback is required.";
+  private static final String NO_DATA_TO_SEND = "No data to send.";
   /** The logging system. */
   private final Logger log = LoggerFactory.getLogger(WebSocket.class);
 
@@ -74,27 +76,27 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void onConnect(final Runnable callback) {
-    this.onConnectCallback = requireNonNull(callback, "A callback is required.");
+    this.onConnectCallback = requireNonNull(callback, A_CALLBACK_IS_REQUIRED);
   }
 
   @Override
   public void onTextMessage(final Consumer<String> callback) {
-    this.onTextCallback = requireNonNull(callback, "A callback is required.");
+    this.onTextCallback = requireNonNull(callback, A_CALLBACK_IS_REQUIRED);
   }
 
   @Override
   public void onBinaryMessage(final Consumer<ByteBuffer> callback) {
-    this.onBinaryCallback = requireNonNull(callback, "A callback is required.");
+    this.onBinaryCallback = requireNonNull(callback, A_CALLBACK_IS_REQUIRED);
   }
 
   @Override
   public void onCloseMessage(final BiConsumer<Integer, Optional<String>> callback) {
-    this.onCloseCallback = requireNonNull(callback, "A callback is required.");
+    this.onCloseCallback = requireNonNull(callback, A_CALLBACK_IS_REQUIRED);
   }
 
   @Override
   public void onErrorMessage(final Consumer<Throwable> callback) {
-    this.onErrorCallback = requireNonNull(callback, "A callback is required.");
+    this.onErrorCallback = requireNonNull(callback, A_CALLBACK_IS_REQUIRED);
   }
 
   @Override
@@ -111,7 +113,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendBytes(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
-    requireNonNull(data, "No data to send.");
+    requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
     remote.sendBytes(data, callback(log, success, err));
@@ -119,13 +121,13 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendBytes(final byte[] data, final SuccessCallback success, final ErrCallback err) {
-    requireNonNull(data, "No data to send.");
+    requireNonNull(data, NO_DATA_TO_SEND);
     sendBytes(ByteBuffer.wrap(data), success, err);
   }
 
   @Override
   public void sendText(final String data, final SuccessCallback success, final ErrCallback err) {
-    requireNonNull(data, "No data to send.");
+    requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
     remote.sendString(data, callback(log, success, err));
@@ -133,7 +135,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendText(final byte[] data, final SuccessCallback success, final ErrCallback err) {
-    requireNonNull(data, "No data to send.");
+    requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
     remote.sendString(new String(data, StandardCharsets.UTF_8), callback(log, success, err));
@@ -141,7 +143,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendText(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
-    requireNonNull(data, "No data to send.");
+    requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
     CharBuffer buffer = StandardCharsets.UTF_8.decode(data);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1066 - Collapsible "if" statements should be merged. 
squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1193
Please let me know if you have any questions.
George Kankava