### PR TITLE
Fix #309 Jooby coverage-report BeanvalidationFeature fails with German locale

### DIFF
--- a/coverage-report/src/test/java/org/jooby/hbm/data/Car.java
+++ b/coverage-report/src/test/java/org/jooby/hbm/data/Car.java
@@ -7,14 +7,14 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 public class Car {
 
-  @NotEmpty
+  @NotEmpty(message = "may not be empty")
   private String manufacturer;
 
-  @NotEmpty
+  @NotEmpty(message = "may not be empty")
   @Size(min = 2, max = 14)
   private String licensePlate;
 
-  @Min(2)
+  @Min(value = 2, message = "must be greater than or equal to 2")
   private int seatCount;
 
   public Car(final String manufacturer, final String licencePlate, final int seatCount) {

--- a/coverage-report/src/test/java/org/jooby/session/SessionConfigCookieFeature.java
+++ b/coverage-report/src/test/java/org/jooby/session/SessionConfigCookieFeature.java
@@ -6,8 +6,10 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import org.jooby.Session;
+import org.jooby.mvc.Local;
 import org.jooby.test.ServerFeature;
 import org.junit.Test;
 
@@ -44,7 +46,8 @@ public class SessionConfigCookieFeature extends ServerFeature {
     long maxAge = System.currentTimeMillis() + 60 * 1000;
     // remove seconds to make sure test always work
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy HH:mm")
-        .withZone(ZoneId.of("GMT"));
+        .withZone(ZoneId.of("GMT"))
+        .withLocale(Locale.ENGLISH);
     Instant instant = Instant.ofEpochMilli(maxAge);
 
     request()
@@ -54,7 +57,7 @@ public class SessionConfigCookieFeature extends ServerFeature {
           List<String> setCookie = Lists.newArrayList(
               Splitter.onPattern(";\\s*")
                   .splitToList(value)
-              );
+          );
 
           assertTrue(setCookie.remove(0).startsWith("custom.sid"));
           assertTrue(setCookie.remove("Path=/session") || setCookie.remove("Path=\"/session\""));

--- a/coverage-report/src/test/java/org/jooby/session/SessionCookieFeature.java
+++ b/coverage-report/src/test/java/org/jooby/session/SessionCookieFeature.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import org.jooby.Session;
 import org.jooby.test.ServerFeature;
@@ -40,7 +41,8 @@ public class SessionCookieFeature extends ServerFeature {
     long maxAge = System.currentTimeMillis() + 60 * 1000;
     // remove seconds to make sure test always work
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy HH:mm")
-        .withZone(ZoneId.of("GMT"));
+        .withZone(ZoneId.of("GMT"))
+        .withLocale(Locale.ENGLISH);
     Instant instant = Instant.ofEpochMilli(maxAge);
 
     request()

--- a/coverage-report/src/test/java/org/jooby/session/SessionCookieNoSecretFeature.java
+++ b/coverage-report/src/test/java/org/jooby/session/SessionCookieNoSecretFeature.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import org.jooby.Session;
 import org.jooby.test.ServerFeature;
@@ -33,7 +34,8 @@ public class SessionCookieNoSecretFeature extends ServerFeature {
     long maxAge = System.currentTimeMillis() + 60 * 1000;
     // remove seconds to make sure test always work
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy HH:mm")
-        .withZone(ZoneId.of("GMT"));
+        .withZone(ZoneId.of("GMT"))
+        .withLocale(Locale.ENGLISH);
     Instant instant = Instant.ofEpochMilli(maxAge);
 
     request()

--- a/coverage-report/src/test/java/org/jooby/session/SessionWithMaxAgeShouldAlwaysSendHeaderFeature.java
+++ b/coverage-report/src/test/java/org/jooby/session/SessionWithMaxAgeShouldAlwaysSendHeaderFeature.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jooby.Session;
@@ -77,7 +78,8 @@ public class SessionWithMaxAgeShouldAlwaysSendHeaderFeature extends ServerFeatur
 
   private String sessionId(final String id, final Instant instant) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy HH:mm")
-        .withZone(ZoneId.of("GMT"));
+        .withZone(ZoneId.of("GMT"))
+        .withLocale(Locale.ENGLISH);
     return "jooby.sid=" + id + ";Version=1;Path=/;HttpOnly;Max-Age=2;Expires="
         + formatter.format(instant);
   }


### PR DESCRIPTION
Hardcoded bean validation messages to US locale ones to make test pass independent of host system locale.