### PR TITLE
Jooby QueryDSL-JDBC support

### DIFF
--- a/jooby-jdbc/src/main/java/org/jooby/jdbc/Jdbc.java
+++ b/jooby-jdbc/src/main/java/org/jooby/jdbc/Jdbc.java
@@ -191,7 +191,7 @@ public class Jdbc implements Jooby.Module {
 
   private HikariDataSourceProvider ds;
 
-  private Optional<String> dbtype;
+  protected Optional<String> dbtype;
 
   public Jdbc(final String name) {
     checkArgument(name != null && name.length() > 0, "A database name is required.");

--- a/jooby-querydsl/pom.xml
+++ b/jooby-querydsl/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jooby-project</artifactId>
+        <groupId>org.jooby</groupId>
+        <version>0.17.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jooby-querydsl</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-core</artifactId>
+            <version>${querydsl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-sql</artifactId>
+            <version>${querydsl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby-jdbc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jooby-querydsl/src/main/java/org/jooby/querydsl/QueryDSL.java
+++ b/jooby-querydsl/src/main/java/org/jooby/querydsl/QueryDSL.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.querydsl;
+
+import com.google.inject.Binder;
+import com.google.inject.Provider;
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.SQLQueryFactory;
+import com.querydsl.sql.SQLTemplates;
+import com.typesafe.config.Config;
+import org.jooby.Env;
+import org.jooby.jdbc.Jdbc;
+import org.jooby.querydsl.internal.ConfigurationProvider;
+import org.jooby.querydsl.internal.SQLQueryFactoryProvider;
+import org.jooby.querydsl.internal.SQLTemplatesProvider;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * <h1>QueryDSL</h1>
+ * <p>
+ * SQL abstraction provided by <a href="http://www.querydsl.com"QueryDSL</a> using plain JDBC underneath.
+ * </p>
+ *
+ * <p>
+ * This module depends on {@link Jdbc} module, make sure you read the doc of the {@link Jdbc}
+ * module.
+ * </p>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * import org.jooby.querydsl.QueryDSL;
+ *
+ * {
+ *   use(new QueryDSL());
+ *
+ *   get("/my-api", (req, rsp) {@literal ->} {
+ *     SQLQueryFactory queryFactory = req.require(SQLQueryFactory.class);
+ *     // Do something with the database
+ *   });
+ * }
+ * </pre>
+ *
+ * <h2>Multiple DBs</h2>
+ *
+ * <pre>
+ * import org.jooby.querydsl.QueryDSL;
+ *
+ * {
+ *   use(new QueryDSL("db.main");
+ *   use(new QueryDSL("db.aux");
+ *
+ *   get("/my-api", (req, rsp) {@literal ->} {
+ *     SQLQueryFactory queryFactory = req.require("db.main", SQLQueryFactory.class);
+ *     // Do something with the database
+ *   });
+ * }
+ * </pre>
+ *
+ * <h2>Advanced Configuration</h2>
+ * <p>This module builds QueryDSL SQLQueryFactories on top of a default {@link Configuration} object, a
+ * {@link SQLTemplates} instance and a {@link javax.sql.DataSource} from the {@link Jdbc} module. Advanced
+ * configuration can be added by invoking the {@link #doWith(BiConsumer)} method, adding your own settings to the
+ * configuration</p>
+ * <pre>
+ * {
+ *   use(new QueryDSL().doWith(conf {@literal ->} {
+ *     conf.set(...);
+ *   });
+ * }
+ * </pre>
+ *
+ * <h2>Code generation</h2>
+ * <p>
+ *   This module does not provide code generation for DB mapping classes. To learn how to create QueryDSL mapping
+ *   classes using Maven, please consult the
+ *   <a href="http://www.querydsl.com/static/querydsl/latest/reference/html_single/#d0e725">QueryDSL documentation.</a>
+ * </p>
+ *
+ *
+ * @since 0.17.0-SNAPSHOT
+ * @author sjackel
+ */
+public class QueryDSL extends Jdbc {
+
+  private BiConsumer<Configuration, Config> callback;
+
+  /**
+   * Creates a new {@link QueryDSL} module
+   * @param name Database name
+   */
+  public QueryDSL(final String name) {
+    super(name);
+  }
+
+  /**
+   * Creates a new {@link QueryDSL} module
+   */
+  public QueryDSL() {
+    this(DEFAULT_DB);
+  }
+
+  @Override
+  public void configure(final Env env, final Config config, final Binder binder) {
+    super.configure(env, config, binder);
+
+    Provider<SQLTemplates> templatesProvider = new SQLTemplatesProvider(dbtype.orElse("custom"));
+    Configuration queryDslConfig = new Configuration(templatesProvider.get());
+
+    if (callback != null) {
+      callback.accept(queryDslConfig, config);
+    }
+
+    keys(SQLTemplates.class, k -> binder.bind(k).toProvider(templatesProvider));
+    keys(Configuration.class, k -> binder.bind(k).toInstance(queryDslConfig));
+    keys(SQLQueryFactory.class, k -> binder.bind(k).toProvider(SQLQueryFactoryProvider.class));
+  }
+
+  /**
+   * Apply advanced configuration
+   * @param callback a configuration callback.
+   * @return this module.
+   */
+  public QueryDSL doWith(final Consumer<Configuration> callback) {
+    requireNonNull(callback, "Callback needs to be defined");
+    return doWith((configuration, conf) -> callback.accept(configuration));
+  }
+
+  /**
+   * Apply advanced configuration
+   * @param callback a configuration callback.
+   * @return this module.
+   */
+  public QueryDSL doWith(final BiConsumer<Configuration, Config> callback) {
+    this.callback = requireNonNull(callback, "Callback needs to be defined");
+    return this;
+  }
+}

--- a/jooby-querydsl/src/main/java/org/jooby/querydsl/SQLDialectDetector.java
+++ b/jooby-querydsl/src/main/java/org/jooby/querydsl/SQLDialectDetector.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.querydsl;
+
+import com.querydsl.sql.*;
+
+public interface SQLDialectDetector {
+
+    static SQLTemplates detectByUrl(String url) {
+        if (url == null) throw new IllegalArgumentException("URL is null");
+        String[] components = url.split(":");
+        if (components.length < 2 || !components[0].toLowerCase().equals("jdbc")) {
+            throw new IllegalArgumentException(String.format("Invalid jdbc URL: %s", url));
+        }
+        return detectByDbTypeString(components[1].toLowerCase());
+    }
+
+    static SQLTemplates detectByDbTypeString(String dbType) {
+        switch (dbType) {
+            case "mysql":
+                return new MySQLTemplates();
+            case "h2":
+                return new H2Templates();
+            case "derby":
+                return new DerbyTemplates();
+            case "hsqldb":
+                return new HSQLDBTemplates();
+            case "postgres":
+            case "pgsql":
+                return new PostgreSQLTemplates();
+            case "sqlite":
+                return new SQLiteTemplates();
+            default:
+                throw new IllegalArgumentException("Could not determine database type!");
+        }
+    }
+}

--- a/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/ConfigurationProvider.java
+++ b/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/ConfigurationProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.querydsl.internal;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.SQLTemplates;
+
+public class ConfigurationProvider implements Provider<Configuration> {
+
+    private SQLTemplates templates;
+
+    @Inject
+    public ConfigurationProvider(SQLTemplates templates) {
+        this.templates = templates;
+    }
+
+    @Override
+    public Configuration get() {
+        return new Configuration(templates);
+    }
+}

--- a/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/SQLQueryFactoryProvider.java
+++ b/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/SQLQueryFactoryProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.querydsl.internal;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.SQLQueryFactory;
+import com.querydsl.sql.SQLTemplates;
+
+import javax.sql.DataSource;
+
+public class SQLQueryFactoryProvider implements Provider<SQLQueryFactory> {
+
+    private final Configuration configuration;
+    private final DataSource dataSource;
+
+    @Inject
+    public SQLQueryFactoryProvider(Configuration configuration, DataSource dataSource) {
+        this.configuration = configuration;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public SQLQueryFactory get() {
+        return new SQLQueryFactory(configuration, dataSource);
+    }
+}

--- a/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/SQLTemplatesProvider.java
+++ b/jooby-querydsl/src/main/java/org/jooby/querydsl/internal/SQLTemplatesProvider.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.querydsl.internal;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.querydsl.sql.SQLTemplates;
+import org.jooby.querydsl.SQLDialectDetector;
+
+public class SQLTemplatesProvider implements Provider<SQLTemplates> {
+
+    private final String dbType;
+
+    @Inject
+    public SQLTemplatesProvider(String dbType) {
+        this.dbType = dbType;
+    }
+
+
+    @Override
+    public SQLTemplates get() {
+        return SQLDialectDetector.detectByDbTypeString(dbType);
+    }
+}

--- a/jooby-querydsl/src/test/java/org/jooby/querydsl/QueryDSLTest.java
+++ b/jooby-querydsl/src/test/java/org/jooby/querydsl/QueryDSLTest.java
@@ -1,0 +1,106 @@
+package org.jooby.querydsl;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.binder.AnnotatedBindingBuilder;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.binder.ScopedBindingBuilder;
+import com.google.inject.name.Names;
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.H2Templates;
+import com.querydsl.sql.SQLQueryFactory;
+import com.querydsl.sql.SQLTemplates;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
+import org.jooby.Env;
+import org.jooby.querydsl.internal.ConfigurationProvider;
+import org.jooby.querydsl.internal.SQLQueryFactoryProvider;
+import org.jooby.querydsl.internal.SQLTemplatesProvider;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.inject.Provider;
+import javax.sql.DataSource;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Configuration.class, H2Templates.class, SQLTemplatesProvider.class})
+public class QueryDSLTest {
+
+  @SuppressWarnings("unchecked")
+  private MockUnit.Block jdbc = unit -> {
+    Binder binder = unit.get(Binder.class);
+
+    ScopedBindingBuilder scope = unit.mock(ScopedBindingBuilder.class);
+    scope.asEagerSingleton();
+    scope.asEagerSingleton();
+
+    LinkedBindingBuilder<DataSource> binding = unit.mock(LinkedBindingBuilder.class);
+    expect(binding.toProvider(isA(Provider.class))).andReturn(scope).times(2);
+    expect(binder.bind(Key.get(DataSource.class))).andReturn(binding);
+    expect(binder.bind(Key.get(DataSource.class, Names.named("db")))).andReturn(binding);
+  };
+
+  @SuppressWarnings("unchecked")
+  private MockUnit.Block configuration = unit -> {
+
+    AnnotatedBindingBuilder<SQLTemplates> templatesBinding = unit.mock(AnnotatedBindingBuilder.class);
+    expect(templatesBinding.toProvider(isA(SQLTemplatesProvider.class))).andReturn(null).times(2);
+
+    AnnotatedBindingBuilder<Configuration> configBinding = unit.mock(AnnotatedBindingBuilder.class);
+    configBinding.toInstance(isA(Configuration.class));
+    configBinding.toInstance(isA(Configuration.class));
+    expectLastCall();
+
+    AnnotatedBindingBuilder<SQLQueryFactory> queryFactoryBinding = unit.mock(AnnotatedBindingBuilder.class);
+    expect(queryFactoryBinding.toProvider(SQLQueryFactoryProvider.class)).andReturn(null).times(2);
+
+    Binder binder = unit.get(Binder.class);
+    expect(binder.bind(Key.get(SQLTemplates.class))).andReturn(templatesBinding);
+    expect(binder.bind(Key.get(SQLTemplates.class, Names.named("db")))).andReturn(templatesBinding);
+    expect(binder.bind(Key.get(Configuration.class))).andReturn(configBinding);
+    expect(binder.bind(Key.get(Configuration.class, Names.named("db")))).andReturn(configBinding);
+    expect(binder.bind(Key.get(SQLQueryFactory.class))).andReturn(queryFactoryBinding);
+    expect(binder.bind(Key.get(SQLQueryFactory.class, Names.named("db")))).andReturn(queryFactoryBinding);
+  };
+
+  @Test
+  public void defaults() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, Configuration.class)
+        .expect(jdbc)
+        .expect(configuration)
+        .run(unit -> {
+          new QueryDSL()
+              .configure(unit.get(Env.class), config(), unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void doWith() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class)
+        .expect(jdbc)
+        .expect(configuration)
+        .run(unit -> {
+          new QueryDSL()
+              .doWith(c -> assertEquals(H2Templates.class, c.getTemplates().getClass()))
+              .configure(unit.get(Env.class), config(), unit.get(Binder.class));
+        });
+  }
+
+  public Config config() {
+    return new QueryDSL().config()
+        .withValue("db", ConfigValueFactory.fromAnyRef("mem"))
+        .withValue("application.ns", ConfigValueFactory.fromAnyRef("my.model"))
+        .withValue("application.tmpdir", ConfigValueFactory.fromAnyRef("target"))
+        .withValue("application.name", ConfigValueFactory.fromAnyRef("model"))
+        .withValue("application.charset", ConfigValueFactory.fromAnyRef("UTF-8"))
+        .resolve();
+  }
+}

--- a/jooby-querydsl/src/test/java/org/jooby/querydsl/SQLDialectDetectorTest.java
+++ b/jooby-querydsl/src/test/java/org/jooby/querydsl/SQLDialectDetectorTest.java
@@ -1,0 +1,71 @@
+package org.jooby.querydsl;
+
+import com.querydsl.sql.*;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+
+import static org.junit.Assert.*;
+
+
+public class SQLDialectDetectorTest {
+
+  @Test
+  public void detectMySql() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:mysql://localhost:3306");
+    assertTrue(templates instanceof MySQLTemplates);
+  }
+
+  @Test
+  public void detectPostgreSql() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:postgres://localhost:5432");
+    assertTrue(templates instanceof PostgreSQLTemplates);
+  }
+
+  @Test
+  public void detectPgSql() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:pgsql://localhost:5432");
+    assertTrue(templates instanceof PostgreSQLTemplates);
+  }
+
+  @Test
+  public void detectH2() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:h2:mem:test");
+    assertTrue(templates instanceof H2Templates);
+  }
+
+  @Test
+  public void detectHSql() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:hsqldb:hsql://localhost/test");
+    assertTrue(templates instanceof HSQLDBTemplates);
+  }
+
+  @Test
+  public void detectSqlite() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:sqlite:some.db");
+    assertTrue(templates instanceof SQLiteTemplates);
+  }
+
+  @Test
+  public void detectDerby() {
+    SQLTemplates templates = SQLDialectDetector.detectByUrl("jdbc:derby:some.db");
+    assertTrue(templates instanceof DerbyTemplates);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void unknownDbShouldFail() {
+    SQLDialectDetector.detectByUrl("jdbc:fail:so.hard");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nonjdbcUrlShouldFail() {
+    SQLDialectDetector.detectByUrl("fail:db:now");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void detectFromDataSourceShouldFailOnNull() {
+    SQLDialectDetector.detectByUrl(null);
+  }
+}

--- a/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/ConfigurationProviderTest.java
+++ b/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/ConfigurationProviderTest.java
@@ -1,0 +1,18 @@
+package org.jooby.querydsl.internal;
+
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.H2Templates;
+import com.querydsl.sql.SQLTemplates;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConfigurationProviderTest {
+
+  @Test
+  public void get() throws Exception {
+    SQLTemplates templates = new H2Templates();
+    Configuration configuration = new ConfigurationProvider(templates).get();
+    assertEquals(configuration.getTemplates(), templates);
+  }
+}

--- a/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/SQLQueryFactoryProviderTest.java
+++ b/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/SQLQueryFactoryProviderTest.java
@@ -1,0 +1,32 @@
+package org.jooby.querydsl.internal;
+
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.SQLCloseListener;
+import com.querydsl.sql.SQLQueryFactory;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.sql.DataSource;
+
+import static org.easymock.EasyMock.expectLastCall;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Configuration.class, SQLQueryFactory.class, SQLQueryFactoryProvider.class, SQLCloseListener.class})
+public class SQLQueryFactoryProviderTest {
+
+  @Test
+  public void get() throws Exception {
+    new MockUnit(Configuration.class, DataSource.class, SQLQueryFactory.class, SQLQueryFactoryProvider.class, SQLCloseListener.class)
+        .expect(unit -> {
+          Configuration config = unit.get(Configuration.class);
+          config.addListener(SQLCloseListener.DEFAULT);
+          expectLastCall();
+        }).run(unit -> {
+      new SQLQueryFactoryProvider(unit.get(Configuration.class), unit.get(DataSource.class)).get();
+    });
+  }
+
+}

--- a/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/SQLTemplatesProviderTest.java
+++ b/jooby-querydsl/src/test/java/org/jooby/querydsl/internal/SQLTemplatesProviderTest.java
@@ -1,0 +1,26 @@
+package org.jooby.querydsl.internal;
+
+import com.querydsl.sql.H2Templates;
+import com.querydsl.sql.SQLTemplates;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertTrue;
+
+public class SQLTemplatesProviderTest {
+
+  @Test
+  public void getH2() throws Exception {
+    new MockUnit(DatabaseMetaData.class, Connection.class, DataSource.class).run(unit -> {
+      SQLTemplates templates = new SQLTemplatesProvider("h2").get();
+      assertTrue(templates.getClass().equals(H2Templates.class));
+    });
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <module>jooby-assets-babel</module>
     <module>jooby-assets-rollup</module>
     <module>jooby-metrics</module>
+    <module>jooby-querydsl</module>
     <module>coverage-report</module>
   </modules>
 
@@ -2192,6 +2193,9 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
 
     <!-- jooq -->
     <jooq.version>3.7.2</jooq.version>
+
+    <!-- QueryDSL -->
+    <querydsl.version>4.0.9</querydsl.version>
 
     <!-- javaslang -->
     <javaslang.version>2.0.0</javaslang.version>


### PR DESCRIPTION
I kinda hope this isn't unsolicited as I've seen, you guys seem to be working on a QueryDSL module of your own, using QueryDSL with JPA. I've recently implemented a small service based on Jooby and tried out QueryDSL on plain JDBC specifically because I had relatively few interactions with the DB and wanted to avoid the bload of JPA.

...and suddenly I ended up with everything to exract a generic Jooby module for integrating QueryDSL over JDBC.
I've borrowed heavily from the jOOQ module to get the layout in shape. Biggest hurdle was the actual lack of any SQL Dialect detection, but turns out, nobody seems to do anything smarter than examining the DB URL string.

Maybe you've already got this on the backburner or decide it is redundant to have, but I'd like to hear your input on this!