### PR TITLE
Used the PebbleEngine#cacheActive method to enable/disable Pebble tem…

### DIFF
--- a/jooby-pebble/src/main/java/org/jooby/pebble/Pebble.java
+++ b/jooby-pebble/src/main/java/org/jooby/pebble/Pebble.java
@@ -186,6 +186,7 @@ public class Pebble implements Jooby.Module {
   public void configure(final Env env, final Config conf, final Binder binder) {
     /** Template cache. */
     String mode = env.name();
+	pebble.cacheActive(!mode.equals("dev"));
     if (mode.equals("dev") || conf.getString("pebble.cache").isEmpty()) {
       pebble.templateCache(null);
     } else {


### PR DESCRIPTION
Using `PebbleEngine#templateCache(null)` by itself doesn't disable template caching, the `PebbleEngine#cacheActive()` method needs to be called. See [here](https://github.com/PebbleTemplates/pebble/blob/master/src/main/java/com/mitchellbosecke/pebble/PebbleEngine.java#L418-L428)