### PR TITLE
Add named globbing using "**:name" or "{name:**}"

### DIFF
--- a/jooby/src/test/java/org/jooby/internal/RoutePatternTest.java
+++ b/jooby/src/test/java/org/jooby/internal/RoutePatternTest.java
@@ -139,6 +139,104 @@ public class RoutePatternTest {
   }
 
   @Test
+  public void anyNamed() {
+    new RoutePathAssert("GET", "com/**:rest")
+        .matches("GET/com/test.jsp", vars -> assertEquals("test.jsp", vars.get("rest")))
+        .matches("GET/com/a/test.jsp", vars -> assertEquals("a/test.jsp", vars.get("rest")))
+        .matches("GET/com/", vars -> assertEquals("", vars.get("rest")))
+        .butNot("GET/com")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedSpring() {
+    new RoutePathAssert("GET", "com/{rest:**}")
+        .matches("GET/com/test.jsp", vars -> assertEquals("test.jsp", vars.get("rest")))
+        .matches("GET/com/a/test.jsp", vars -> assertEquals("a/test.jsp", vars.get("rest")))
+        .matches("GET/com/", vars -> assertEquals("", vars.get("rest")))
+        .butNot("GET/com")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedInner() {
+    new RoutePathAssert("GET", "com/**:rest/bar")
+        .matches("GET/com/foo/bar", (vars) -> assertEquals("foo", vars.get("rest")))
+        .matches("GET/com/a/foo/bar", (vars) -> assertEquals("a/foo", vars.get("rest")))
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedInnerSpring() {
+    new RoutePathAssert("GET", "com/{rest:**}/bar")
+        .matches("GET/com/foo/bar", (vars) -> assertEquals("foo", vars.get("rest")))
+        .matches("GET/com/a/foo/bar", (vars) -> assertEquals("a/foo", vars.get("rest")))
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedMulti() {
+    new RoutePathAssert("GET", "com/**:first/bar/**:second")
+        .matches("GET/com/foo/bar/moo", (vars) -> {
+          assertEquals("foo", vars.get("first"));
+          assertEquals("moo", vars.get("second"));
+        })
+        .matches("GET/com/a/foo/bar/moo/baz", (vars) -> {
+          assertEquals("a/foo", vars.get("first"));
+          assertEquals("moo/baz", vars.get("second"));
+        })
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedMultiSpring() {
+    new RoutePathAssert("GET", "com/{first:**}/bar/{second:**}")
+        .matches("GET/com/foo/bar/moo", (vars) -> {
+          assertEquals("foo", vars.get("first"));
+          assertEquals("moo", vars.get("second"));
+        })
+        .matches("GET/com/a/foo/bar/moo/baz", (vars) -> {
+          assertEquals("a/foo", vars.get("first"));
+          assertEquals("moo/baz", vars.get("second"));
+        })
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedMultiMixed() {
+    new RoutePathAssert("GET", "com/**:first/bar/{second:**}")
+        .matches("GET/com/foo/bar/moo", (vars) -> {
+          assertEquals("foo", vars.get("first"));
+          assertEquals("moo", vars.get("second"));
+        })
+        .matches("GET/com/a/foo/bar/moo/baz", (vars) -> {
+          assertEquals("a/foo", vars.get("first"));
+          assertEquals("moo/baz", vars.get("second"));
+        })
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
+  public void anyNamedMultiMixed2() {
+    new RoutePathAssert("GET", "com/{first:**}/bar/**:second")
+        .matches("GET/com/foo/bar/moo", (vars) -> {
+          assertEquals("foo", vars.get("first"));
+          assertEquals("moo", vars.get("second"));
+        })
+        .matches("GET/com/a/foo/bar/moo/baz", (vars) -> {
+          assertEquals("a/foo", vars.get("first"));
+          assertEquals("moo/baz", vars.get("second"));
+        })
+        .butNot("GET/com/foo/baz")
+        .butNot("GET/test.jsp");
+  }
+
+  @Test
   public void rootVar() {
     new RoutePathAssert("GET", "{id}/list")
         .matches("GET/xqi/list")

--- a/md/routes.md
+++ b/md/routes.md
@@ -86,6 +86,9 @@ get("/user/:id", req -> "hey " + req.param("id").value());
 // alternative syntax
 get("/user/{id}", req -> "hey " + req.param("id").value());
 
+// matches path element with prefix "uid"
+get("/user/uid{id}", req -> "hey " + req.param("id").value());
+
 // regex
 get("/user/{id:\\d+}", req -> "hey " + req.param("id").intValue());
 ```
@@ -103,6 +106,8 @@ Request params are covered later, for now all you need to know is that you can a
   ```**``` - matches any path at any level
 
   ```*``` - matches any path at any level, shortcut for ```**```
+  
+  ```**:name``` or ```{name:**}``` - matches any path at any level and binds the match to the request parameter ```name```
 
 ## static files
 


### PR DESCRIPTION
Enhances the routing path matcher by allowing the binding of globs as a named parameter using the following syntax:

```java
get("/foo/**:tail", req -> {
  doSomething(req.params("tail")); // GET/foo/bar/baz -> tail == "bar/baz"
});

get("/foo/{tail:**}", req -> {
  doSomething(eq.params("tail")); // same
});

get("/foo/**:inbetween/end", req -> {
  doSomething(eq.params("inbetween")); // GET/foo/bar/baz/end -> inbetween == "bar/baz"
});

get("/foo/{inbetween:**}/end", req -> {
  doSomething(eq.params("inbetween")); // same
});
```