### PR TITLE
add Caffeine cache support

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -64,6 +64,7 @@
                     <source>${project.parent.basedir}/jooby-pebble/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-jade/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-jooq/src/main/java</source>
+                    <source>${project.parent.basedir}/jooby-caffeine/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-guava-cache/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-executor/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-querydsl/src/main/java</source>
@@ -120,6 +121,7 @@
                     <source>${project.parent.basedir}/jooby-pebble/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-jade/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-jooq/src/test/java</source>
+                    <source>${project.parent.basedir}/jooby-caffeine/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-guava-cache/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-executor/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-querydsl/src/test/java</source>
@@ -329,6 +331,12 @@
     <dependency>
       <groupId>org.jooby</groupId>
       <artifactId>jooby-commons-email</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby-caffeine</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/jooby-caffeine/pom.xml
+++ b/jooby-caffeine/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.jooby</groupId>
+    <artifactId>jooby-project</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-caffeine</artifactId>
+
+  <name>caffeine module</name>
+
+  <build>
+    <plugins>
+      <!-- sure-fire -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Feature.java</include>
+            <include>**/Issue*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <dependencies>
+    <!-- Jooby -->
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Caffeine -->
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jooby-caffeine/src/main/java/org/jooby/caffeine/CaffeineCache.java
+++ b/jooby-caffeine/src/main/java/org/jooby/caffeine/CaffeineCache.java
@@ -1,0 +1,319 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.caffeine;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import org.jooby.Env;
+import org.jooby.Jooby;
+import org.jooby.Session;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+/**
+ * <h1>caffeine</h1>
+ * <p>
+ * {@link Cache} services from <a href="https://github.com/ben-manes/caffeine">Caffeine</a>
+ * </p>
+ *
+ * <h2>usage</h2>
+ *
+ * <p>
+ * App.java:
+ * </p>
+ * <pre>
+ * {
+ *   use(CaffeineCache.newCache());
+ *
+ *   get("/", req {@literal ->} {
+ *     Cache cache = req.require(Cache.class);
+ *     // do with cache...
+ *   });
+ * }
+ * </pre>
+ *
+ * <h2>options</h2>
+ *
+ * <h3>cache configuration</h3>
+ * <p>
+ * A default cache will be created, if you need to control the number of entries, expire policy,
+ * etc... set the <code>caffeine.cache</code> property in <code>application.conf</code>, like:
+ * </p>
+ *
+ * <pre>
+ * caffeine.cache {
+ *   maximumSize = 10
+ * }
+ * </pre>
+ *
+ * or via {@link CaffeineSpec} syntax:
+ *
+ * <pre>
+ * caffeine.cache = "maximumSize=10"
+ * </pre>
+ *
+ * <h3>multiple caches</h3>
+ * <p>
+ * Just add entries to: <code>caffeine.</code>, like:
+ * </p>
+ *
+ * <pre>
+ * # default cache (don't need a name on require calls)
+ * caffeine.cache = "maximumSize=10"
+ *
+ * caffeine.cache1 = "maximumSize=1"
+ *
+ * caffeine.cacheX = "maximumSize=100"
+ * </pre>
+ *
+ * <pre>
+ * {
+ *   get("/", req {@literal ->} {
+ *     Cache defcache = req.require(Cache.class);
+ *
+ *     Cache cache1 = req.require("cache1", Cache.class);
+ *
+ *     Cache cacheX = req.require("cacheX", Cache.class);
+ *   });
+ * }
+ * </pre>
+ *
+ * <h3>type-safe caches</h3>
+ * <p>
+ * Type safe caches are provided by calling and creating a new {@link CaffeineCache} subclass:
+ * </p>
+ *
+ * <pre>
+ * {
+ *   // please notes the {} at the line of the next line
+ *   use(new CaffeineCache&lt;Integer, String&gt;() {});
+ * }
+ * </pre>
+ *
+ * <p>
+ * Later, you can inject this cache in a type-safe manner:
+ * </p>
+ *
+ * <pre>
+ * &#64;Inject
+ * public MyService(Cache&lt;Integer, String&gt; cache) {
+ *  ...
+ * }
+ * </pre>
+ *
+ * <h2>session store</h2>
+ * <p>
+ * This module comes with a {@link Session.Store} implementation. In order to use it you need to
+ * define a cache named <code>session</code> in your <code>application.conf</code> file:
+ * </p>
+ *
+ * <pre>
+ * caffeine.session = "maximumSize=10"
+ * </pre>
+ *
+ * And set the {@link CaffeineSessionStore}:
+ *
+ * <pre>
+ * {
+ *   session(CaffeineSessionStore.class);
+ * }
+ * </pre>
+ *
+ * You can access to the ```session``` via name:
+ *
+ * <pre>
+ * {
+ *   get("/", req {@literal} {
+ *     Cache cache = req.require("session", Cache.class);
+ *   });
+ * }
+ * </pre>
+ *
+ * @author edgar
+ * @author ben manes
+ * @since 1.0.0.Final
+ * @param <K> Cache key.
+ * @param <V> Cache value.
+ * @see CaffeineSessionStore
+ */
+public abstract class CaffeineCache<K, V> implements Jooby.Module {
+
+  public interface Callback<K, V, C extends Cache<K, V>> {
+    C apply(String name, Caffeine<K, V> builder);
+  }
+
+  public interface AsyncCallback<K, V> {
+    AsyncLoadingCache<K, V> apply(String name, Caffeine<K, V> builder);
+  }
+
+  private static final String DEF = "caffeine";
+
+  @SuppressWarnings("rawtypes")
+  private BiFunction<String, Caffeine, Object> callback = (n, b) -> b.build();
+
+  private final String name;
+
+  /**
+   * Creates a new {@link CaffeineCache} using the provided namespace.
+   *
+   * @param name Cache namespace.
+   */
+  public CaffeineCache(final String name) {
+    this.name = name;
+  }
+
+  /**
+   * Creates a new {@link CaffeineCache} using <code>caffeine</code> as cache namespace.
+   */
+  public CaffeineCache() {
+    this(DEF);
+  }
+
+  /**
+   * Creates a new {@link CaffeineCache} with {@link String} and {@link Object} types as key/value.
+   *
+   * @return A new {@link CaffeineCache}.
+   */
+  public static final CaffeineCache<String, Object> newCache() {
+    return new CaffeineCache<String, Object>() {
+    };
+  }
+
+  /**
+   * Configure a cache builder and creates a new {@link Cache}.
+   *
+   * @param configurer Configurer callback.
+   * @return This instance.
+   */
+  public CaffeineCache<K, V> doWith(final Callback<K, V, Cache<K, V>> configurer) {
+    requireNonNull(configurer, "Configurer callback is required.");
+    this.callback = configurer::apply;
+    return this;
+  }
+
+  /**
+   * Configure a cache builder and creates a new {@link AsyncLoadingCache}.
+   *
+   * @param configurer Configurer callback.
+   * @return This instance.
+   */
+  public CaffeineCache<K, V> doWithAsync(final AsyncCallback<K, V> configurer) {
+    requireNonNull(configurer, "Configurer callback is required.");
+    this.callback = configurer::apply;
+    return this;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Override
+  public void configure(final Env env, final Config conf, final Binder binder) {
+    Config gconf = conf.hasPath(name)
+        ? conf
+        : ConfigFactory.empty().withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""));
+
+    gconf.getObject(name).unwrapped().forEach((name, spec) -> {
+      Caffeine<K, V> cb = (Caffeine<K, V>) Caffeine.from(toSpec(spec));
+
+      Object cache = callback.apply(name, cb);
+
+      List<TypeLiteral> types = cacheType(name, cache, getClass().getGenericSuperclass());
+
+      types.forEach(type -> {
+        binder.bind(Key.get(type, Names.named(name)))
+            .toInstance(cache);
+        if (name.equals("cache")) {
+          // unnamed cache for default cache
+          binder.bind(type).toInstance(cache);
+          // raw type for default cache
+          binder.bind(type.getRawType()).toInstance(cache);
+        }
+        if (name.equals("session")) {
+          binder.bind(Key.get(type, Names.named(name))).toInstance(cache);
+          binder.bind(Key.get(type.getRawType(), Names.named(name))).toInstance(cache);
+        }
+      });
+    });
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static List<TypeLiteral> cacheType(final String name, final Object cache,
+      final Type superclass) {
+    Class[] ctypes;
+    if (cache instanceof AsyncLoadingCache) {
+      ctypes = new Class[]{AsyncLoadingCache.class };
+    } else if (cache instanceof LoadingCache) {
+      ctypes = new Class[]{LoadingCache.class, Cache.class };
+    } else {
+      ctypes = new Class[]{Cache.class };
+    }
+    List<TypeLiteral> result = new ArrayList<>(ctypes.length);
+    for (Class ctype : ctypes) {
+      if (name.equals("session")) {
+        result.add(TypeLiteral.get(Types.newParameterizedType(ctype, String.class, Session.class)));
+      } else {
+        result.add(TypeLiteral.get(Types.newParameterizedType(ctype, types(superclass))));
+      }
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private String toSpec(final Object spec) {
+    if (spec instanceof Map) {
+      Map<String, Object> m = (Map<String, Object>) spec;
+      return m.entrySet().stream()
+          .map(e -> e.getKey() + "=" + e.getValue())
+          .collect(Collectors.joining(","))
+          .toString();
+    }
+    return spec.toString();
+  }
+
+  private static Type[] types(final Type superclass) {
+    Type key = String.class;
+    Type value = Object.class;
+    if (superclass instanceof ParameterizedType) {
+      ParameterizedType parameterized = (ParameterizedType) superclass;
+      Type[] args = parameterized.getActualTypeArguments();
+      key = args[0];
+      value = args[1];
+    }
+    return new Type[]{key, value };
+  }
+
+}

--- a/jooby-caffeine/src/main/java/org/jooby/caffeine/CaffeineSessionStore.java
+++ b/jooby-caffeine/src/main/java/org/jooby/caffeine/CaffeineSessionStore.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.caffeine;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jooby.Session;
+import org.jooby.Session.Builder;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+/**
+ * <h1>session store</h1>
+ * <p>
+ * This module comes with a {@link Session.Store} implementation. In order to use it you need to
+ * define a cache named <code>session</code> in your <code>application.conf</code> file:
+ * </p>
+ *
+ * <pre>
+ * caffeine.session = "maximumSize=10"
+ * </pre>
+ *
+ * And set the {@link CaffeineSessionStore}:
+ *
+ * <pre>
+ * {
+ *   session(CaffeineSessionStore.class);
+ * }
+ * </pre>
+ *
+ * You can access to the ```session``` via name:
+ *
+ * <pre>
+ * {
+ *   get("/", req {@literal} {
+ *     Cache cache = req.require("session", Cache.class);
+ *   });
+ * }
+ * </pre>
+ *
+ * @author edgar
+ * @author ben manes
+ *
+ */
+@Singleton
+public class CaffeineSessionStore implements Session.Store {
+
+  private Cache<String, Session> cache;
+
+  @Inject
+  public CaffeineSessionStore(@Named("session") final Cache<String, Session> cache) {
+    this.cache = requireNonNull(cache, "Session cache is required.");
+  }
+
+  @Override
+  public Session get(final Builder builder) {
+    return cache.getIfPresent(builder.sessionId());
+  }
+
+  @Override
+  public void save(final Session session) {
+    cache.put(session.id(), session);
+  }
+
+  @Override
+  public void create(final Session session) {
+    cache.put(session.id(), session);
+  }
+
+  @Override
+  public void delete(final String id) {
+    cache.invalidate(id);
+  }
+
+}

--- a/jooby-caffeine/src/test/java/org/jooby/caffeine/CaffeineCacheTest.java
+++ b/jooby-caffeine/src/test/java/org/jooby/caffeine/CaffeineCacheTest.java
@@ -1,0 +1,217 @@
+package org.jooby.caffeine;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import javax.inject.Inject;
+
+import org.jooby.Env;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+public class CaffeineCacheTest {
+
+  public static class RequireCache {
+    @Inject
+    public RequireCache(final Cache<String, Object> cache) {
+      requireNonNull(cache, "The cache is required.");
+    }
+  }
+
+  public static class RequireLoadingCache {
+    @Inject
+    public RequireLoadingCache(final LoadingCache<String, Object> cache) {
+      requireNonNull(cache, "The cache is required.");
+    }
+  }
+
+  public static class RequireAsyncLoadingCache {
+    @Inject
+    public RequireAsyncLoadingCache(final AsyncLoadingCache<String, Object> cache) {
+      requireNonNull(cache, "The cache is required.");
+    }
+  }
+
+  public static class RequireTypeSafeCache {
+    @Inject
+    public RequireTypeSafeCache(final Cache<Integer, String> cache) {
+      requireNonNull(cache, "The cache is required.");
+    }
+  }
+
+  @Test
+  public void defaults() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""))
+        .withValue("caffeine.session", ConfigValueFactory.fromAnyRef(""));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            CaffeineCache.newCache().configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireCache.class);
+          injector.getInstance(CaffeineSessionStore.class);
+        });
+  }
+
+  @Test
+  public void loadingCache() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""))
+        .withValue("caffeine.session", ConfigValueFactory.fromAnyRef(""));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache<String, Object>(){}.doWith((n, b) ->{
+              return b.build(new CacheLoader<String, Object>() {
+
+                @Override
+                public Object load(final String key) throws Exception {
+                  return null;
+                }
+
+              });
+            }).configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireCache.class);
+          injector.getInstance(RequireLoadingCache.class);
+          injector.getInstance(CaffeineSessionStore.class);
+        });
+  }
+
+  @Test
+  public void ayncLoadingCache() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""))
+        .withValue("caffeine.session", ConfigValueFactory.fromAnyRef(""));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache<String, Object>(){}.doWithAsync((n, b) ->{
+              return b.buildAsync(new CacheLoader<String, Object>() {
+
+                @Override
+                public Object load(final String key) throws Exception {
+                  return null;
+                }
+
+              });
+            }).configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireAsyncLoadingCache.class);
+        });
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void defaultsNoSpec() throws Exception {
+    Config conf = ConfigFactory.empty();
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache() {
+            }.configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireCache.class);
+        });
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void oneCache() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache() {
+            }.configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireCache.class);
+
+          try {
+            injector.getInstance(CaffeineSessionStore.class);
+            fail("No session found");
+          } catch (ConfigurationException ex) {
+            // OK
+          }
+        });
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void cacheWithObjectSpec() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache.maximumSize", ConfigValueFactory.fromAnyRef(10));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache() {
+            }.configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireCache.class);
+
+          try {
+            injector.getInstance(CaffeineSessionStore.class);
+            fail("No session found");
+          } catch (ConfigurationException ex) {
+            // OK
+          }
+        });
+  }
+
+  @Test
+  public void typeSafeCache() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef(""))
+        .withValue("caffeine.session", ConfigValueFactory.fromAnyRef(""));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache<Integer, String>() {
+            }
+                .configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireTypeSafeCache.class);
+          // raw cache
+          injector.getInstance(Cache.class);
+          // raw cache for session
+          injector.getInstance(Key.get(Cache.class, Names.named("session")));
+        });
+  }
+
+  @Test
+  public void withCallback() throws Exception {
+    Config conf = ConfigFactory.empty()
+        .withValue("caffeine.cache", ConfigValueFactory.fromAnyRef("maximumSize=10"));
+    new MockUnit(Env.class)
+        .run(unit -> {
+          Injector injector = Guice.createInjector(binder -> {
+            new CaffeineCache<Integer, String>() {
+            }.doWith((n, builder) -> {
+              assertEquals("cache", n);
+              assertNotNull(builder);
+              return builder.build();
+            })
+                .configure(unit.get(Env.class), conf, binder);
+          });
+          injector.getInstance(RequireTypeSafeCache.class);
+        });
+  }
+
+}

--- a/jooby-caffeine/src/test/java/org/jooby/caffeine/CaffeineSessionStoreTest.java
+++ b/jooby-caffeine/src/test/java/org/jooby/caffeine/CaffeineSessionStoreTest.java
@@ -1,0 +1,89 @@
+package org.jooby.caffeine;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+
+import org.jooby.Session;
+import org.jooby.caffeine.CaffeineSessionStore;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+public class CaffeineSessionStoreTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void defaults() throws Exception {
+    new MockUnit(Cache.class)
+        .run(unit -> {
+          new CaffeineSessionStore(unit.get(Cache.class));
+        });
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Test
+  public void get() throws Exception {
+    new MockUnit(Cache.class, Session.class, Session.Builder.class)
+        .expect(unit -> {
+          Session.Builder sb = unit.get(Session.Builder.class);
+          expect(sb.sessionId()).andReturn("sid");
+
+          Cache cache = unit.get(Cache.class);
+          expect(cache.getIfPresent("sid")).andReturn(unit.get(Session.class));
+        })
+        .run(unit -> {
+          assertEquals(unit.get(Session.class), new CaffeineSessionStore(unit.get(Cache.class))
+              .get(unit.get(Session.Builder.class)));
+        });
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Test
+  public void save() throws Exception {
+    new MockUnit(Cache.class, Session.class)
+        .expect(unit -> {
+          Session sb = unit.get(Session.class);
+          expect(sb.id()).andReturn("sid");
+
+          Cache cache = unit.get(Cache.class);
+          cache.put("sid", unit.get(Session.class));
+        })
+        .run(unit -> {
+          new CaffeineSessionStore(unit.get(Cache.class))
+              .save(unit.get(Session.class));
+        });
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Test
+  public void create() throws Exception {
+    new MockUnit(Cache.class, Session.class)
+        .expect(unit -> {
+          Session sb = unit.get(Session.class);
+          expect(sb.id()).andReturn("sid");
+
+          Cache cache = unit.get(Cache.class);
+          cache.put("sid", unit.get(Session.class));
+        })
+        .run(unit -> {
+          new CaffeineSessionStore(unit.get(Cache.class))
+              .create(unit.get(Session.class));
+        });
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Test
+  public void delete() throws Exception {
+    new MockUnit(Cache.class)
+        .expect(unit -> {
+          Cache cache = unit.get(Cache.class);
+          cache.invalidate("sid");
+        })
+        .run(unit -> {
+          new CaffeineSessionStore(unit.get(Cache.class))
+              .delete("sid");
+        });
+  }
+
+}

--- a/md/doc/caffeine/caffeine.md
+++ b/md/doc/caffeine/caffeine.md
@@ -1,0 +1,128 @@
+# caffeine
+
+Provides cache solution and session storage via: <a href="https://github.com/ben-manes/caffeine">Caffeine</a>.
+
+## exports
+
+* ```Cache```
+
+## dependency
+
+```xml
+<dependency>
+ <groupId>org.jooby</groupId>
+ <artifactId>jooby-caffeine-cache</artifactId>
+ <version>{{version}}</version>
+</dependency>
+```
+
+## usage
+
+App.java:
+
+```java
+import org.jooby.caffeine.CaffeineCache;
+
+{
+  use(CaffeineCache.newCache());
+
+  get("/", req -> {
+
+    Cache cache = req.require(Cache.class);
+    // do with cache...
+  });
+
+}
+```
+
+## options
+
+### cache configuration
+
+A default cache will be created, if you need to control the number of entries, expire policy, etc... set the ```caffeine.cache``` property in ```application.conf```, like:
+
+```
+caffeine.cache {
+  maximumSize = 10
+}
+```
+
+or via ```com.github.benmanes.caffeine.cache.CaffeineSpec``` syntax:
+
+```
+caffeine.cache = "maximumSize=10"
+```
+
+### multiple caches
+
+Just add entries to: ```caffeine.```, like:
+
+```
+# default cache (don't need a name on require calls)
+caffeine.cache = "maximumSize=10"
+caffeine.cache1 = "maximumSize=1"
+caffeine.cacheX = "maximumSize=100"
+```
+
+```java
+{
+  get("/", req -> {
+    Cache defcache = req.require(Cache.class);
+    Cache cache1 = req.require("cache1", Cache.class);
+    Cache cacheX = req.require("cacheX", Cache.class);
+  });
+}
+```
+
+### type-safe caches
+
+Type safe caches are provided by calling and creating a new ```CaffeineCache``` subclass:
+
+```java
+{
+  // please notes the {} at the line of the next line
+  use(new CaffeineCache<Integer, String>() {});
+}
+```
+
+Later, you can inject this cache in a type-safe manner:
+
+```java
+@Inject
+public MyService(Cache<Integer, String> cache) {
+ ...
+}
+```
+
+# caffeine session store
+
+## usage
+
+This module comes with a ```Session.Store``` implementation. In order to use it you need to define a cache named ```session``` in your ```application.conf``` file:
+
+```
+caffeine.session = "maximumSize=10"
+```
+
+And set the ```CaffeineSessionStore```:
+
+```java
+import org.jooby.caffeine.CaffeineCache;
+import org.jooby.caffeine.CaffeineSessionStore;
+
+{
+  use(CaffeineCache.newCache());
+
+  session(CaffeineSessionStore.class);
+}
+```
+
+You can access to the ```session``` via name:
+
+```java
+{
+  get("/", req -> {
+    Cache cache = req.require("session", Cache.class);
+  });
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module>jooby-ftl</module>
     <module>jooby-pebble</module>
     <module>jooby-jade</module>
+    <module>jooby-caffeine</module>
     <module>jooby-guava-cache</module>
     <module>jooby-jdbc</module>
     <module>jooby-jooq</module>
@@ -620,6 +621,13 @@
         <groupId>com.typesafe</groupId>
         <artifactId>config</artifactId>
         <version>${config.version}</version>
+      </dependency>
+
+      <!-- Caffeine -->
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
 
       <!-- Guava -->
@@ -1609,15 +1617,15 @@
               <compilerArgs>
                 <arg>-parameters</arg>
               </compilerArgs>
-              <!-- eclipse compiler <debuglevel>lines,vars,source</debuglevel> <compilerId>eclipse</compilerId> 
-                <compilerArguments> <org.eclipse.jdt.core.compiler.codegen.methodParameters>generate</org.eclipse.jdt.core.compiler.codegen.methodParameters> 
-                <org.eclipse.jdt.core.compiler.debug.lineNumber>generate</org.eclipse.jdt.core.compiler.debug.lineNumber> 
-                <org.eclipse.jdt.core.compiler.debug.localVariable>generate</org.eclipse.jdt.core.compiler.debug.localVariable> 
-                <org.eclipse.jdt.core.compiler.debug.sourceFile>generate</org.eclipse.jdt.core.compiler.debug.sourceFile> 
-                <org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode>enabled</org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode> 
-                <org.eclipse.jdt.core.compiler.codegen.unusedLocal>preserve</org.eclipse.jdt.core.compiler.codegen.unusedLocal> 
-                <org.eclipse.jdt.core.compiler.compliance>1.8</org.eclipse.jdt.core.compiler.compliance> <org.eclipse.jdt.core.compiler.source>1.8</org.eclipse.jdt.core.compiler.source> 
-                <org.eclipse.jdt.core.compiler.codegen.targetPlatform>1.8</org.eclipse.jdt.core.compiler.codegen.targetPlatform> 
+              <!-- eclipse compiler <debuglevel>lines,vars,source</debuglevel> <compilerId>eclipse</compilerId>
+                <compilerArguments> <org.eclipse.jdt.core.compiler.codegen.methodParameters>generate</org.eclipse.jdt.core.compiler.codegen.methodParameters>
+                <org.eclipse.jdt.core.compiler.debug.lineNumber>generate</org.eclipse.jdt.core.compiler.debug.lineNumber>
+                <org.eclipse.jdt.core.compiler.debug.localVariable>generate</org.eclipse.jdt.core.compiler.debug.localVariable>
+                <org.eclipse.jdt.core.compiler.debug.sourceFile>generate</org.eclipse.jdt.core.compiler.debug.sourceFile>
+                <org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode>enabled</org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode>
+                <org.eclipse.jdt.core.compiler.codegen.unusedLocal>preserve</org.eclipse.jdt.core.compiler.codegen.unusedLocal>
+                <org.eclipse.jdt.core.compiler.compliance>1.8</org.eclipse.jdt.core.compiler.compliance> <org.eclipse.jdt.core.compiler.source>1.8</org.eclipse.jdt.core.compiler.source>
+                <org.eclipse.jdt.core.compiler.codegen.targetPlatform>1.8</org.eclipse.jdt.core.compiler.codegen.targetPlatform>
                 <encoding>UTF-8</encoding> </compilerArguments> -->
             </configuration>
             <dependencies>
@@ -2334,6 +2342,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
     <logback-classic.version>1.1.2</logback-classic.version>
+    <caffeine.version>2.3.3</caffeine.version>
     <guava.version>19.0</guava.version>
     <guice.version>4.0</guice.version>
     <config.version>1.3.0</config.version>


### PR DESCRIPTION
This is derived from the Guava module. The changes were,
* Replace Guava types with Caffeine's (`Cache`, `LoadingCache`, `CaffeineSpec`)
* Add AsyncLoadingCache support
* Update documentation, modules, etc.

Note that `AsyncLoadingCache` does not extend the Cache interface due to some minor differences. It would ideally be a `LoadingCache<K, CompletableFuture<V>>`, but that would require allowing a null return value (as Caffeine does not throw an exception on a cache miss). To support this type, `doWithAsync` was added along with `AsyncCallback`. The private `callback` instance has weaker type safety, but is internal so this has no negative effect. That approach allowed for making the most minimal changes from the original Guava code.