### PR TITLE
Upgrade to latest stable AWS Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2450,7 +2450,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <hibernate.version>5.2.1.Final</hibernate.version>
     <hibernate4.version>4.3.9.Final</hibernate4.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <http-client.version>4.3.6</http-client.version>
+    <http-client.version>4.5.2</http-client.version>
     <async-http-client.version>1.9.36</async-http-client.version>
     <cglib.version>3.2.0</cglib.version>
     <asm.version>5.0.3</asm.version>
@@ -2476,7 +2476,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <commons-lang3.version>3.4</commons-lang3.version>
     <snakeyaml.version>1.15</snakeyaml.version>
     <spymemcached.version>2.12.0</spymemcached.version>
-    <aws-java-sdk.version>1.10.66</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.43</aws-java-sdk.version>
     <commons-email.version>1.4</commons-email.version>
     <jongo.version>1.2</jongo.version>
     <bson4jackson.version>2.5.0</bson4jackson.version>


### PR DESCRIPTION
Note: This also requires a newer Apache HTTP client (4.5.2). See https://aws.amazon.com/releasenotes/9979983567247718