### PR TITLE
jooby-jdbc configure callback fix

### DIFF
--- a/jooby-jdbc/src/main/java/org/jooby/jdbc/Jdbc.java
+++ b/jooby-jdbc/src/main/java/org/jooby/jdbc/Jdbc.java
@@ -360,8 +360,8 @@ public class Jdbc implements Jooby.Module {
       props.setProperty("url", url);
     }
 
+    callback(hikariConf, config);
     HikariDataSource ds = new HikariDataSource(hikariConf);
-    callback(ds, config);
 
     extensions.accept(dbname, ds);
 

--- a/jooby-jdbc/src/test/java/org/jooby/jdbc/JdbcTest.java
+++ b/jooby-jdbc/src/test/java/org/jooby/jdbc/JdbcTest.java
@@ -134,7 +134,7 @@ public class JdbcTest {
         .expect(serviceKey("jdbctest"))
         .expect(onStop)
         .expect(unit -> {
-          HikariDataSource h = unit.get(HikariDataSource.class);
+          HikariConfig h = unit.get(HikariConfig.class);
           h.setAllowPoolSuspension(true);
         })
         .run(unit -> {


### PR DESCRIPTION
Execute callback just before HikariDataSource creation, passing HikariConfig and Config objects