### PR TITLE
Server worker executor

### DIFF
--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -198,9 +199,9 @@ public class JettyServer implements org.jooby.spi.Server {
   }
 
   @Override
-  public Executor executor()
+  public Optional<Executor> executor()
   {
-    return executor;
+    return Optional.of(executor);
   }
 
   private void tryOption(final Object source, final Config config, final Method option) {

--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -69,11 +70,13 @@ public class JettyServer implements org.jooby.spi.Server {
   private final Logger log = LoggerFactory.getLogger(org.jooby.spi.Server.class);
 
   private Server server;
+  private Executor executor;
 
   @Inject
   public JettyServer(final HttpHandler handler, final Config conf,
       final Provider<SSLContext> sslCtx) {
     this.server = server(handler, conf, sslCtx);
+    this.executor = this.server.getThreadPool();
   }
 
   private Server server(final HttpHandler handler, final Config conf,
@@ -192,6 +195,12 @@ public class JettyServer implements org.jooby.spi.Server {
   @Override
   public void stop() throws Exception {
     server.stop();
+  }
+
+  @Override
+  public Executor executor()
+  {
+    return executor;
   }
 
   private void tryOption(final Object source, final Config config, final Method option) {

--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyServer.java
@@ -71,13 +71,11 @@ public class JettyServer implements org.jooby.spi.Server {
   private final Logger log = LoggerFactory.getLogger(org.jooby.spi.Server.class);
 
   private Server server;
-  private Executor executor;
 
   @Inject
   public JettyServer(final HttpHandler handler, final Config conf,
       final Provider<SSLContext> sslCtx) {
     this.server = server(handler, conf, sslCtx);
-    this.executor = this.server.getThreadPool();
   }
 
   private Server server(final HttpHandler handler, final Config conf,
@@ -201,7 +199,7 @@ public class JettyServer implements org.jooby.spi.Server {
   @Override
   public Optional<Executor> executor()
   {
-    return Optional.of(executor);
+    return Optional.ofNullable(server.getThreadPool());
   }
 
   private void tryOption(final Object source, final Config config, final Method option) {

--- a/jooby-jetty/src/test/java/org/jooby/internal/jetty/JettyServerTest.java
+++ b/jooby-jetty/src/test/java/org/jooby/internal/jetty/JettyServerTest.java
@@ -1,7 +1,10 @@
 package org.jooby.internal.jetty;
 
+import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.isA;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
@@ -109,6 +112,8 @@ public class JettyServerTest {
     server.stop();
 
     unit.registerMock(Server.class, server);
+
+    expect(server.getThreadPool()).andReturn(unit.get(QueuedThreadPool.class)).anyTimes();
   };
 
   private MockUnit.Block httpConf = unit -> {
@@ -194,7 +199,9 @@ public class JettyServerTest {
           JettyServer server = new JettyServer(unit.get(HttpHandler.class), config,
               unit.get(Provider.class));
 
+          assertNotNull(server.executor());
           server.start();
+          assertTrue(server.executor().isPresent());
           server.join();
           server.stop();
         });

--- a/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
+++ b/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
@@ -157,7 +157,7 @@ public class NettyServer implements Server {
   @Override
   public Optional<Executor> executor()
   {
-    return Optional.of(executor);
+    return Optional.ofNullable(executor);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked" })

--- a/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
+++ b/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 
@@ -150,6 +151,12 @@ public class NettyServer implements Server {
   @Override
   public void join() throws InterruptedException {
     ch.closeFuture().sync();
+  }
+
+  @Override
+  public Executor executor()
+  {
+    return executor;
   }
 
   @SuppressWarnings({"rawtypes", "unchecked" })

--- a/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
+++ b/jooby-netty/src/main/java/org/jooby/internal/netty/NettyServer.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
@@ -154,9 +155,9 @@ public class NettyServer implements Server {
   }
 
   @Override
-  public Executor executor()
+  public Optional<Executor> executor()
   {
-    return executor;
+    return Optional.of(executor);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked" })

--- a/jooby-netty/src/test/java/org/jooby/internal/netty/NettyServerTest.java
+++ b/jooby-netty/src/test/java/org/jooby/internal/netty/NettyServerTest.java
@@ -1,5 +1,8 @@
 package org.jooby.internal.netty;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
 
@@ -117,7 +120,9 @@ public class NettyServerTest {
         .run(unit -> {
           NettyServer server = new NettyServer(unit.get(HttpHandler.class), config);
           try {
+            assertNotNull(server.executor());
             server.start();
+            assertTrue(server.executor().isPresent());
             server.join();
           } finally {
             server.stop();

--- a/jooby-servlet/src/main/java/org/jooby/servlet/ServletContainer.java
+++ b/jooby-servlet/src/main/java/org/jooby/servlet/ServletContainer.java
@@ -20,6 +20,9 @@ package org.jooby.servlet;
 
 import org.jooby.spi.Server;
 
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
 /**
  * NOOP server for servlets.
  *
@@ -42,6 +45,11 @@ public class ServletContainer implements Server {
 
   @Override
   public void join() throws InterruptedException {
+  }
+
+  @Override
+  public Optional<Executor> executor() {
+    return Optional.empty();
   }
 
 }

--- a/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
+++ b/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
@@ -56,7 +56,6 @@ public class UndertowServer implements org.jooby.spi.Server {
   private static final Logger log = LoggerFactory.getLogger(org.jooby.spi.Server.class);
 
   private Undertow server;
-  private Executor executor;
 
   private final GracefulShutdownHandler shutdown;
 
@@ -88,8 +87,6 @@ public class UndertowServer implements org.jooby.spi.Server {
 
     this.server = ubuilder.setHandler(shutdown)
         .build();
-
-    this.executor = server.getWorker();
   }
 
   private String host(final String host) {
@@ -214,7 +211,7 @@ public class UndertowServer implements org.jooby.spi.Server {
   @Override
   public Optional<Executor> executor()
   {
-    return Optional.of(executor);
+    return Optional.ofNullable(server.getWorker());
   }
 
 }

--- a/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
+++ b/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
@@ -20,6 +20,7 @@ package org.jooby.internal.undertow;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -54,6 +55,7 @@ public class UndertowServer implements org.jooby.spi.Server {
   private static final Logger log = LoggerFactory.getLogger(org.jooby.spi.Server.class);
 
   private Undertow server;
+  private Executor executor;
 
   private final GracefulShutdownHandler shutdown;
 
@@ -85,6 +87,8 @@ public class UndertowServer implements org.jooby.spi.Server {
 
     this.server = ubuilder.setHandler(shutdown)
         .build();
+
+    this.executor = server.getWorker();
   }
 
   private String host(final String host) {
@@ -204,6 +208,12 @@ public class UndertowServer implements org.jooby.spi.Server {
     shutdown.shutdown();
     shutdown.awaitShutdown(awaitShutdown);
     server.stop();
+  }
+
+  @Override
+  public Executor executor()
+  {
+    return executor;
   }
 
 }

--- a/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
+++ b/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowServer.java
@@ -20,6 +20,7 @@ package org.jooby.internal.undertow;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -211,9 +212,9 @@ public class UndertowServer implements org.jooby.spi.Server {
   }
 
   @Override
-  public Executor executor()
+  public Optional<Executor> executor()
   {
-    return executor;
+    return Optional.of(executor);
   }
 
 }

--- a/jooby-undertow/src/test/java/org/jooby/internal/undertow/UndertowServerTest.java
+++ b/jooby-undertow/src/test/java/org/jooby/internal/undertow/UndertowServerTest.java
@@ -1,5 +1,8 @@
 package org.jooby.internal.undertow;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import javax.inject.Provider;
 
 import org.jooby.spi.HttpHandler;
@@ -37,7 +40,9 @@ public class UndertowServerTest {
           UndertowServer server = new UndertowServer(unit.get(HttpHandler.class), config,
               unit.get(Provider.class));
           try {
+            assertNotNull(server.executor());
             server.start();
+            assertTrue(server.executor().isPresent());
             server.join();// NOOP
           } finally {
             server.stop();

--- a/jooby/src/main/java/org/jooby/Jooby.java
+++ b/jooby/src/main/java/org/jooby/Jooby.java
@@ -108,6 +108,7 @@ import org.jooby.internal.LocaleUtils;
 import org.jooby.internal.ParameterNameProvider;
 import org.jooby.internal.RequestScope;
 import org.jooby.internal.RouteMetadata;
+import org.jooby.internal.ServerExecutorProvider;
 import org.jooby.internal.ServerLookup;
 import org.jooby.internal.ServerSessionManager;
 import org.jooby.internal.SessionManager;
@@ -2365,6 +2366,24 @@ public class Jooby implements Router, LifeCycle, Registry {
    * Default executor runs each task in the thread that invokes {@link Executor#execute execute},
    * that's a Jooby worker thread. A worker thread in Jooby can block.
    *
+   * @param name Name of the executor.
+   * @param provider Provider for the executor.
+   * @return This jooby instance.
+   */
+  public Jooby executor(final String name, final Class<? extends javax.inject.Provider<Executor>> provider) {
+    this.executors.add(binder -> {
+      binder.bind(Key.get(Executor.class, Names.named(name))).toProvider(provider).in(Singleton.class);
+    });
+    return this;
+  }
+
+  /**
+   * Set a named executor to use from {@link Deferred Deferred API}. Useful for override the
+   * default/global executor.
+   *
+   * Default executor runs each task in the thread that invokes {@link Executor#execute execute},
+   * that's a Jooby worker thread. A worker thread in Jooby can block.
+   *
    * The {@link ExecutorService} will automatically shutdown.
    *
    * @param name Name of the executor.
@@ -2565,6 +2584,7 @@ public class Jooby implements Router, LifeCycle, Registry {
       executor(MoreExecutors.directExecutor());
     }
     executor("direct", MoreExecutors.directExecutor());
+    executor("server", ServerExecutorProvider.class);
 
     /** Some basic xss functions. */
     xss(finalEnv);

--- a/jooby/src/main/java/org/jooby/Jooby.java
+++ b/jooby/src/main/java/org/jooby/Jooby.java
@@ -2366,24 +2366,6 @@ public class Jooby implements Router, LifeCycle, Registry {
    * Default executor runs each task in the thread that invokes {@link Executor#execute execute},
    * that's a Jooby worker thread. A worker thread in Jooby can block.
    *
-   * @param name Name of the executor.
-   * @param provider Provider for the executor.
-   * @return This jooby instance.
-   */
-  public Jooby executor(final String name, final Class<? extends javax.inject.Provider<Executor>> provider) {
-    this.executors.add(binder -> {
-      binder.bind(Key.get(Executor.class, Names.named(name))).toProvider(provider).in(Singleton.class);
-    });
-    return this;
-  }
-
-  /**
-   * Set a named executor to use from {@link Deferred Deferred API}. Useful for override the
-   * default/global executor.
-   *
-   * Default executor runs each task in the thread that invokes {@link Executor#execute execute},
-   * that's a Jooby worker thread. A worker thread in Jooby can block.
-   *
    * The {@link ExecutorService} will automatically shutdown.
    *
    * @param name Name of the executor.
@@ -2430,6 +2412,24 @@ public class Jooby implements Router, LifeCycle, Registry {
     defaultExecSet = true;
     this.executors.add(binder -> {
       binder.bind(Key.get(String.class, Names.named("deferred"))).toInstance(name);
+    });
+    return this;
+  }
+
+  /**
+   * Set a named executor to use from {@link Deferred Deferred API}. Useful for override the
+   * default/global executor.
+   *
+   * Default executor runs each task in the thread that invokes {@link Executor#execute execute},
+   * that's a Jooby worker thread. A worker thread in Jooby can block.
+   *
+   * @param name Name of the executor.
+   * @param provider Provider for the executor.
+   * @return This jooby instance.
+   */
+  private Jooby executor(final String name, final Class<? extends Provider<Executor>> provider) {
+    this.executors.add(binder -> {
+      binder.bind(Key.get(Executor.class, Names.named(name))).toProvider(provider).in(Singleton.class);
     });
     return this;
   }

--- a/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
+++ b/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
@@ -20,14 +20,15 @@ package org.jooby.internal;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.jooby.spi.Server;
 
-import javax.inject.Provider;
 import java.util.concurrent.Executor;
 
 import static java.util.Objects.requireNonNull;
 
-public class ServerExecutorProvider implements Provider<Executor> {
+public class ServerExecutorProvider implements Provider<Executor>
+{
 
   private Executor executor;
 

--- a/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
+++ b/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
@@ -16,44 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jooby.spi;
+package org.jooby.internal;
 
+import org.jooby.spi.Server;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
 import java.util.concurrent.Executor;
 
-/**
- * A HTTP web server.
- *
- * @author edgar
- * @since 0.1.0
- */
-public interface Server {
+import static java.util.Objects.requireNonNull;
 
-  /**
-   * Start the web server.
-   *
-   * @throws Exception If server fail to start.
-   */
-  void start() throws Exception;
+public class ServerExecutorProvider implements Provider<Executor> {
 
-  /**
-   * Stop the web server.
-   *
-   * @throws Exception If server fail to stop.
-   */
-  void stop() throws Exception;
+  private Executor executor;
 
-  /**
-   * Waits for this thread to die.
-   *
-   * @throws InterruptedException If wait didn't success.
-   */
-  void join() throws InterruptedException;
+  @Inject
+  public ServerExecutorProvider(final Server server) {
+    executor = requireNonNull(server, "Server is required.").executor();
+  }
 
-  /**
-   * Obtain the executor for worker threads.
-   *
-   * @return The executor for worker threads.
-   */
-  Executor executor();
+  @Override
+  public Executor get() {
+    return executor;
+  }
 
 }

--- a/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
+++ b/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
@@ -19,9 +19,9 @@
 package org.jooby.internal;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Inject;
 import org.jooby.spi.Server;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.concurrent.Executor;
 
@@ -32,14 +32,23 @@ public class ServerExecutorProvider implements Provider<Executor> {
   private Executor executor;
 
   @Inject
-  public ServerExecutorProvider(final Server server) {
-    executor = requireNonNull(server, "Server is required.")
-      .executor().orElse(MoreExecutors.directExecutor());
+  public ServerExecutorProvider(final ServerHolder serverHolder) {
+    requireNonNull(serverHolder, "Server holder is required.");
+
+    executor = (serverHolder.server != null) ?
+               serverHolder.server.executor().orElse(MoreExecutors.directExecutor()) :
+               MoreExecutors.directExecutor();
   }
 
   @Override
   public Executor get() {
     return executor;
+  }
+
+  static class ServerHolder {
+
+    @Inject(optional = true) Server server = null;
+
   }
 
 }

--- a/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
+++ b/jooby/src/main/java/org/jooby/internal/ServerExecutorProvider.java
@@ -18,6 +18,7 @@
  */
 package org.jooby.internal;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.jooby.spi.Server;
 
 import javax.inject.Inject;
@@ -32,7 +33,8 @@ public class ServerExecutorProvider implements Provider<Executor> {
 
   @Inject
   public ServerExecutorProvider(final Server server) {
-    executor = requireNonNull(server, "Server is required.").executor();
+    executor = requireNonNull(server, "Server is required.")
+      .executor().orElse(MoreExecutors.directExecutor());
   }
 
   @Override

--- a/jooby/src/main/java/org/jooby/spi/Server.java
+++ b/jooby/src/main/java/org/jooby/spi/Server.java
@@ -18,6 +18,7 @@
  */
 package org.jooby.spi;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 /**
@@ -54,6 +55,6 @@ public interface Server {
    *
    * @return The executor for worker threads.
    */
-  Executor executor();
+  Optional<Executor> executor();
 
 }

--- a/jooby/src/test/java/org/jooby/issues/Issue430.java
+++ b/jooby/src/test/java/org/jooby/issues/Issue430.java
@@ -4,6 +4,9 @@ import org.jooby.Jooby;
 import org.jooby.spi.Server;
 import org.junit.Test;
 
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
 public class Issue430 {
 
   public static class NOOP implements Server {
@@ -18,6 +21,11 @@ public class Issue430 {
 
     @Override
     public void join() throws InterruptedException {
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+      return Optional.empty();
     }
 
   }


### PR DESCRIPTION
Rational: When doing async tasks with RxJava or other frameworks, it would be a good idea to reuse the server's worker threads.