### PR TITLE
Executors pool size config

### DIFF
--- a/jooby-executor/src/main/java/org/jooby/exec/Exec.java
+++ b/jooby-executor/src/main/java/org/jooby/exec/Exec.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -186,8 +187,18 @@ public class Exec implements Module {
       ImmutableMap
           .of(
               "cached", (name, n, tf, opts) -> Executors.newCachedThreadPool(tf.get()),
-              "fixed", (name, n, tf, opts) -> Executors.newFixedThreadPool(n, tf.get()),
-              "scheduled", (name, n, tf, opts) -> Executors.newScheduledThreadPool(n, tf.get()),
+              "fixed", (name, n, tf, opts) -> {
+                Optional<Integer> size = Optional.ofNullable(
+                  opts.containsKey("size") ? Integer.parseInt(opts.get("size").toString()) : null
+                );
+                return Executors.newFixedThreadPool(size.orElse(n), tf.get());
+              },
+              "scheduled", (name, n, tf, opts) -> {
+                Optional<Integer> size = Optional.ofNullable(
+                  opts.containsKey("size") ? Integer.parseInt(opts.get("size").toString()) : null
+                );
+                return Executors.newScheduledThreadPool(size.orElse(n), tf.get());
+              },
               "forkjoin", (name, n, tf, opts) -> {
                 boolean asyncMode = Boolean.parseBoolean(opts.getOrDefault("asyncMode", "false")
                     .toString());

--- a/jooby-executor/src/main/java/org/jooby/exec/Exec.java
+++ b/jooby-executor/src/main/java/org/jooby/exec/Exec.java
@@ -364,7 +364,11 @@ public class Exec implements Module {
     options.put("priority", priority);
     if (value instanceof Map) {
       Map<String, Object> config = (Map<String, Object>) value;
-      String type = config.get("type").toString();
+      Object rawType = config.get("type");
+      if (rawType == null) {
+        throw new IllegalArgumentException("Missing executor type");
+      }
+      String type = rawType.toString();
       options.put("type", type);
       options.put(type, config.containsKey("size") ?
         Integer.parseInt(config.get("size").toString()) : n);
@@ -375,7 +379,6 @@ public class Exec implements Module {
       options.put("priority", config.containsKey("priority") ?
         Integer.parseInt(config.get("priority").toString()) : priority);
     } else {
-      System.out.println("Bere");
       Iterable<String> spec = Splitter.on(",").trimResults().omitEmptyStrings()
                                       .split(value.toString());
       for (String option : spec) {


### PR DESCRIPTION
Rational: It would be a good idea to have an alternative configuration style for custom executors like:

executors {
  custom {
    type = fixed
    size = ${runtime.processors-x2}
  }
}