### PR TITLE
File watcher module

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -85,6 +85,7 @@
                     <source>${project.parent.basedir}/jooby-csl/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-unbescape/src/main/java</source>
                     <source>${project.parent.basedir}/jooby-thymeleaf/src/main/java</source>
+                    <source>${project.parent.basedir}/jooby-filewatcher/src/main/java</source>
                   </sources>
                 </configuration>
               </execution>
@@ -145,6 +146,7 @@
                     <source>${project.parent.basedir}/jooby-csl/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-unbescape/src/test/java</source>
                     <source>${project.parent.basedir}/jooby-thymeleaf/src/test/java</source>
+                    <source>${project.parent.basedir}/jooby-filewatcher/src/test/java</source>
                   </sources>
                 </configuration>
               </execution>

--- a/jooby-filewatcher/.gitignore
+++ b/jooby-filewatcher/.gitignore
@@ -1,0 +1,1 @@
+workdir

--- a/jooby-filewatcher/pom.xml
+++ b/jooby-filewatcher/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.jooby</groupId>
+    <artifactId>jooby-project</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-filewatcher</artifactId>
+
+  <name>file watcher module</name>
+  <build>
+    <plugins>
+      <!-- sure-fire -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Feature.java</include>
+            <include>**/Issue*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <dependencies>
+    <!-- Jooby -->
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <classifier>tests</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jooby</groupId>
+      <artifactId>jooby-netty</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileEventHandler.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileEventHandler.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+
+/**
+ * Callback call when a file or folder has been created, modified or deleted.
+ *
+ * @author edgar
+ * @since 1.1.0
+ */
+public interface FileEventHandler {
+
+  /**
+   * File handler callback.
+   *
+   * @param kind Event type.
+   * @param path Path created, modified or deleted.
+   * @throws IOException If something goes wrong.
+   */
+  void handle(WatchEvent.Kind<Path> kind, Path path) throws IOException;
+
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileEventOptions.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileEventOptions.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Allow to customize a file watch handler. You can listen for particular event kinds, apply a glob
+ * filter, recursive listening for changes and set watcher priority or modifier.
+ * <p>
+ * Default filter watch recursively listen for all the available kinds using a <code>HIGH</code>
+ * modifier.
+ * <p>
+ * This class can't be instantiated by client code. Intances of this class are provided via
+ * configuration callbacks. See
+ * {@link FileWatcher#register(Path, Class, java.util.function.Consumer)}
+ *
+ * @author edgar
+ * @since 1.1.0
+ */
+public class FileEventOptions {
+
+  private List<WatchEvent.Kind<Path>> kinds = new ArrayList<>();
+
+  static final PathMatcher TRUE = new PathMatcher() {
+
+    @Override
+    public boolean matches(final Path path) {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "**/*";
+    }
+  };
+
+  private static final WatchEvent.Kind<?>[] KINDS = {ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY};
+
+  private final List<PathMatcher> matchers = new ArrayList<>();
+
+  private Modifier modifier = SensitivityWatchEventModifier.HIGH;
+
+  private boolean recursive = true;
+
+  private final Class<? extends FileEventHandler> handler;
+
+  private final Path path;
+
+  private FileEventHandler handlerInstance;
+
+  FileEventOptions(final Path path, final Class<? extends FileEventHandler> handler)
+      throws IOException {
+    if (!Files.exists(path)) {
+      Files.createDirectories(path);
+    }
+    this.path = path;
+    this.handler = handler;
+    this.handlerInstance = null;
+  }
+
+  FileEventOptions(final Path path, final FileEventHandler handler) throws IOException {
+    this(path, handler.getClass());
+    this.handlerInstance = handler;
+  }
+
+  /**
+   * Append a kind filter.
+   * <p>
+   * The default filter is: {@link StandardWatchEventKinds#ENTRY_CREATE},
+   * {@link StandardWatchEventKinds#ENTRY_DELETE} and {@link StandardWatchEventKinds#ENTRY_MODIFY}.
+   *
+   * @param kind Filter type.
+   * @return This options.
+   */
+  public FileEventOptions kind(final WatchEvent.Kind<Path> kind) {
+    requireNonNull(kind, "WatchEvent.Kind required.");
+    kinds.add(kind);
+    return this;
+  }
+
+  /**
+   * Turn on/off watching of subfolder.
+   *
+   * @param recursive True to watch on subfolder.
+   * @return This options.
+   */
+  public FileEventOptions recursive(final boolean recursive) {
+    this.recursive = recursive;
+    return this;
+  }
+
+  /**
+   * Add a path filter using <code>glob</code> expression, like <code><pre>** / *.java</pre><code>,
+   * etc...
+   *
+   * @param expression Glob expression.
+   * @return This options.
+   */
+  public FileEventOptions includes(final String expression) {
+    requireNonNull(expression, "Glob expression required.");
+    this.matchers.add(new GlobPathMatcher(expression));
+    return this;
+  }
+
+  /**
+   * Set a watch modifier. Default is: <code>HIGH</code>.
+   *
+   * @param modifier Watch modifier.
+   * @return This options.
+   */
+  public FileEventOptions modifier(final WatchEvent.Modifier modifier) {
+    requireNonNull(modifier, "Modifier required.");
+    this.modifier = modifier;
+    return this;
+  }
+
+  Modifier modifier() {
+    return modifier;
+  }
+
+  WatchEvent.Kind<?>[] kinds() {
+    return kinds.size() == 0 ? KINDS : kinds.toArray(new WatchEvent.Kind[0]);
+  }
+
+  PathMatcher filter() {
+    return matchers.size() == 0 ? TRUE : new FirstOfPathMatcher(matchers);
+  }
+
+  boolean recursive() {
+    return recursive;
+  }
+
+  Path path() {
+    return path;
+  }
+
+  FileEventHandler handler(
+      final Function<Class<? extends FileEventHandler>, FileEventHandler> factory) {
+    return Optional.ofNullable(handlerInstance).orElseGet(() -> factory.apply(handler));
+  }
+
+  @Override
+  public String toString() {
+    return path + " {kinds: " + Arrays.toString(kinds()) + ", filter: " + filter()
+        + ", recursive: " + recursive + ", modifier: " + modifier + "}";
+  }
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileMonitor.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileMonitor.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchEvent.Modifier;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Injector;
+
+class FileMonitor implements Runnable {
+
+  /** The logging system. */
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final Injector injector;
+
+  private final WatchService watcher;
+
+  private final Map<WatchKey, Path> keys = new ConcurrentHashMap<>();
+
+  private final Map<Path, FileEventOptions> options = new ConcurrentHashMap<>();
+
+  private final Set<FileEventOptions> optionList;
+
+  @Inject
+  public FileMonitor(final Injector injector,
+      final WatchService watcher, final Set<FileEventOptions> optionList) throws IOException {
+    this.injector = injector;
+    this.watcher = watcher;
+    this.optionList = optionList;
+
+    // start monitor:
+    Thread thread = new Thread(this, "file-watcher");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  @Override
+  public void run() {
+    // register directory:
+    for (FileEventOptions options : optionList) {
+      log.debug("watching: {}", options);
+      try {
+        registerTree(options.path(), options);
+      } catch (IOException x) {
+        log.error("traversal of {} resulted in exception", options.path(), x);
+      }
+    }
+
+    boolean process = true;
+    while (process) {
+      try {
+        process = poll(watcher.take());
+      } catch (InterruptedException x) {
+        Thread.currentThread().interrupt();
+        process = false;
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private boolean poll(final WatchKey key) {
+    Path source = keys.get(key);
+    if (source == null) {
+      log.debug("ignoring key {}", key);
+      return true;
+    }
+
+    for (WatchEvent<?> event : key.pollEvents()) {
+      Kind<?> kind = event.kind();
+
+      if (kind != OVERFLOW) {
+
+        // Context for directory entry event is the file name of entry
+        Path path = source.resolve((Path) event.context()).toAbsolutePath();
+        log.debug("found {}({})", path, kind);
+
+        // handler
+        FileEventOptions options = this.options.get(source);
+        PathMatcher filter = options.filter();
+        if (filter.matches(path)) {
+          FileEventHandler handler = options.handler(injector::getInstance);
+          try {
+            handler.handle((Kind<Path>) kind, path);
+          } catch (IOException x) {
+            log.debug("execution of {}({}) resulted in exception", path, kind, x);
+          }
+        } else {
+          log.debug("ignoring {}({})", kind, path);
+        }
+
+        // if directory is created, and watching recursively, then
+        // register it and its sub-directories
+        if (options.recursive() && kind == ENTRY_CREATE && Files.isDirectory(path)) {
+          try {
+            registerTree(path, options);
+          } catch (IOException x) {
+            log.debug("execution of {}({}) resulted in exception", path, kind, x);
+          }
+        }
+      } else {
+        log.trace("execution of {} resulted in {}", event.context(), kind);
+      }
+    }
+
+    // reset key and remove from set if directory no longer accessible
+    if (!key.reset()) {
+      keys.remove(key);
+    }
+    return !keys.isEmpty();
+  }
+
+  private void register(final Path path, final FileEventOptions options) throws IOException {
+    Kind<?>[] kinds = options.kinds();
+    Modifier modifier = options.modifier();
+    WatchKey key = path.register(watcher, kinds, modifier);
+    this.keys.put(key, path);
+    this.options.put(path, options);
+  }
+
+  private void registerTree(final Path path, final FileEventOptions options) throws IOException {
+    if (options.recursive()) {
+      Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs)
+            throws IOException {
+          register(dir, options);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } else {
+      register(path, options);
+    }
+  }
+
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileWatcher.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FileWatcher.java
@@ -1,0 +1,385 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.jooby.Env;
+import org.jooby.Jooby.Module;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import javaslang.CheckedFunction1;
+import javaslang.CheckedFunction2;
+import javaslang.control.Try.CheckedConsumer;
+
+/**
+ * <h1>file watcher</h1>
+ * <p>
+ * Watches for file system changes or event. It uses a watch service to monitor a directory for
+ * changes so that it can update its display of the list of files when files are created or deleted.
+ * </p>
+ *
+ * <h2>usage</h2>
+ * <p>
+ * Watch <code>mydir</code> and listen for create, modify or delete event on all files under it:
+ * </p>
+ *
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher()
+ *     .register(Paths.get("mydir"), (kind, path) -> {
+ *       log.info("found {} on {}", kind, path);
+ *     });
+ *   );
+ * }
+ * }</pre>
+ *
+ * <h2>file handler</h2>
+ * <p>
+ * You can specify a {@link FileEventHandler} instance or class while registering a path:
+ * </p>
+ *
+ * <p>
+ * Instance:
+ * </p>
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher()
+ *     .register(Paths.get("mydir"), (kind, path) -> {
+ *       log.info("found {} on {}", kind, path);
+ *     });
+ *   );
+ * }
+ * }</pre>
+ *
+ * <p>
+ * Class reference:
+ * </p>
+ *
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher()
+ *     .register(Paths.get("mydir"), MyFileEventHandler.class)
+ *   );
+ * }
+ * }</pre>
+ *
+ * <p>
+ * Worth to mention that <code>MyFileEventHandler</code> will be provided by Guice.
+ * </p>
+ *
+ * <h2>options</h2>
+ * <p>
+ * You can specify a couple of options at registration time:
+ * </p>
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher(
+ *     .register(Paths.get("mydir"), MyFileEventHandler.class, options -> {
+ *       options.kind(StandardWatchEventKinds.ENTRY_MODIFY)
+ *              .recursive(false)
+ *              .includes("*.java");
+ *     });
+ *   ));
+ * }
+ * }</pre>
+ *
+ * <p>
+ * 1. Here we listen for {@link StandardWatchEventKinds#ENTRY_MODIFY} (we don't care about create or
+ * delete).
+ * </p>
+ * <p>
+ * 2. We turn off recursive watching, only direct files are detected.
+ * </p>
+ * <p>
+ * 3. We want <code>.java</code> files and we ignore any other files.
+ * </p>
+ *
+ * <h2>configuration file</h2>
+ * <p>
+ * In addition to do it programmatically, you can do it via configuration properties:
+ * </p>
+ *
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher()
+ *     .register("mydirproperty", MyEventHandler.class)
+ *   );
+ * }
+ * }</pre>
+ *
+ * <p>
+ * The <code>mydirproperty</code> property must be present in your <code>.conf</code> file.
+ * </p>
+ *
+ * <p>
+ * But of course, you can entirely register paths from <code>.conf</code> file:
+ * </p>
+ *
+ * <pre>{@code
+ * filewatcher {
+ *   register {
+ *     path: "mydir"
+ *     handler: "org.example.MyFileEventHandler"
+ *     kind: "ENTRY_MODIFY"
+ *     includes: "*.java"
+ *     recursive: false
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>
+ * Multiple paths are supported using array notation:
+ * </p>
+ *
+ * <pre>{@code
+ * filewatcher {
+ *   register: [{
+ *     path: "mydir1"
+ *     handler: "org.example.MyFileEventHandler"
+ *   }, {
+ *     path: "mydir2"
+ *     handler: "org.example.MyFileEventHandler"
+ *   }]
+ * }
+ * }</pre>
+ *
+ * <p>
+ * Now use the module:
+ * </p>
+ * <pre>{@code
+ * {
+ *   use(new FileWatcher());
+ * }
+ * }</pre>
+ *
+ * <p>
+ * The {@link FileWatcher} module read the <code>filewatcher.register</code> property and setup
+ * everything.
+ * </p>
+ *
+ * @author edgar
+ */
+public class FileWatcher implements Module {
+  private static final Consumer<FileEventOptions> EMPTY = it -> {
+  };
+
+  /** The logging system. */
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final List<CheckedFunction2<Config, Binder, FileEventOptions>> bindings = new ArrayList<>();
+
+  private WatchService watcher;
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @return This module.
+   */
+  public FileWatcher register(final Path path, final Class<? extends FileEventHandler> handler) {
+    return register(path, handler, EMPTY);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete. The configurer callback allow you to customize default event
+   * kinds, filter specific file types and restrict the watch scope lookup to direct files.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @param configurer Configurer callback.
+   * @return This module.
+   * @see FileEventOptions
+   */
+  public FileWatcher register(final Path path, final Class<? extends FileEventHandler> handler,
+      final Consumer<FileEventOptions> configurer) {
+    return register(c -> path, p -> new FileEventOptions(p, handler), configurer);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @return This module.
+   */
+  public FileWatcher register(final Path path, final FileEventHandler handler) {
+    return register(c -> path, p -> new FileEventOptions(p, handler), EMPTY);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete. The configurer callback allow you to customize default event
+   * kinds, filter specific file types and restrict the watch scope lookup to direct files.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @param configurer Configurer callback.
+   * @return This module.
+   * @see FileEventOptions
+   */
+  public FileWatcher register(final Path path, final FileEventHandler handler,
+      final Consumer<FileEventOptions> configurer) {
+    return register(c -> path, p -> new FileEventOptions(p, handler), configurer);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @return This module.
+   */
+  public FileWatcher register(final String property, final FileEventHandler handler) {
+    return register(c -> Paths.get(c.getString(property)), p -> new FileEventOptions(p, handler),
+        EMPTY);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete. The configurer callback allow you to customize default event
+   * kinds, filter specific file types and restrict the watch scope lookup to direct files.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @param configurer Configurer callback.
+   * @return This module.
+   * @see FileEventOptions
+   */
+  public FileWatcher register(final String property, final FileEventHandler handler,
+      final Consumer<FileEventOptions> configurer) {
+    return register(c -> Paths.get(c.getString(property)), p -> new FileEventOptions(p, handler),
+        configurer);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @return This module.
+   */
+  public FileWatcher register(final String property,
+      final Class<? extends FileEventHandler> handler) {
+    return register(property, handler, EMPTY);
+  }
+
+  /**
+   * Register the given directory tree and execute the given handler whenever a file/folder has been
+   * created, modified or delete. The configurer callback allow you to customize default event
+   * kinds, filter specific file types and restrict the watch scope lookup to direct files.
+   *
+   * @param path Directory to register.
+   * @param handler Handler to execute.
+   * @param configurer Configurer callback.
+   * @return This module.
+   * @see FileEventOptions
+   */
+  public FileWatcher register(final String property,
+      final Class<? extends FileEventHandler> handler,
+      final Consumer<FileEventOptions> configurer) {
+    return register(c -> Paths.get(c.getString(property)),
+        path -> new FileEventOptions(path, handler), configurer);
+  }
+
+  private FileWatcher register(final Function<Config, Path> provider,
+      final CheckedFunction1<Path, FileEventOptions> handler,
+      final Consumer<FileEventOptions> configurer) {
+    bindings.add((conf, binder) -> {
+      Path path = provider.apply(conf);
+      FileEventOptions options = handler.apply(path);
+      configurer.accept(options);
+      return register(binder, options);
+    });
+    return this;
+  }
+
+  private FileEventOptions register(final Binder binder, final FileEventOptions options) {
+    Multibinder.newSetBinder(binder, FileEventOptions.class)
+        .addBinding()
+        .toInstance(options);
+    return options;
+  }
+
+  @Override
+  public void configure(final Env env, final Config conf, final Binder binder) throws Throwable {
+    this.watcher = FileSystems.getDefault().newWatchService();
+    binder.bind(WatchService.class).toInstance(watcher);
+    List<FileEventOptions> paths = new ArrayList<>();
+    paths(env.getClass().getClassLoader(), conf, "filewatcher.register", options -> {
+      paths.add(register(binder, options));
+    });
+    for (CheckedFunction2<Config, Binder, FileEventOptions> binding : bindings) {
+      paths.add(binding.apply(conf, binder));
+    }
+    binder.bind(FileMonitor.class).asEagerSingleton();
+    paths.forEach(it -> log.info("Watching: {}", it));
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  private void paths(final ClassLoader loader, final Config conf, final String name,
+      final Consumer<FileEventOptions> callback) throws Throwable {
+    list(conf, name, value -> {
+      Config coptions = ConfigFactory.parseMap((Map) value);
+      Class handler = loader.loadClass(coptions.getString("handler"));
+      Path path = Paths.get(coptions.getString("path"));
+      FileEventOptions options = new FileEventOptions(path, handler);
+      list(coptions, "kind", it -> options.kind(new WatchEventKind(it.toString())));
+      list(coptions, "modifier", it -> options.modifier(new WatchEventModifier(it.toString())));
+      list(coptions, "includes", it -> options.includes(it.toString()));
+      list(coptions, "recursive", it -> options.recursive(Boolean.valueOf(it.toString())));
+      callback.accept(options);
+    });
+  }
+
+  @SuppressWarnings("rawtypes")
+  private void list(final Config conf, final String name, final CheckedConsumer<Object> callback)
+      throws Throwable {
+    if (conf.hasPath(name)) {
+      Object value = conf.getAnyRef(name);
+      List values = value instanceof List ? (List) value : ImmutableList.of(value);
+      for (Object it : values) {
+        callback.accept(it);
+      }
+    }
+  }
+
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FirstOfPathMatcher.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/FirstOfPathMatcher.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+
+class FirstOfPathMatcher implements PathMatcher {
+
+  private final List<PathMatcher> matchers;
+
+  FirstOfPathMatcher(final List<PathMatcher> matchers) {
+    this.matchers = matchers;
+  }
+
+  @Override
+  public boolean matches(final Path path) {
+    return matchers.stream()
+        .filter(it -> it.matches(path))
+        .findFirst()
+        .isPresent();
+  }
+
+  @Override
+  public String toString() {
+    return this.matchers.toString();
+  }
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/GlobPathMatcher.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/GlobPathMatcher.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+
+class GlobPathMatcher implements PathMatcher {
+
+  private final String expression;
+
+  private final PathMatcher matcher;
+
+  public GlobPathMatcher(final String expression) {
+    this.expression = expression.trim();
+    this.matcher = FileSystems.getDefault().getPathMatcher("glob:" + this.expression);
+  }
+
+  @Override
+  public boolean matches(final Path path) {
+    return matcher.matches(path);
+  }
+
+  @Override
+  public String toString() {
+    return expression;
+  }
+
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/WatchEventKind.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/WatchEventKind.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+
+class WatchEventKind implements WatchEvent.Kind<Path> {
+
+  private final String name;
+
+  public WatchEventKind(final String name) {
+    this.name = name.toUpperCase();
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Class<Path> type() {
+    return Path.class;
+  }
+
+}

--- a/jooby-filewatcher/src/main/java/org/jooby/filewatcher/WatchEventModifier.java
+++ b/jooby-filewatcher/src/main/java/org/jooby/filewatcher/WatchEventModifier.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jooby.filewatcher;
+
+import java.nio.file.WatchEvent;
+
+class WatchEventModifier implements WatchEvent.Modifier {
+
+  private final String name;
+
+  public WatchEventModifier(final String name) {
+    this.name = name.toUpperCase();
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/jooby-filewatcher/src/test/java/filewatcher/FileWatcherApp.java
+++ b/jooby-filewatcher/src/test/java/filewatcher/FileWatcherApp.java
@@ -1,0 +1,38 @@
+package filewatcher;
+
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+
+import org.jooby.Jooby;
+import org.jooby.filewatcher.FileWatcher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
+
+public class FileWatcherApp extends Jooby {
+
+  {
+    use(ConfigFactory.parseMap(ImmutableMap.of("filewatcher.register",
+        ImmutableList.of(
+            ImmutableMap.of("path", "workdir/hashmap", "handler",
+                MyFileEventHandler.class.getName()),
+            ImmutableMap.of("path", "workdir/f2", "handler", MyFileEventHandler.class.getName())),
+        "fprop", "workdir/2nf")));
+
+    use(new FileWatcher()
+        .register(Paths.get("workdir", "watchme"), MyFileEventHandler.class)
+        .register("fprop", MyFileEventHandler.class, options -> {
+          options.recursive(false);
+        }).register(Paths.get("workdir", "kt"), MyFileEventHandler.class, options -> {
+          options.includes("**/*.kt");
+          options.includes("**/*.cp");
+          options.kind(StandardWatchEventKinds.ENTRY_MODIFY);
+        }));
+  }
+
+  public static void main(final String[] args) {
+    run(FileWatcherApp::new, args);
+  }
+
+}

--- a/jooby-filewatcher/src/test/java/filewatcher/MyFileEventHandler.java
+++ b/jooby-filewatcher/src/test/java/filewatcher/MyFileEventHandler.java
@@ -1,0 +1,22 @@
+package filewatcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent.Kind;
+
+import org.jooby.filewatcher.FileEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MyFileEventHandler implements FileEventHandler {
+
+  /** The logging system. */
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  @Override
+  public void handle(final Kind<Path> kind, final Path path) throws IOException {
+    log.info("{}({}) exists? {}", path, kind, Files.exists(path));
+  }
+
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileEventOptionsTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileEventOptionsTest.java
@@ -1,0 +1,121 @@
+package org.jooby.filewatcher;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent.Kind;
+
+import static org.junit.Assert.*;
+
+public class FileEventOptionsTest {
+
+  public static class MyHandler implements FileEventHandler {
+
+    @Override
+    public void handle(final Kind<Path> kind, final Path path) throws IOException {
+    }
+  }
+
+  @Test
+  public void defaults() throws IOException {
+    Path source = Paths.get(".");
+    MyHandler handler = new MyHandler();
+    FileEventOptions options = new FileEventOptions(source, MyHandler.class);
+    assertEquals(handler, options.handler(type -> handler));
+    assertEquals(source, options.path());
+    assertEquals("**/*", options.filter().toString());
+    assertEquals(true, options.filter().matches(null));
+    assertArrayEquals(new Object[]{StandardWatchEventKinds.ENTRY_CREATE,
+            StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY},
+        options.kinds());
+    assertEquals("HIGH", options.modifier().name());
+    assertEquals(true, options.recursive());
+    assertEquals(
+        ". {kinds: [ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY], filter: **/*, recursive: true, modifier: HIGH}",
+        options.toString());
+  }
+
+  @Test
+  public void withInstance() throws IOException {
+    Path source = Paths.get(".");
+    MyHandler handler = new MyHandler();
+    FileEventOptions options = new FileEventOptions(source, handler);
+    assertEquals(handler, options.handler(type -> handler));
+    assertEquals(source, options.path());
+    assertEquals("**/*", options.filter().toString());
+    assertEquals(true, options.filter().matches(null));
+    assertArrayEquals(new Object[]{StandardWatchEventKinds.ENTRY_CREATE,
+            StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY},
+        options.kinds());
+    assertEquals("HIGH", options.modifier().name());
+    assertEquals(true, options.recursive());
+    assertEquals(
+        ". {kinds: [ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY], filter: **/*, recursive: true, modifier: HIGH}",
+        options.toString());
+  }
+
+  @Test
+  public void mkdir() throws IOException {
+    Path source = Paths.get("target/" + FileEventOptions.class.getSimpleName());
+    new FileEventOptions(source, MyHandler.class);
+    assertTrue(Files.exists(source));
+  }
+
+  @Test
+  public void filter() throws IOException {
+    assertEquals("[**/*.java]", new FileEventOptions(Paths.get("."), MyHandler.class)
+        .includes("**/*.java")
+        .filter()
+        .toString());
+
+    assertEquals("[**/*.java, **/*.kt]", new FileEventOptions(Paths.get("."), MyHandler.class)
+        .includes("**/*.java")
+        .includes("**/*.kt")
+        .filter()
+        .toString());
+  }
+
+  @Test
+  public void modifier() throws IOException {
+    assertEquals("LOW", new FileEventOptions(Paths.get("."), MyHandler.class)
+        .modifier(() -> "LOW")
+        .modifier()
+        .name());
+  }
+
+  @Test
+  public void recursive() throws IOException {
+    assertEquals(false, new FileEventOptions(Paths.get("."), MyHandler.class)
+        .recursive(false)
+        .recursive());
+  }
+
+  @Test
+  public void kind() throws IOException {
+    assertArrayEquals(new Object[]{StandardWatchEventKinds.ENTRY_CREATE},
+        new FileEventOptions(Paths.get("."), MyHandler.class)
+            .kind(StandardWatchEventKinds.ENTRY_CREATE)
+            .kinds());
+
+    assertArrayEquals(new Object[]{StandardWatchEventKinds.ENTRY_MODIFY},
+        new FileEventOptions(Paths.get("."), MyHandler.class)
+            .kind(StandardWatchEventKinds.ENTRY_MODIFY)
+            .kinds());
+
+    assertArrayEquals(new Object[]{StandardWatchEventKinds.ENTRY_DELETE},
+        new FileEventOptions(Paths.get("."), MyHandler.class)
+            .kind(StandardWatchEventKinds.ENTRY_DELETE)
+            .kinds());
+
+    assertArrayEquals(
+        new Object[]{StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE},
+        new FileEventOptions(Paths.get("."), MyHandler.class)
+            .kind(StandardWatchEventKinds.ENTRY_MODIFY)
+            .kind(StandardWatchEventKinds.ENTRY_CREATE)
+            .kinds());
+  }
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileMonitorTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileMonitorTest.java
@@ -1,0 +1,394 @@
+package org.jooby.filewatcher;
+
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+
+import java.io.IOException;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchEvent.Modifier;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.function.Function;
+
+import org.easymock.IExpectationSetters;
+import org.jooby.test.MockUnit;
+import org.jooby.test.MockUnit.Block;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileMonitor.class, Thread.class, Files.class })
+public class FileMonitorTest {
+
+  private Block newThread = unit -> {
+    Thread thread = unit.constructor(Thread.class)
+        .args(Runnable.class, String.class)
+        .build(unit.capture(Runnable.class), eq("file-watcher"));
+
+    thread.setDaemon(true);
+    thread.start();
+  };
+  private Block takeInterrupt = unit -> {
+    WatchService watcher = unit.get(WatchService.class);
+    expect(watcher.take()).andThrow(new InterruptedException());
+  };
+
+  private Block take = unit -> {
+    WatchService watcher = unit.get(WatchService.class);
+    expect(watcher.take()).andReturn(unit.get(WatchKey.class));
+  };
+
+  private Block takeIgnore = unit -> {
+    WatchService watcher = unit.get(WatchService.class);
+    expect(watcher.take()).andReturn(unit.mock(WatchKey.class));
+  };
+
+  @Test
+  public void newFileMonitor() throws Exception {
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class)
+        .expect(newThread)
+        .run(unit -> {
+          new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+              ImmutableSet.of(unit.get(FileEventOptions.class)));
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void registerTreeRecursive() throws Exception {
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class)
+            .expect(newThread)
+            .expect(registerTree(true, false))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+              unit.captured(FileVisitor.class).get(0).preVisitDirectory(unit.get(Path.class), null);
+            });
+  }
+
+  @Test
+  public void registerTree() throws Exception {
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void registerTreeErr() throws Exception {
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class)
+            .expect(newThread)
+            .expect(registerTree(false, true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollIgnoreMissing() throws Exception {
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(takeIgnore)
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEvents() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_MODIFY, path))
+            .expect(filter(true))
+            .expect(handler(StandardWatchEventKinds.ENTRY_MODIFY, false))
+            .expect(recursive(false, false))
+            .expect(reset(true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEventsInvalid() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_MODIFY, path))
+            .expect(filter(true))
+            .expect(handler(StandardWatchEventKinds.ENTRY_MODIFY, false))
+            .expect(recursive(false, false))
+            .expect(reset(false))
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEventsRecursive() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_CREATE, path))
+            .expect(filter(true))
+            .expect(handler(StandardWatchEventKinds.ENTRY_CREATE, false))
+            .expect(recursive(true, false))
+            .expect(reset(true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.first(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEventsRecursiveErr() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_CREATE, path))
+            .expect(filter(true))
+            .expect(handler(StandardWatchEventKinds.ENTRY_CREATE, false))
+            .expect(recursive(true, true))
+            .expect(reset(true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.first(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEventWithHandleErr() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_MODIFY, path))
+            .expect(filter(true))
+            .expect(handler(StandardWatchEventKinds.ENTRY_MODIFY, true))
+            .expect(recursive(false, false))
+            .expect(reset(true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  @Test
+  public void pollEventsNoMatches() throws Exception {
+    Path path = Paths.get("target/foo.txt");
+    new MockUnit(Injector.class, WatchService.class, FileEventOptions.class, Path.class,
+        WatchEvent.Kind.class, WatchEvent.Modifier.class, WatchKey.class, WatchEvent.class,
+        PathMatcher.class, FileEventHandler.class)
+            .expect(newThread)
+            .expect(registerTree(false, false))
+            .expect(take)
+            .expect(poll(StandardWatchEventKinds.ENTRY_MODIFY, path))
+            .expect(filter(false))
+            .expect(recursive(false, false))
+            .expect(reset(true))
+            .expect(takeInterrupt)
+            .run(unit -> {
+              new FileMonitor(unit.get(Injector.class), unit.get(WatchService.class),
+                  ImmutableSet.of(unit.get(FileEventOptions.class)));
+            }, unit -> {
+              unit.captured(Runnable.class).get(0).run();
+            });
+  }
+
+  private Block reset(final boolean valid) {
+    return unit -> {
+      WatchKey key = unit.get(WatchKey.class);
+      expect(key.reset()).andReturn(valid);
+    };
+  }
+
+  @SuppressWarnings("rawtypes")
+  private Block poll(final Kind kind, final Path path) {
+    return unit -> {
+      WatchEvent event = unit.get(WatchEvent.class);
+      expect(event.kind()).andReturn(kind);
+      expect(event.context()).andReturn(path);
+      Path source = unit.get(Path.class);
+      Path resolved = unit.mock(Path.class);
+      unit.registerMock(Path.class, resolved);
+      expect(source.resolve(path)).andReturn(resolved);
+      expect(resolved.toAbsolutePath()).andReturn(resolved);
+
+      WatchEvent overflow = unit.mock(WatchEvent.class);
+      expect(overflow.kind()).andReturn(StandardWatchEventKinds.OVERFLOW);
+      expect(overflow.context()).andReturn(path);
+
+      WatchKey key = unit.get(WatchKey.class);
+      expect(key.pollEvents()).andReturn(ImmutableList.of(event, overflow));
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private Block handler(final Kind<Path> kind, final boolean err) {
+    return unit -> {
+      FileEventHandler handler = unit.get(FileEventHandler.class);
+      FileEventOptions options = unit.get(FileEventOptions.class);
+      expect(options.handler(isA(Function.class))).andReturn(handler);
+      handler.handle(kind, unit.get(Path.class));
+      if (err) {
+        expectLastCall().andThrow(new IOException("intentional err"));
+      }
+    };
+  }
+
+  private Block filter(final boolean matches) {
+    return unit -> {
+      Path resolved = unit.get(Path.class);
+      PathMatcher filter = unit.get(PathMatcher.class);
+      expect(filter.matches(resolved)).andReturn(matches);
+
+      FileEventOptions options = unit.get(FileEventOptions.class);
+      expect(options.filter()).andReturn(filter);
+    };
+  }
+
+  private Block registerTree(final boolean recursive, final boolean err) {
+    return unit -> {
+      register(unit, recursive, err);
+    };
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private void register(final MockUnit unit, final boolean recursive, final boolean err)
+      throws IOException {
+    FileEventOptions options = unit.get(FileEventOptions.class);
+    expect(options.recursive()).andReturn(recursive);
+
+    Path path = unit.get(Path.class);
+    expect(options.path()).andReturn(path).times(1, 2);
+
+    Kind kind = unit.get(WatchEvent.Kind.class);
+    Kind[] kinds = {kind };
+    expect(options.kinds()).andReturn(kinds);
+
+    Modifier mod = unit.get(WatchEvent.Modifier.class);
+    expect(options.modifier()).andReturn(mod);
+
+    if (recursive) {
+      unit.mockStatic(Files.class);
+      expect(Files.walkFileTree(eq(path), unit.capture(FileVisitor.class))).andReturn(path);
+    }
+
+    WatchKey key = unit.get(WatchKey.class);
+
+    IExpectationSetters<WatchKey> register = expect(
+        path.register(unit.get(WatchService.class), kinds, mod));
+    if (err) {
+      register.andThrow(new IOException("intentional error"));
+    } else {
+      register.andReturn(key);
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  private Block recursive(final boolean recursive, final boolean err) {
+    return unit -> {
+      FileEventOptions options = unit.get(FileEventOptions.class);
+      expect(options.recursive()).andReturn(recursive);
+
+      if (recursive) {
+        unit.mockStatic(Files.class);
+        expect(Files.isDirectory(unit.get(Path.class))).andReturn(true);
+        expect(options.recursive()).andReturn(false);
+
+        ///
+        Path path = unit.get(Path.class);
+
+        Kind kind = unit.get(WatchEvent.Kind.class);
+        Kind[] kinds = {kind };
+        expect(options.kinds()).andReturn(kinds);
+
+        Modifier mod = unit.get(WatchEvent.Modifier.class);
+        expect(options.modifier()).andReturn(mod);
+
+        WatchKey key = unit.get(WatchKey.class);
+
+        IExpectationSetters<WatchKey> register = expect(
+            path.register(unit.get(WatchService.class), kinds, mod));
+        if (err) {
+          register.andThrow(new IOException("intentional error"));
+        } else {
+          register.andReturn(key);
+        }
+      }
+    };
+  }
+
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileWatcherTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FileWatcherTest.java
@@ -1,0 +1,322 @@
+package org.jooby.filewatcher;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchService;
+import java.util.List;
+import java.util.Map;
+
+import org.jooby.Env;
+import org.jooby.test.MockUnit;
+import org.jooby.test.MockUnit.Block;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.binder.AnnotatedBindingBuilder;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.Multibinder;
+import com.typesafe.config.Config;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileWatcher.class, Multibinder.class, FileSystems.class, FileEventOptions.class,
+    Paths.class })
+public class FileWatcherTest {
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private Block watcher = unit -> {
+    WatchService watcher = unit.get(WatchService.class);
+    FileSystem fs = unit.get(FileSystem.class);
+    expect(fs.newWatchService()).andReturn(watcher);
+
+    unit.mockStatic(FileSystems.class);
+    expect(FileSystems.getDefault()).andReturn(fs);
+
+    AnnotatedBindingBuilder abbws = unit.mock(AnnotatedBindingBuilder.class);
+    abbws.toInstance(watcher);
+
+    Binder binder = unit.get(Binder.class);
+    expect(binder.bind(WatchService.class)).andReturn(abbws);
+  };
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private Block filemonitor = unit -> {
+    AnnotatedBindingBuilder aab = unit.mock(AnnotatedBindingBuilder.class);
+    aab.asEagerSingleton();
+
+    Binder binder = unit.get(Binder.class);
+    expect(binder.bind(FileMonitor.class)).andReturn(aab);
+  };
+
+  @Test
+  public void newModule() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class)
+        .expect(watcher)
+        .expect(filewatcherProp(false))
+        .expect(filemonitor)
+        .run(unit -> {
+          new FileWatcher()
+              .configure(unit.get(Env.class), unit.get(Config.class), unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void registerPath() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(filemonitor)
+            .expect(fileeventoptions(FileEventHandler.class))
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register(unit.get(Path.class), FileEventHandler.class)
+                  .configure(unit.get(Env.class), unit.get(Config.class),
+                      unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPathInstance() throws Exception {
+    FileEventHandler handler = (k, p) -> {
+    };
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(filemonitor)
+            .expect(fileeventoptions(handler))
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register(unit.get(Path.class), handler)
+                  .configure(unit.get(Env.class), unit.get(Config.class),
+                      unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPathInstanceCallback() throws Exception {
+    FileEventHandler handler = (k, p) -> {
+    };
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(filemonitor)
+            .expect(fileeventoptions(handler))
+            .expect(unit -> {
+              FileEventOptions options = unit.get(FileEventOptions.class);
+              expect(options.recursive(true)).andReturn(options);
+            })
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register(unit.get(Path.class), handler, options -> {
+                options.recursive(true);
+              })
+                  .configure(unit.get(Env.class), unit.get(Config.class),
+                      unit.get(Binder.class));
+            });
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes" })
+  @Test
+  public void registerFromConf() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(true))
+            .expect(unit -> {
+              Config conf = unit.get(Config.class);
+              Map<String, Object> options = ImmutableMap.<String, Object> builder()
+                  .put("path", "target")
+                  .put("handler", FileEventHandler.class.getName())
+                  .put("kind", ImmutableList.of("ENTRY_CREATE", "ENTRY_MODIFY"))
+                  .put("recursive", false)
+                  .put("includes", "*.cp")
+                  .put("modifier", "LOW")
+                  .build();
+              expect(conf.getAnyRef("filewatcher.register")).andReturn(options);
+
+              unit.mockStatic(Paths.class);
+              expect(Paths.get("target")).andReturn(unit.get(Path.class));
+            })
+            .expect(filemonitor)
+            .expect(fileeventoptions(FileEventHandler.class))
+            .expect(unit -> {
+              FileEventOptions options = unit.get(FileEventOptions.class);
+              expect(options.kind(unit.capture(WatchEvent.Kind.class))).andReturn(options);
+              expect(options.kind(unit.capture(WatchEvent.Kind.class))).andReturn(options);
+              expect(options.recursive(false)).andReturn(options);
+              expect(options.includes("*.cp")).andReturn(options);
+              expect(options.modifier(unit.capture(WatchEvent.Modifier.class))).andReturn(options);
+            })
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.configure(unit.get(Env.class), unit.get(Config.class),
+                  unit.get(Binder.class));
+            }, unit -> {
+              List<Kind> kinds = unit.captured(WatchEvent.Kind.class);
+              assertEquals("ENTRY_CREATE", kinds.get(0).name());
+              assertEquals("ENTRY_MODIFY", kinds.get(1).name());
+              assertEquals("LOW", unit.captured(WatchEvent.Modifier.class).get(0).name());
+            });
+  }
+
+  @Test
+  public void registerPropPath() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(pathprop("property"))
+            .expect(filemonitor)
+            .expect(fileeventoptions(FileEventHandler.class))
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register("property", FileEventHandler.class)
+                  .configure(unit.get(Env.class), unit.get(Config.class),
+                      unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPropPathInstance() throws Exception {
+    FileEventHandler handler = (k, p) -> {
+    };
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(pathprop("property"))
+            .expect(filemonitor)
+            .expect(fileeventoptions(handler))
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register("property", handler)
+                  .configure(unit.get(Env.class), unit.get(Config.class),
+                      unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPropPathInstanceOptions() throws Exception {
+    FileEventHandler handler = (k, p) -> {
+    };
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(pathprop("property"))
+            .expect(filemonitor)
+            .expect(fileeventoptions(handler))
+            .expect(unit -> {
+              FileEventOptions options = unit.get(FileEventOptions.class);
+              expect(options.kind(StandardWatchEventKinds.ENTRY_CREATE)).andReturn(options);
+            })
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register("property", handler, options -> {
+                options.kind(StandardWatchEventKinds.ENTRY_CREATE);
+              }).configure(unit.get(Env.class), unit.get(Config.class),
+                  unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPropPathWithOptions() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(pathprop("prop"))
+            .expect(filemonitor)
+            .expect(fileeventoptions(FileEventHandler.class))
+            .expect(unit -> {
+              FileEventOptions options = unit.get(FileEventOptions.class);
+              expect(options.kind(StandardWatchEventKinds.ENTRY_CREATE)).andReturn(options);
+            })
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register("prop", FileEventHandler.class, options -> {
+                options.kind(StandardWatchEventKinds.ENTRY_CREATE);
+              }).configure(unit.get(Env.class), unit.get(Config.class),
+                  unit.get(Binder.class));
+            });
+  }
+
+  @Test
+  public void registerPathWithOptions() throws Exception {
+    new MockUnit(Env.class, Config.class, Binder.class, WatchService.class, FileSystem.class,
+        Path.class)
+            .expect(watcher)
+            .expect(filewatcherProp(false))
+            .expect(filemonitor)
+            .expect(fileeventoptions(FileEventHandler.class))
+            .expect(unit -> {
+              FileEventOptions options = unit.get(FileEventOptions.class);
+              expect(options.kind(StandardWatchEventKinds.ENTRY_CREATE)).andReturn(options);
+            })
+            .run(unit -> {
+              FileWatcher watcher = new FileWatcher();
+              watcher.register(unit.get(Path.class), FileEventHandler.class, options -> {
+                options.kind(StandardWatchEventKinds.ENTRY_CREATE);
+              }).configure(unit.get(Env.class), unit.get(Config.class),
+                  unit.get(Binder.class));
+            });
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private Block fileeventoptions(final Object handler) {
+    return unit -> {
+      Binder binder = unit.get(Binder.class);
+
+      FileEventOptions options;
+      if (handler instanceof FileEventHandler) {
+        options = unit.constructor(FileEventOptions.class)
+            .args(Path.class, FileEventHandler.class)
+            .build(unit.get(Path.class), handler);
+      } else {
+        options = unit.constructor(FileEventOptions.class)
+            .args(Path.class, Class.class)
+            .build(unit.get(Path.class), handler);
+      }
+      unit.registerMock(FileEventOptions.class, options);
+
+      LinkedBindingBuilder lbb = unit.mock(LinkedBindingBuilder.class);
+      lbb.toInstance(options);
+
+      Multibinder mbinder = unit.mock(Multibinder.class);
+      unit.mockStatic(Multibinder.class);
+      expect(Multibinder.newSetBinder(binder, FileEventOptions.class)).andReturn(mbinder);
+      expect(mbinder.addBinding()).andReturn(lbb);
+    };
+  }
+
+  private Block filewatcherProp(final boolean b) {
+    return unit -> {
+      Config config = unit.get(Config.class);
+      expect(config.hasPath("filewatcher.register")).andReturn(b);
+    };
+  }
+
+  private Block pathprop(final String name) {
+    return unit -> {
+      Config conf = unit.get(Config.class);
+      expect(conf.getString(name)).andReturn("target");
+      unit.mockStatic(Paths.class);
+      expect(Paths.get("target")).andReturn(unit.get(Path.class));
+    };
+  }
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FirstOfPathMatcherTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/FirstOfPathMatcherTest.java
@@ -1,0 +1,43 @@
+package org.jooby.filewatcher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class FirstOfPathMatcherTest {
+
+  @Test
+  public void nomatches() {
+    assertEquals(false, new FirstOfPathMatcher(ImmutableList.of()).matches(Paths.get("target")));
+  }
+
+  @Test
+  public void matchFirst() {
+    assertEquals(true,
+        new FirstOfPathMatcher(
+            ImmutableList.of(new GlobPathMatcher("**/*.java")))
+                .matches(Paths.get("target/Foo.java")));
+    assertEquals(true,
+        new FirstOfPathMatcher(
+            ImmutableList.of(new GlobPathMatcher("**/*.java")))
+                .matches(Paths.get("target/foo/Foo.java")));
+    assertEquals(false,
+        new FirstOfPathMatcher(
+            ImmutableList.of(new GlobPathMatcher("**/*.java")))
+                .matches(Paths.get("target/Foo.kt")));
+  }
+
+  @Test
+  public void matchOne() {
+    assertEquals(true,
+        new FirstOfPathMatcher(
+            ImmutableList.of(new GlobPathMatcher("**/*.java"),
+                new GlobPathMatcher("**/*.kt")))
+                    .matches(Paths.get("target/Foo.kt")));
+  }
+
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/WatchEventKindTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/WatchEventKindTest.java
@@ -1,0 +1,18 @@
+package org.jooby.filewatcher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class WatchEventKindTest {
+
+  @Test
+  public void watchEvent() {
+    WatchEventKind kind = new WatchEventKind("foo");
+    assertEquals("FOO", kind.name());
+    assertEquals("FOO", kind.toString());
+    assertEquals(Path.class, kind.type());
+  }
+}

--- a/jooby-filewatcher/src/test/java/org/jooby/filewatcher/WatchEventModifierTest.java
+++ b/jooby-filewatcher/src/test/java/org/jooby/filewatcher/WatchEventModifierTest.java
@@ -1,0 +1,15 @@
+package org.jooby.filewatcher;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class WatchEventModifierTest {
+
+  @Test
+  public void watchEventModifier() {
+    WatchEventModifier mod = new WatchEventModifier("foo");
+    assertEquals("FOO", mod.name());
+    assertEquals("FOO", mod.toString());
+  }
+}

--- a/jooby/pom.xml
+++ b/jooby/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
     <groupId>org.jooby</groupId>

--- a/md/doc/filewatcher/filewatcher.md
+++ b/md/doc/filewatcher/filewatcher.md
@@ -1,0 +1,129 @@
+# file watcher
+
+Watches for file system changes or event. It uses a watch service to monitor a directory for changes so that it can update its display of the list of files when files are created or deleted.
+
+## dependency
+
+```xml
+<dependency>
+ <groupId>org.jooby</groupId>
+ <artifactId>jooby-file watcher</artifactId>
+ <version>{{version}}</version>
+</dependency>
+```
+
+## usage
+
+Watch ```mydir``` and listen for create, modify or delete event on all files under it:
+
+```java
+{
+  use(new FileWatcher()
+    .register(Paths.get("mydir"), (kind, path) -> {
+      log.info("found {} on {}", kind, path);
+    });
+  );
+}
+```
+
+## file handler
+
+You can specify a {@link FileEventHandler} instance or class while registering a path:
+
+Instance:
+
+```java
+{
+  use(new FileWatcher()
+    .register(Paths.get("mydir"), (kind, path) -> {
+      log.info("found {} on {}", kind, path);
+    });
+  );
+}
+```
+
+Class reference:
+
+```java
+{
+  use(new FileWatcher()
+    .register(Paths.get("mydir"), MyFileEventHandler.class)
+  );
+}
+```
+
+Worth to mention that ```MyFileEventHandler``` will be provided by Guice.
+
+## options
+
+You can specify a couple of options at registration time:
+
+```java
+{
+  use(new FileWatcher(
+    .register(Paths.get("mydir"), MyFileEventHandler.class, options -> {
+      options.kind(StandardWatchEventKinds.ENTRY_MODIFY)
+             .recursive(false)
+             .includes("*.java");
+    });
+  ));
+}
+```
+
+1. Here we listen for {@link StandardWatchEventKinds#ENTRY_MODIFY} (we don't care about create or delete).
+
+2. We turn off recursive watching, only direct files are detected.
+
+3. We want ```.java``` files and we ignore any other files.
+
+## configuration file
+
+In addition to do it programmatically, you can do it via configuration properties:
+
+```java
+{
+  use(new FileWatcher()
+    .register("mydirproperty", MyEventHandler.class)
+  );
+}
+```
+
+The ```mydirproperty``` property must be present in your ```.conf``` file.
+
+But of course, you can entirely register paths from ```.conf``` file:
+
+```
+filewatcher {
+  register {
+    path: "mydir"
+    handler: "org.example.MyFileEventHandler"
+    kind: "ENTRY_MODIFY"
+    includes: "*.java"
+    recursive: false
+  }
+}
+```
+
+Multiple paths are supported using array notation:
+
+```java
+filewatcher {
+  register: [{
+    path: "mydir1"
+    handler: "org.example.MyFileEventHandler"
+  }, {
+    path: "mydir2"
+    handler: "org.example.MyFileEventHandler"
+  }]
+}
+```
+
+Now use the module:
+
+```java
+{
+  use(new FileWatcher());
+}
+```
+
+The [FileWatcher]({{defdocs}}/filewatcher/FileWatcher.html) module read the ```filewatcher.register``` property and setup everything.

--- a/md/guides/guide.footer.md
+++ b/md/guides/guide.footer.md
@@ -1,6 +1,6 @@
 # source code
 
-* Complete source code available at: [jooby-guides/{{guide}}]({{gh-guides}}/{{guide}})
+* Complete source code available at: [jooby-project/{{guide}}]({{gh-guides}}/{{guide}})
 
 # help and support
 

--- a/md/guides/jdbi.md
+++ b/md/guides/jdbi.md
@@ -350,4 +350,4 @@ As you already see, building an API that saves data in a **database** is very si
 
 The {{modlink "jdbi"}} module makes perfect sense if you want to have full control on your SQL queries, or if you don't like **ORM** tools too.
 
-{{guides/guide.footer.md}}
+{{> guides/guide.footer}}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jooby</groupId>
@@ -75,6 +76,7 @@
     <module>jooby-unbescape</module>
     <module>jooby-crash</module>
     <module>jooby-thymeleaf</module>
+    <module>jooby-filewatcher</module>
     <!-- Assets -->
     <module>jooby-assets</module>
     <module>jooby-assets-j2v8</module>
@@ -585,6 +587,12 @@
       <dependency>
         <groupId>org.jooby</groupId>
         <artifactId>jooby-thymeleaf</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jooby</groupId>
+        <artifactId>jooby-filewatcher</artifactId>
         <version>${jooby.version}</version>
       </dependency>
 
@@ -1741,8 +1749,10 @@
               </goals>
               <configuration>
                 <transformers>
-                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                     <mainClass>${application.class}</mainClass>
                   </transformer>
                 </transformers>
@@ -1875,10 +1885,23 @@
     </profile>
 
     <profile>
+      <id>IDEA</id>
+      <dependencies>
+        <!-- ASM -->
+        <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+          <optional>false</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
       <id>stork</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}stork.yml</exists>
+          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}stork.yml
+          </exists>
         </file>
       </activation>
       <properties>
@@ -1954,7 +1977,9 @@
       <id>static-assets</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}assets.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}assets.activator
+          </exists>
         </file>
       </activation>
       <build>
@@ -1988,7 +2013,8 @@
       <id>war</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}war.activator</exists>
+          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}war.activator
+          </exists>
         </file>
       </activation>
       <properties>
@@ -2034,7 +2060,9 @@
       <id>capsule</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}capsule.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}capsule.activator
+          </exists>
         </file>
       </activation>
       <properties>
@@ -2168,7 +2196,9 @@
       <id>docker.jar</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}docker.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}docker.activator
+          </exists>
         </file>
       </activation>
       <properties>
@@ -2207,7 +2237,9 @@
       <id>docker.stork</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}docker.stork.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}docker.stork.activator
+          </exists>
         </file>
       </activation>
       <properties>
@@ -2252,11 +2284,15 @@
       <id>checkstyle</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}checkstyle.xml</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}checkstyle.xml
+          </exists>
         </file>
       </activation>
       <properties>
-        <checkstyle-file>${basedir}${file.separator}src${file.separator}etc${file.separator}checkstyle.xml</checkstyle-file>
+        <checkstyle-file>
+          ${basedir}${file.separator}src${file.separator}etc${file.separator}checkstyle.xml
+        </checkstyle-file>
         <checkstyle.phase>package</checkstyle.phase>
       </properties>
       <build>
@@ -2288,7 +2324,9 @@
       <id>ebean-activator</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}ebean.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}ebean.activator
+          </exists>
         </file>
       </activation>
       <dependencies>
@@ -2321,13 +2359,19 @@
       <id>querydsl-jpa</id>
       <activation>
         <file>
-          <exists>${basedir}${file.separator}src${file.separator}etc${file.separator}querydsl-jpa.activator</exists>
+          <exists>
+            ${basedir}${file.separator}src${file.separator}etc${file.separator}querydsl-jpa.activator
+          </exists>
         </file>
       </activation>
       <properties>
-        <querydsl-jpa-apt-file>querydsl-jpa-${querydsl.version}-apt-one-jar.jar</querydsl-jpa-apt-file>
-        <querydsl-jpa-apt-dir>${settings.localRepository}/com/querydsl/querydsl-jpa/${querydsl.version}</querydsl-jpa-apt-dir>
-        <querydsl-jpa-apt-path>${querydsl-jpa-apt-dir}/${querydsl-jpa-apt-file}</querydsl-jpa-apt-path>
+        <querydsl-jpa-apt-file>querydsl-jpa-${querydsl.version}-apt-one-jar.jar
+        </querydsl-jpa-apt-file>
+        <querydsl-jpa-apt-dir>
+          ${settings.localRepository}/com/querydsl/querydsl-jpa/${querydsl.version}
+        </querydsl-jpa-apt-dir>
+        <querydsl-jpa-apt-path>${querydsl-jpa-apt-dir}/${querydsl-jpa-apt-file}
+        </querydsl-jpa-apt-path>
         <querydsl-jpa-output-dir>target/generated-sources</querydsl-jpa-output-dir>
       </properties>
       <build>


### PR DESCRIPTION
# file watcher

Watches for file system changes or event. It uses a watch service to monitor a directory for changes so that it can update its display of the list of files when files are created or deleted.

## dependency

```xml
<dependency>
 <groupId>org.jooby</groupId>
 <artifactId>jooby-file watcher</artifactId>
 <version>{{version}}</version>
</dependency>
```

## usage

Watch ```mydir``` and listen for create, modify or delete event on all files under it:

```java
{
  use(new FileWatcher()
    .register(Paths.get("mydir"), (kind, path) -> {
      log.info("found {} on {}", kind, path);
    });
  );
}
```

## file handler

You can specify a {@link FileEventHandler} instance or class while registering a path:

Instance:

```java
{
  use(new FileWatcher()
    .register(Paths.get("mydir"), (kind, path) -> {
      log.info("found {} on {}", kind, path);
    });
  );
}
```

Class reference:

```java
{
  use(new FileWatcher()
    .register(Paths.get("mydir"), MyFileEventHandler.class)
  );
}
```

Worth to mention that ```MyFileEventHandler``` will be provided by Guice.

## options

You can specify a couple of options at registration time:

```java
{
  use(new FileWatcher(
    .register(Paths.get("mydir"), MyFileEventHandler.class, options -> {
      options.kind(StandardWatchEventKinds.ENTRY_MODIFY)
             .recursive(false)
             .includes("*.java");
    });
  ));
}
```

1. Here we listen for {@link StandardWatchEventKinds#ENTRY_MODIFY} (we don't care about create or delete).

2. We turn off recursive watching, only direct files are detected.

3. We want ```.java``` files and we ignore any other files.

## configuration file

In addition to do it programmatically, you can do it via configuration properties:

```java
{
  use(new FileWatcher()
    .register("mydirproperty", MyEventHandler.class)
  );
}
```

The ```mydirproperty``` property must be present in your ```.conf``` file.

But of course, you can entirely register paths from ```.conf``` file:

```
filewatcher {
  register {
    path: "mydir"
    handler: "org.example.MyFileEventHandler"
    kind: "ENTRY_MODIFY"
    includes: "*.java"
    recursive: false
  }
}
```

Multiple paths are supported using array notation:

```java
filewatcher {
  register: [{
    path: "mydir1"
    handler: "org.example.MyFileEventHandler"
  }, {
    path: "mydir2"
    handler: "org.example.MyFileEventHandler"
  }]
}
```

Now use the module:

```java
{
  use(new FileWatcher());
}
```

The [FileWatcher]({{defdocs}}/filewatcher/FileWatcher.html) module read the ```filewatcher.register``` property and setup everything.
