### PR TITLE
Add parsing of comma-separated lists in params

### DIFF
--- a/jooby/src/main/java/org/jooby/internal/BuiltinParser.java
+++ b/jooby/src/main/java/org/jooby/internal/BuiltinParser.java
@@ -135,7 +135,13 @@ public enum BuiltinParser implements Parser {
           TypeLiteral<?> paramType = TypeLiteral.get(((ParameterizedType) type.getType())
               .getActualTypeArguments()[0]);
           for (Object value : values) {
-            builder.add(ctx.next(paramType, value));
+            if (!paramType.getRawType().equals(String.class)) {
+              for (Object csv : value.toString().split(",")) {
+                builder.add(ctx.next(paramType, csv));
+              }
+            } else {
+              builder.add(ctx.next(paramType, value));
+            }
           }
           return builder.build();
         }).upload(uploads -> {

--- a/jooby/src/test/java/org/jooby/internal/ParamConverterTest.java
+++ b/jooby/src/test/java/org/jooby/internal/ParamConverterTest.java
@@ -10,15 +10,9 @@ import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.SortedSet;
-import java.util.UUID;
+import java.util.*;
 
 import org.jooby.MediaType;
 import org.jooby.internal.parser.DateParser;
@@ -135,7 +129,9 @@ public class ParamConverterTest {
     ParserExecutor resolver = newParser();
     Date date = resolver.convert(TypeLiteral.get(Date.class), data("1393038000000"));
     assertNotNull(date);
-    assertEquals("22/02/2014", new SimpleDateFormat("dd/MM/yyyy").format(date));
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy");
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    assertEquals("22/02/2014", simpleDateFormat.format(date));
   }
 
   @Test
@@ -399,7 +395,7 @@ public class ParamConverterTest {
                 BuiltinParser.Optional,
                 BuiltinParser.Enum,
                 new DateParser("dd/MM/yyyy"),
-                new LocalDateParser(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                new LocalDateParser(DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(ZoneId.of("UTC"))),
                 new LocaleParser(),
                 new StaticMethodParser("valueOf"),
                 new StringConstructorParser(),

--- a/jooby/src/test/java/org/jooby/internal/ParamConverterTest.java
+++ b/jooby/src/test/java/org/jooby/internal/ParamConverterTest.java
@@ -336,9 +336,9 @@ public class ParamConverterTest {
   @Test
   public void shouldConvertToListOfBoolean() throws Throwable {
     ParserExecutor resolver = newParser();
-    assertEquals(Lists.newArrayList(true, false),
+    assertEquals(Lists.newArrayList(true, false, true),
         resolver.convert(TypeLiteral.get(Types.listOf(Boolean.class)),
-            data("true", "false")));
+            data("true", "false,true")));
 
     assertEquals(Lists.newArrayList(false, false),
         resolver.convert(TypeLiteral.get(Types.listOf(Boolean.class)),
@@ -384,6 +384,22 @@ public class ParamConverterTest {
     assertEquals(Lists.newArrayList(MediaType.valueOf("text/html")),
         resolver.convert(TypeLiteral.get(Types.listOf(MediaType.class)),
             data("text/html")));
+  }
+
+  @Test
+  public void shouldConvertToListOfInteger() throws Throwable {
+    ParserExecutor resolver = newParser();
+    assertEquals(Lists.newArrayList(1,2,3),
+            resolver.convert(TypeLiteral.get(Types.listOf(Integer.class)),
+                    data("1,2", "3")));
+  }
+
+  @Test
+  public void shouldConvertToListOfString() throws Throwable {
+    ParserExecutor resolver = newParser();
+    assertEquals(Lists.newArrayList("foo", "foo,bar"),
+            resolver.convert(TypeLiteral.get(Types.listOf(String.class)),
+                    data("foo", "foo,bar")));
   }
 
   private ParserExecutor newParser() {


### PR DESCRIPTION
Currently, in order to pass a list of Integers for a parameter pet_ids, one has to repeat the parameter name for each value in the request (eg: pet_ids=1&pet_ids=2&pet_ids=3&pet_ids=4).  With this change, it would be possible to specify the parameter name once with multiple comma-separated values (eg. pet_ids=1,2,3,4)