### PR TITLE
MVC should support WebSockets fix #548

### DIFF
--- a/coverage-report/src/test/java/org/jooby/issues/Issue548.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue548.java
@@ -1,0 +1,92 @@
+package org.jooby.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jooby.test.ServerFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ws.WebSocket;
+import com.ning.http.client.ws.WebSocketTextListener;
+import com.ning.http.client.ws.WebSocketUpgradeHandler;
+
+public class Issue548 extends ServerFeature {
+
+  public static class MySocket implements org.jooby.WebSocket.OnMessage<String> {
+
+    private org.jooby.WebSocket ws;
+
+    @Inject
+    public MySocket(final org.jooby.WebSocket ws) {
+      this.ws = ws;
+    }
+
+    @Override
+    public void onMessage(final String message) throws Exception {
+      ws.send("=" + message);
+    }
+
+  }
+
+  {
+    ws("/548/mvcws", MySocket.class);
+  }
+
+  private AsyncHttpClient client;
+
+  @Before
+  public void before() {
+    client = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().build());
+  }
+
+  @After
+  public void after() {
+    client.close();
+  }
+
+  @Test
+  public void sendText() throws Exception {
+    LinkedList<String> messages = new LinkedList<>();
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    client.prepareGet(ws("548/mvcws").toString())
+        .execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(
+            new WebSocketTextListener() {
+
+              @Override
+              public void onMessage(final String message) {
+                messages.add(message);
+                latch.countDown();
+              }
+
+              @Override
+              public void onOpen(final WebSocket websocket) {
+                websocket.sendMessage("mvc");
+              }
+
+              @Override
+              public void onClose(final WebSocket websocket) {
+              }
+
+              @Override
+              public void onError(final Throwable t) {
+              }
+            }).build())
+        .get();
+    if (latch.await(1L, TimeUnit.SECONDS)) {
+      assertEquals(Arrays.asList("=mvc"), messages);
+    }
+  }
+
+}

--- a/coverage-report/src/test/java/org/jooby/issues/Issue548b.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue548b.java
@@ -1,0 +1,111 @@
+package org.jooby.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jooby.json.Jackson;
+import org.jooby.mvc.Consumes;
+import org.jooby.mvc.Path;
+import org.jooby.mvc.Produces;
+import org.jooby.test.ServerFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ws.WebSocket;
+import com.ning.http.client.ws.WebSocketTextListener;
+import com.ning.http.client.ws.WebSocketUpgradeHandler;
+
+public class Issue548b extends ServerFeature {
+
+  public static class User {
+    public String name;
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  @Path("/548d/more-annotations")
+  @Produces("json")
+  @Consumes("json")
+  public static class MySocket implements org.jooby.WebSocket.OnMessage<User> {
+
+    private org.jooby.WebSocket ws;
+
+    @Inject
+    public MySocket(final org.jooby.WebSocket ws) {
+      this.ws = ws;
+    }
+
+    @Override
+    public void onMessage(final User message) throws Exception {
+      User rsp = new User();
+      rsp.name = message.name + " marmol";
+      ws.send(rsp);
+    }
+
+  }
+
+  {
+    use(new Jackson());
+
+    ws(MySocket.class);
+  }
+
+  private AsyncHttpClient client;
+
+  @Before
+  public void before() {
+    client = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().build());
+  }
+
+  @After
+  public void after() {
+    client.close();
+  }
+
+  @Test
+  public void shouldParseAndRenderJsonViaAnnotationsOnTopLevelClass() throws Exception {
+    LinkedList<String> messages = new LinkedList<>();
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    client.prepareGet(ws("548d/more-annotations").toString())
+        .execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(
+            new WebSocketTextListener() {
+
+              @Override
+              public void onMessage(final String message) {
+                messages.add(message);
+                latch.countDown();
+              }
+
+              @Override
+              public void onOpen(final WebSocket websocket) {
+                websocket.sendMessage("{\"name\":\"pablo\"}");
+              }
+
+              @Override
+              public void onClose(final WebSocket websocket) {
+              }
+
+              @Override
+              public void onError(final Throwable t) {
+              }
+            }).build())
+        .get();
+    if (latch.await(1L, TimeUnit.SECONDS)) {
+      assertEquals("{\"name\":\"pablo marmol\"}", messages.get(0));
+    }
+  }
+
+}

--- a/coverage-report/src/test/java/org/jooby/issues/Issue548c.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue548c.java
@@ -1,0 +1,94 @@
+package org.jooby.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jooby.mvc.Path;
+import org.jooby.test.ServerFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ws.WebSocket;
+import com.ning.http.client.ws.WebSocketTextListener;
+import com.ning.http.client.ws.WebSocketUpgradeHandler;
+
+public class Issue548c extends ServerFeature {
+
+  @Path("/548c/annotated-path")
+  public static class MySocket implements org.jooby.WebSocket.OnMessage<String> {
+
+    private org.jooby.WebSocket ws;
+
+    @Inject
+    public MySocket(final org.jooby.WebSocket ws) {
+      this.ws = ws;
+    }
+
+    @Override
+    public void onMessage(final String message) throws Exception {
+      ws.send("=" + message);
+    }
+
+  }
+
+  {
+    ws(MySocket.class);
+  }
+
+  private AsyncHttpClient client;
+
+  @Before
+  public void before() {
+    client = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().build());
+  }
+
+  @After
+  public void after() {
+    client.close();
+  }
+
+  @Test
+  public void sendText() throws Exception {
+    LinkedList<String> messages = new LinkedList<>();
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    client.prepareGet(ws("548c/annotated-path").toString())
+        .execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(
+            new WebSocketTextListener() {
+
+              @Override
+              public void onMessage(final String message) {
+                messages.add(message);
+                latch.countDown();
+              }
+
+              @Override
+              public void onOpen(final WebSocket websocket) {
+                websocket.sendMessage("mvc");
+              }
+
+              @Override
+              public void onClose(final WebSocket websocket) {
+              }
+
+              @Override
+              public void onError(final Throwable t) {
+              }
+            }).build())
+        .get();
+    if (latch.await(1L, TimeUnit.SECONDS)) {
+      assertEquals(Arrays.asList("=mvc"), messages);
+    }
+  }
+
+}

--- a/coverage-report/src/test/java/org/jooby/issues/Issue548d.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue548d.java
@@ -1,0 +1,105 @@
+package org.jooby.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jooby.json.Jackson;
+import org.jooby.test.ServerFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.ws.WebSocket;
+import com.ning.http.client.ws.WebSocketTextListener;
+import com.ning.http.client.ws.WebSocketUpgradeHandler;
+
+public class Issue548d extends ServerFeature {
+
+  public static class User {
+    public String name;
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  public static class MySocket implements org.jooby.WebSocket.OnMessage<User> {
+
+    private org.jooby.WebSocket ws;
+
+    @Inject
+    public MySocket(final org.jooby.WebSocket ws) {
+      this.ws = ws;
+    }
+
+    @Override
+    public void onMessage(final User message) throws Exception {
+      ws.send("=" + message);
+    }
+
+  }
+
+  {
+    use(new Jackson());
+
+    ws("/548b/mvcws", MySocket.class)
+        .consumes("json");
+  }
+
+  private AsyncHttpClient client;
+
+  @Before
+  public void before() {
+    client = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().build());
+  }
+
+  @After
+  public void after() {
+    client.close();
+  }
+
+  @Test
+  public void sendJsonMessage() throws Exception {
+    LinkedList<String> messages = new LinkedList<>();
+
+    CountDownLatch latch = new CountDownLatch(1);
+
+    client.prepareGet(ws("548b/mvcws").toString())
+        .execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(
+            new WebSocketTextListener() {
+
+              @Override
+              public void onMessage(final String message) {
+                messages.add(message);
+                latch.countDown();
+              }
+
+              @Override
+              public void onOpen(final WebSocket websocket) {
+                websocket.sendMessage("{\"name\":\"pablo marmol\"}");
+              }
+
+              @Override
+              public void onClose(final WebSocket websocket) {
+              }
+
+              @Override
+              public void onError(final Throwable t) {
+              }
+            }).build())
+        .get();
+    if (latch.await(1L, TimeUnit.SECONDS)) {
+      assertEquals(Arrays.asList("=pablo marmol"), messages);
+    }
+  }
+
+}

--- a/jooby-crash/src/main/java/org/jooby/crash/WebShellHandler.java
+++ b/jooby-crash/src/main/java/org/jooby/crash/WebShellHandler.java
@@ -40,14 +40,14 @@ import com.google.common.collect.ImmutableMap;
 
 import javaslang.control.Try;
 
-class WebShellHandler implements WebSocket.FullHandler {
+class WebShellHandler implements WebSocket.OnOpen {
 
   /** The logging system. */
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   @SuppressWarnings("rawtypes")
   @Override
-  public void connect(final Request req, final WebSocket ws) throws Exception {
+  public void onOpen(final Request req, final WebSocket ws) throws Exception {
     PluginContext ctx = req.require(PluginContext.class);
     ShellFactory factory = ctx.getPlugin(ShellFactory.class);
     Shell shell = factory.create(null);

--- a/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyWebSocket.java
+++ b/jooby-jetty/src/main/java/org/jooby/internal/jetty/JettyWebSocket.java
@@ -34,7 +34,7 @@ import org.eclipse.jetty.websocket.api.SuspendToken;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.jooby.WebSocket;
-import org.jooby.WebSocket.ErrCallback;
+import org.jooby.WebSocket.OnError;
 import org.jooby.WebSocket.SuccessCallback;
 import org.jooby.spi.NativeWebSocket;
 import org.slf4j.Logger;
@@ -115,7 +115,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendBytes(final ByteBuffer data, final SuccessCallback success,
-      final ErrCallback err) {
+      final OnError err) {
     requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
@@ -123,13 +123,13 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
   }
 
   @Override
-  public void sendBytes(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendBytes(final byte[] data, final SuccessCallback success, final OnError err) {
     requireNonNull(data, NO_DATA_TO_SEND);
     sendBytes(ByteBuffer.wrap(data), success, err);
   }
 
   @Override
-  public void sendText(final String data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final String data, final SuccessCallback success, final OnError err) {
     requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
@@ -137,7 +137,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
   }
 
   @Override
-  public void sendText(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final byte[] data, final SuccessCallback success, final OnError err) {
     requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
@@ -146,7 +146,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
   @Override
   public void sendText(final ByteBuffer data, final SuccessCallback success,
-      final ErrCallback err) {
+      final OnError err) {
     requireNonNull(data, NO_DATA_TO_SEND);
 
     RemoteEndpoint remote = session.getRemote();
@@ -187,7 +187,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
   }
 
   static WriteCallback callback(final Logger log, final SuccessCallback success,
-      final ErrCallback err) {
+      final OnError err) {
     requireNonNull(success, "Success callback is required.");
     requireNonNull(err, "Error callback is required.");
 
@@ -200,7 +200,7 @@ public class JettyWebSocket implements NativeWebSocket, WebSocketListener {
 
       @Override
       public void writeFailed(final Throwable cause) {
-        Try.run(() -> err.invoke(cause))
+        Try.run(() -> err.onError(cause))
             .onFailure(ex -> log.error("Error while invoking err callback", ex));
       }
     };

--- a/jooby-jetty/src/test/java/org/jooby/internal/jetty/JettyWebSocketTest.java
+++ b/jooby-jetty/src/test/java/org/jooby/internal/jetty/JettyWebSocketTest.java
@@ -9,7 +9,7 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.SuspendToken;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.jooby.WebSocket;
-import org.jooby.WebSocket.ErrCallback;
+import org.jooby.WebSocket.OnError;
 import org.jooby.WebSocket.SuccessCallback;
 import org.jooby.test.MockUnit;
 import org.junit.Test;
@@ -76,14 +76,14 @@ public class JettyWebSocketTest {
   @Test
   public void successCallback() throws Exception {
     new MockUnit(Consumer.class, Logger.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class)
+        WebSocket.OnError.class)
             .expect(unit -> {
               SuccessCallback callback = unit.get(WebSocket.SuccessCallback.class);
               callback.invoke();
             })
             .run(unit -> {
               WriteCallback callback = JettyWebSocket.callback(unit.get(Logger.class),
-                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.OnError.class));
               callback.writeSuccess();
             });
   }
@@ -92,7 +92,7 @@ public class JettyWebSocketTest {
   public void successCallbackErr() throws Exception {
     IllegalStateException cause = new IllegalStateException("intentional err");
     new MockUnit(Consumer.class, Logger.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class)
+        WebSocket.OnError.class)
             .expect(unit -> {
               SuccessCallback callback = unit.get(WebSocket.SuccessCallback.class);
               callback.invoke();
@@ -103,7 +103,7 @@ public class JettyWebSocketTest {
             })
             .run(unit -> {
               WriteCallback callback = JettyWebSocket.callback(unit.get(Logger.class),
-                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.OnError.class));
               callback.writeSuccess();
             });
   }
@@ -112,14 +112,14 @@ public class JettyWebSocketTest {
   public void errCallback() throws Exception {
     IllegalStateException cause = new IllegalStateException("intentional err");
     new MockUnit(Consumer.class, Logger.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class)
+        WebSocket.OnError.class)
             .expect(unit -> {
-              ErrCallback callback = unit.get(WebSocket.ErrCallback.class);
-              callback.invoke(cause);
+              OnError callback = unit.get(WebSocket.OnError.class);
+              callback.onError(cause);
             })
             .run(unit -> {
               WriteCallback callback = JettyWebSocket.callback(unit.get(Logger.class),
-                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.OnError.class));
               callback.writeFailed(cause);
             });
   }
@@ -128,10 +128,10 @@ public class JettyWebSocketTest {
   public void errCallbackFailure() throws Exception {
     IllegalStateException cause = new IllegalStateException("intentional err");
     new MockUnit(Consumer.class, Logger.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class)
+        WebSocket.OnError.class)
             .expect(unit -> {
-              ErrCallback callback = unit.get(WebSocket.ErrCallback.class);
-              callback.invoke(cause);
+              OnError callback = unit.get(WebSocket.OnError.class);
+              callback.onError(cause);
               expectLastCall().andThrow(cause);
 
               Logger logger = unit.get(Logger.class);
@@ -139,7 +139,7 @@ public class JettyWebSocketTest {
             })
             .run(unit -> {
               WriteCallback callback = JettyWebSocket.callback(unit.get(Logger.class),
-                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.SuccessCallback.class), unit.get(WebSocket.OnError.class));
               callback.writeFailed(cause);
             });
   }

--- a/jooby-netty/src/main/java/org/jooby/internal/netty/NettyWebSocket.java
+++ b/jooby-netty/src/main/java/org/jooby/internal/netty/NettyWebSocket.java
@@ -29,7 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.jooby.WebSocket;
-import org.jooby.WebSocket.ErrCallback;
+import org.jooby.WebSocket.OnError;
 import org.jooby.WebSocket.SuccessCallback;
 import org.jooby.spi.NativeWebSocket;
 import org.slf4j.Logger;
@@ -139,30 +139,30 @@ public class NettyWebSocket implements NativeWebSocket {
   }
 
   @Override
-  public void sendBytes(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
+  public void sendBytes(final ByteBuffer data, final SuccessCallback success, final OnError err) {
     sendBytes(Unpooled.wrappedBuffer(data), success, err);
   }
 
   @Override
-  public void sendBytes(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendBytes(final byte[] data, final SuccessCallback success, final OnError err) {
     sendBytes(Unpooled.wrappedBuffer(data), success, err);
   }
 
   @Override
-  public void sendText(final String data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final String data, final SuccessCallback success, final OnError err) {
     ctx.channel().writeAndFlush(new TextWebSocketFrame(data))
         .addListener(listener(success, err));
   }
 
   @Override
-  public void sendText(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final ByteBuffer data, final SuccessCallback success, final OnError err) {
     ByteBuf buffer = Unpooled.wrappedBuffer(data);
     ctx.channel().writeAndFlush(new TextWebSocketFrame(buffer))
         .addListener(listener(success, err));
   }
 
   @Override
-  public void sendText(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final byte[] data, final SuccessCallback success, final OnError err) {
     ByteBuf buffer = Unpooled.wrappedBuffer(data);
     ctx.channel().writeAndFlush(new TextWebSocketFrame(buffer))
         .addListener(listener(success, err));
@@ -211,18 +211,18 @@ public class NettyWebSocket implements NativeWebSocket {
     }
   }
 
-  private void sendBytes(final ByteBuf buffer, final SuccessCallback success, final ErrCallback err) {
+  private void sendBytes(final ByteBuf buffer, final SuccessCallback success, final OnError err) {
     ctx.channel().writeAndFlush(new BinaryWebSocketFrame(buffer))
         .addListener(listener(success, err));
   }
 
   private GenericFutureListener<? extends Future<? super Void>> listener(
-      final SuccessCallback success, final ErrCallback err) {
+      final SuccessCallback success, final OnError err) {
     return f -> {
       if (f.isSuccess()) {
         success.invoke();
       } else {
-        err.invoke(f.cause());
+        err.onError(f.cause());
       }
     };
   }

--- a/jooby-netty/src/test/java/org/jooby/internal/netty/NettyWebSocketTest.java
+++ b/jooby-netty/src/test/java/org/jooby/internal/netty/NettyWebSocketTest.java
@@ -222,7 +222,7 @@ public class NettyWebSocketTest {
   public void sendBytes() throws Exception {
     ByteBuffer buffer = ByteBuffer.wrap(new byte[]{'a', 'b', 'c' });
     new MockUnit(ChannelHandlerContext.class, WebSocketServerHandshaker.class, Consumer.class,
-        WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class, Future.class)
+        WebSocket.SuccessCallback.class, WebSocket.OnError.class, Future.class)
             .expect(unit -> {
               ByteBuf byteBuf = unit.mock(ByteBuf.class);
 
@@ -254,7 +254,7 @@ public class NettyWebSocketTest {
                       unit.get(WebSocketServerHandshaker.class),
                       unit.get(Consumer.class));
                   ws.sendBytes(buffer, unit.get(WebSocket.SuccessCallback.class),
-                      unit.get(WebSocket.ErrCallback.class));
+                      unit.get(WebSocket.OnError.class));
                 },
                 unit -> {
                   GenericFutureListener listener = unit.captured(GenericFutureListener.class)
@@ -268,7 +268,7 @@ public class NettyWebSocketTest {
   public void sendString() throws Exception {
     String data = "abc";
     new MockUnit(ChannelHandlerContext.class, WebSocketServerHandshaker.class, Consumer.class,
-        WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class, Future.class)
+        WebSocket.SuccessCallback.class, WebSocket.OnError.class, Future.class)
             .expect(unit -> {
 
               ChannelFuture future = unit.mock(ChannelFuture.class);
@@ -296,7 +296,7 @@ public class NettyWebSocketTest {
                       unit.get(WebSocketServerHandshaker.class),
                       unit.get(Consumer.class));
                   ws.sendText(data, unit.get(WebSocket.SuccessCallback.class),
-                      unit.get(WebSocket.ErrCallback.class));
+                      unit.get(WebSocket.OnError.class));
                 },
                 unit -> {
                   GenericFutureListener listener = unit.captured(GenericFutureListener.class)
@@ -310,7 +310,7 @@ public class NettyWebSocketTest {
   public void sendBytesFailure() throws Exception {
     ByteBuffer buffer = ByteBuffer.wrap(new byte[]{'a', 'b', 'c' });
     new MockUnit(ChannelHandlerContext.class, WebSocketServerHandshaker.class, Consumer.class,
-        WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class, Future.class)
+        WebSocket.SuccessCallback.class, WebSocket.OnError.class, Future.class)
             .expect(unit -> {
               ByteBuf byteBuf = unit.mock(ByteBuf.class);
 
@@ -334,8 +334,8 @@ public class NettyWebSocketTest {
               Future future = unit.get(Future.class);
               expect(future.isSuccess()).andReturn(false);
               expect(future.cause()).andReturn(cause);
-              WebSocket.ErrCallback err = unit.get(WebSocket.ErrCallback.class);
-              err.invoke(cause);
+              WebSocket.OnError err = unit.get(WebSocket.OnError.class);
+              err.onError(cause);
             })
             .run(
                 unit -> {
@@ -344,7 +344,7 @@ public class NettyWebSocketTest {
                       unit.get(WebSocketServerHandshaker.class),
                       unit.get(Consumer.class));
                   ws.sendBytes(buffer, unit.get(WebSocket.SuccessCallback.class),
-                      unit.get(WebSocket.ErrCallback.class));
+                      unit.get(WebSocket.OnError.class));
                 },
                 unit -> {
                   GenericFutureListener listener = unit.captured(GenericFutureListener.class)
@@ -358,7 +358,7 @@ public class NettyWebSocketTest {
   public void sendStringFailure() throws Exception {
     String data = "abc";
     new MockUnit(ChannelHandlerContext.class, WebSocketServerHandshaker.class, Consumer.class,
-        WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class, Future.class)
+        WebSocket.SuccessCallback.class, WebSocket.OnError.class, Future.class)
             .expect(unit -> {
 
               ChannelFuture future = unit.mock(ChannelFuture.class);
@@ -378,8 +378,8 @@ public class NettyWebSocketTest {
               Future future = unit.get(Future.class);
               expect(future.isSuccess()).andReturn(false);
               expect(future.cause()).andReturn(cause);
-              WebSocket.ErrCallback err = unit.get(WebSocket.ErrCallback.class);
-              err.invoke(cause);
+              WebSocket.OnError err = unit.get(WebSocket.OnError.class);
+              err.onError(cause);
             })
             .run(
                 unit -> {
@@ -388,7 +388,7 @@ public class NettyWebSocketTest {
                       unit.get(WebSocketServerHandshaker.class),
                       unit.get(Consumer.class));
                   ws.sendText(data, unit.get(WebSocket.SuccessCallback.class),
-                      unit.get(WebSocket.ErrCallback.class));
+                      unit.get(WebSocket.OnError.class));
                 },
                 unit -> {
                   GenericFutureListener listener = unit.captured(GenericFutureListener.class)

--- a/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowWebSocket.java
+++ b/jooby-undertow/src/main/java/org/jooby/internal/undertow/UndertowWebSocket.java
@@ -50,7 +50,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.jooby.WebSocket;
-import org.jooby.WebSocket.ErrCallback;
+import org.jooby.WebSocket.OnError;
 import org.jooby.WebSocket.SuccessCallback;
 import org.jooby.spi.NativeWebSocket;
 import org.slf4j.Logger;
@@ -204,32 +204,32 @@ public class UndertowWebSocket extends AbstractReceiveListener implements Native
   }
 
   @Override
-  public void sendBytes(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
+  public void sendBytes(final ByteBuffer data, final SuccessCallback success, final OnError err) {
     WebSockets.sendBinary(data, channel, callback(log, success, err));
   }
 
   @Override
-  public void sendBytes(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendBytes(final byte[] data, final SuccessCallback success, final OnError err) {
     WebSockets.sendBinary(ByteBuffer.wrap(data), channel, callback(log, success, err));
   }
 
   @Override
-  public void sendText(final String data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final String data, final SuccessCallback success, final OnError err) {
     WebSockets.sendText(data, channel, callback(log, success, err));
   }
 
   @Override
-  public void sendText(final ByteBuffer data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final ByteBuffer data, final SuccessCallback success, final OnError err) {
     WebSockets.sendText(data, channel, callback(log, success, err));
   }
 
   @Override
-  public void sendText(final byte[] data, final SuccessCallback success, final ErrCallback err) {
+  public void sendText(final byte[] data, final SuccessCallback success, final OnError err) {
     WebSockets.sendText(ByteBuffer.wrap(data), channel, callback(log, success, err));
   }
 
   private static WebSocketCallback<Void> callback(final Logger log, final SuccessCallback success,
-      final ErrCallback err) {
+      final OnError err) {
     return new WebSocketCallback<Void>() {
       @Override
       public void complete(final WebSocketChannel channel, final Void context) {
@@ -242,7 +242,7 @@ public class UndertowWebSocket extends AbstractReceiveListener implements Native
 
       @Override
       public void onError(final WebSocketChannel channel, final Void context, final Throwable cause) {
-        err.invoke(cause);
+        err.onError(cause);
       }
     };
   }

--- a/jooby-undertow/src/test/java/org/jooby/internal/undertow/UndertowWebSocketTest.java
+++ b/jooby-undertow/src/test/java/org/jooby/internal/undertow/UndertowWebSocketTest.java
@@ -452,7 +452,7 @@ public class UndertowWebSocketTest {
   @Test
   public void sendText() throws Exception {
     new MockUnit(Config.class, WebSocketChannel.class, CloseMessage.class, Consumer.class,
-        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class)
+        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.OnError.class)
         .expect(config)
         .expect(connect)
         .expect(unit -> {
@@ -468,7 +468,7 @@ public class UndertowWebSocketTest {
           ws.onConnect(unit.get(Runnable.class));
           ws.connect(unit.get(WebSocketChannel.class));
           ws.sendText("data", unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
         }, unit -> {
           WebSocketCallback<Void> callback = unit.captured(WebSocketCallback.class).iterator()
               .next();
@@ -480,7 +480,7 @@ public class UndertowWebSocketTest {
   @Test
   public void sendTextCallbackErr() throws Exception {
     new MockUnit(Config.class, WebSocketChannel.class, CloseMessage.class, Consumer.class,
-        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class)
+        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.OnError.class)
         .expect(config)
         .expect(connect)
         .expect(unit -> {
@@ -497,7 +497,7 @@ public class UndertowWebSocketTest {
           ws.onConnect(unit.get(Runnable.class));
           ws.connect(unit.get(WebSocketChannel.class));
           ws.sendText("data", unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
         }, unit -> {
           WebSocketCallback<Void> callback = unit.captured(WebSocketCallback.class).iterator()
               .next();
@@ -510,7 +510,7 @@ public class UndertowWebSocketTest {
   public void sendBytes() throws Exception {
     ByteBuffer data = ByteBuffer.wrap(new byte[0]);
     new MockUnit(Config.class, WebSocketChannel.class, CloseMessage.class, Consumer.class,
-        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class)
+        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.OnError.class)
         .expect(config)
         .expect(connect)
         .expect(unit -> {
@@ -526,7 +526,7 @@ public class UndertowWebSocketTest {
           ws.onConnect(unit.get(Runnable.class));
           ws.connect(unit.get(WebSocketChannel.class));
           ws.sendBytes(data, unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
         }, unit -> {
           WebSocketCallback<Void> callback = unit.captured(WebSocketCallback.class).iterator()
               .next();
@@ -539,7 +539,7 @@ public class UndertowWebSocketTest {
   public void sendTextErrCallback() throws Exception {
     Throwable cause = new IllegalStateException("intentional err");
     new MockUnit(Config.class, WebSocketChannel.class, CloseMessage.class, Consumer.class,
-        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.ErrCallback.class)
+        Runnable.class, WebSocket.SuccessCallback.class, WebSocket.OnError.class)
         .expect(config)
         .expect(connect)
         .expect(unit -> {
@@ -548,14 +548,14 @@ public class UndertowWebSocketTest {
               unit.capture(WebSocketCallback.class));
         })
         .expect(unit -> {
-          unit.get(WebSocket.ErrCallback.class).invoke(cause);
+          unit.get(WebSocket.OnError.class).onError(cause);
         })
         .run(unit -> {
           UndertowWebSocket ws = new UndertowWebSocket(unit.get(Config.class));
           ws.onConnect(unit.get(Runnable.class));
           ws.connect(unit.get(WebSocketChannel.class));
           ws.sendText("data", unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
         }, unit -> {
           WebSocketCallback<Void> callback = unit.captured(WebSocketCallback.class).iterator()
               .next();

--- a/jooby/src/main/java/org/jooby/Router.java
+++ b/jooby/src/main/java/org/jooby/Router.java
@@ -2280,8 +2280,8 @@ public interface Router {
    * @param handler A connect callback.
    * @return A new WebSocket definition.
    */
-  default WebSocket.Definition ws(final String path, final WebSocket.Handler handler) {
-    return ws(path, (WebSocket.FullHandler) handler);
+  default WebSocket.Definition ws(final String path, final WebSocket.OnOpen1 handler) {
+    return ws(path, (WebSocket.OnOpen) handler);
   }
 
   /**
@@ -2301,7 +2301,13 @@ public interface Router {
    * @param handler A connect callback.
    * @return A new WebSocket definition.
    */
-  WebSocket.Definition ws(String path, WebSocket.FullHandler handler);
+  WebSocket.Definition ws(String path, WebSocket.OnOpen handler);
+
+  default <T> WebSocket.Definition ws(final Class<? extends WebSocket.OnMessage<T>> handler) {
+    return ws("", handler);
+  }
+
+  <T> WebSocket.Definition ws(String path, Class<? extends WebSocket.OnMessage<T>> handler);
 
   /**
    * Add a server-sent event handler.

--- a/jooby/src/main/java/org/jooby/internal/WebSocketRendererContext.java
+++ b/jooby/src/main/java/org/jooby/internal/WebSocketRendererContext.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 
 import org.jooby.MediaType;
 import org.jooby.Renderer;
-import org.jooby.WebSocket.ErrCallback;
+import org.jooby.WebSocket.OnError;
 import org.jooby.WebSocket.SuccessCallback;
 import org.jooby.spi.NativeWebSocket;
 
@@ -40,13 +40,13 @@ public class WebSocketRendererContext extends AbstractRendererContext {
 
   private SuccessCallback success;
 
-  private ErrCallback err;
+  private OnError err;
 
   private MediaType type;
 
   public WebSocketRendererContext(final List<Renderer> renderers, final NativeWebSocket ws,
       final MediaType type, final Charset charset, Locale locale, final SuccessCallback success,
-      final ErrCallback err) {
+      final OnError err) {
     super(renderers, ImmutableList.of(type), charset, locale, Collections.emptyMap());
     this.ws = ws;
     this.type = type;

--- a/jooby/src/main/java/org/jooby/internal/mvc/MvcWebSocket.java
+++ b/jooby/src/main/java/org/jooby/internal/mvc/MvcWebSocket.java
@@ -1,0 +1,90 @@
+package org.jooby.internal.mvc;
+
+import static javaslang.Predicates.instanceOf;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import org.jooby.Mutant;
+import org.jooby.Request;
+import org.jooby.WebSocket;
+import org.jooby.WebSocket.CloseStatus;
+
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+
+@SuppressWarnings({"rawtypes", "unchecked" })
+public class MvcWebSocket implements WebSocket.Handler<Mutant> {
+
+  private Object handler;
+
+  private TypeLiteral messageType;
+
+  MvcWebSocket(final WebSocket ws, final Class handler) {
+    Injector injector = ws.require(Injector.class)
+        .createChildInjector(binder -> binder.bind(WebSocket.class).toInstance(ws));
+    this.handler = injector.getInstance(handler);
+    this.messageType = TypeLiteral.get(messageType(handler));
+  }
+
+  public static WebSocket.OnOpen newWebSocket(final Class handler) {
+    return (req, ws) -> {
+      MvcWebSocket socket = new MvcWebSocket(ws, handler);
+      socket.onOpen(req, ws);
+      if (socket.isClose()) {
+        ws.onClose(socket::onClose);
+      }
+      if (socket.isError()) {
+        ws.onError(socket::onError);
+      }
+      ws.onMessage(socket::onMessage);
+    };
+  }
+
+  @Override
+  public void onClose(final CloseStatus status) throws Exception {
+    if (isClose()) {
+      ((WebSocket.OnClose) handler).onClose(status);
+    }
+  }
+
+  @Override
+  public void onMessage(final Mutant data) throws Exception {
+    ((WebSocket.OnMessage) handler).onMessage(data.to(messageType));
+  }
+
+  @Override
+  public void onError(final Throwable err) {
+    if (isError()) {
+      ((WebSocket.OnError) handler).onError(err);
+    }
+  }
+
+  @Override
+  public void onOpen(final Request req, final WebSocket ws) throws Exception {
+    if (handler instanceof WebSocket.OnOpen) {
+      ((WebSocket.OnOpen) handler).onOpen(req, ws);
+    }
+  }
+
+  private boolean isClose() {
+    return handler instanceof WebSocket.OnClose;
+  }
+
+  private boolean isError() {
+    return handler instanceof WebSocket.OnError;
+  }
+
+  static Type messageType(final Class handler) {
+    return Arrays.asList(handler.getGenericInterfaces())
+        .stream()
+        .filter(it -> TypeLiteral.get(it).getRawType().isAssignableFrom(WebSocket.OnMessage.class))
+        .findFirst()
+        .filter(instanceOf(ParameterizedType.class))
+        .map(it -> ((ParameterizedType) it).getActualTypeArguments()[0])
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Can't extract message type from: " + handler.getName()));
+  }
+
+}

--- a/jooby/src/main/java/org/jooby/spi/NativeWebSocket.java
+++ b/jooby/src/main/java/org/jooby/spi/NativeWebSocket.java
@@ -102,7 +102,7 @@ public interface NativeWebSocket {
    * @param success Success callback.
    * @param err Error callback.
    */
-  void sendBytes(ByteBuffer data, WebSocket.SuccessCallback success, WebSocket.ErrCallback err);
+  void sendBytes(ByteBuffer data, WebSocket.SuccessCallback success, WebSocket.OnError err);
 
   /**
    * Send a binary message to the client.
@@ -111,7 +111,7 @@ public interface NativeWebSocket {
    * @param success Success callback.
    * @param err Error callback.
    */
-  void sendBytes(byte[] data, WebSocket.SuccessCallback success, WebSocket.ErrCallback err);
+  void sendBytes(byte[] data, WebSocket.SuccessCallback success, WebSocket.OnError err);
 
   /**
    * Send a text message to the client.
@@ -120,7 +120,7 @@ public interface NativeWebSocket {
    * @param success Success callback.
    * @param err Error callback.
    */
-  void sendText(String data, WebSocket.SuccessCallback success, WebSocket.ErrCallback err);
+  void sendText(String data, WebSocket.SuccessCallback success, WebSocket.OnError err);
 
   /**
    * Send a text message to the client.
@@ -129,7 +129,7 @@ public interface NativeWebSocket {
    * @param success Success callback.
    * @param err Error callback.
    */
-  void sendText(ByteBuffer data, WebSocket.SuccessCallback success, WebSocket.ErrCallback err);
+  void sendText(ByteBuffer data, WebSocket.SuccessCallback success, WebSocket.OnError err);
 
   /**
    * Send a text message to the client.
@@ -138,7 +138,7 @@ public interface NativeWebSocket {
    * @param success Success callback.
    * @param err Error callback.
    */
-  void sendText(byte[] data, WebSocket.SuccessCallback success, WebSocket.ErrCallback err);
+  void sendText(byte[] data, WebSocket.SuccessCallback success, WebSocket.OnError err);
 
   /**
    * @return True if the websocket connection is open.

--- a/jooby/src/test/java/org/jooby/WebSocketTest.java
+++ b/jooby/src/test/java/org/jooby/WebSocketTest.java
@@ -51,13 +51,13 @@ public class WebSocketTest {
     }
 
     @Override
-    public void send(final Object data, final SuccessCallback success, final ErrCallback err)
+    public void send(final Object data, final SuccessCallback success, final OnError err)
         throws Exception {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void onMessage(final Callback<Mutant> callback) throws Exception {
+    public void onMessage(final OnMessage<Mutant> callback) throws Exception {
       throw new UnsupportedOperationException();
     }
 
@@ -97,12 +97,12 @@ public class WebSocketTest {
     }
 
     @Override
-    public void onError(final ErrCallback callback) {
+    public void onError(final OnError callback) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void onClose(final Callback<CloseStatus> callback) throws Exception {
+    public void onClose(final OnClose callback) throws Exception {
       throw new UnsupportedOperationException();
     }
 
@@ -125,7 +125,7 @@ public class WebSocketTest {
           expect(LoggerFactory.getLogger(WebSocket.class)).andReturn(log);
         })
         .run(unit -> {
-          WebSocket.ERR.invoke(ex);
+          WebSocket.ERR.onError(ex);
         });
   }
 
@@ -244,11 +244,12 @@ public class WebSocketTest {
   public void send() throws Exception {
     Object data = new Object();
     WebSocket.SuccessCallback SUCCESS_ = WebSocket.SUCCESS;
-    WebSocket.ErrCallback ERR_ = WebSocket.ERR;
+    WebSocket.OnError ERR_ = WebSocket.ERR;
     LinkedList<Object> dataList = new LinkedList<>();
     WebSocket ws = new WebSocketMock() {
       @Override
-      public void send(final Object data, final SuccessCallback success, final ErrCallback err) throws Exception {
+      public void send(final Object data, final SuccessCallback success, final OnError err)
+          throws Exception {
         dataList.add(data);
         assertEquals(SUCCESS_, success);
         assertEquals(ERR_, err);
@@ -263,12 +264,14 @@ public class WebSocketTest {
   @Test
   public void sendCustomSuccess() throws Exception {
     Object data = new Object();
-    WebSocket.SuccessCallback SUCCESS_ = () -> {};
-    WebSocket.ErrCallback ERR_ = WebSocket.ERR;
+    WebSocket.SuccessCallback SUCCESS_ = () -> {
+    };
+    WebSocket.OnError ERR_ = WebSocket.ERR;
     LinkedList<Object> dataList = new LinkedList<>();
     WebSocket ws = new WebSocketMock() {
       @Override
-      public void send(final Object data, final SuccessCallback success, final ErrCallback err) throws Exception {
+      public void send(final Object data, final SuccessCallback success, final OnError err)
+          throws Exception {
         dataList.add(data);
         assertEquals(SUCCESS_, success);
         assertEquals(ERR_, err);
@@ -284,11 +287,13 @@ public class WebSocketTest {
   public void sendCustomErr() throws Exception {
     Object data = new Object();
     WebSocket.SuccessCallback SUCCESS_ = WebSocket.SUCCESS;
-    WebSocket.ErrCallback ERR_ = (ex) -> {};
+    WebSocket.OnError ERR_ = (ex) -> {
+    };
     LinkedList<Object> dataList = new LinkedList<>();
     WebSocket ws = new WebSocketMock() {
       @Override
-      public void send(final Object data, final SuccessCallback success, final ErrCallback err) throws Exception {
+      public void send(final Object data, final SuccessCallback success, final OnError err)
+          throws Exception {
         dataList.add(data);
         assertEquals(SUCCESS_, success);
         assertEquals(ERR_, err);
@@ -303,12 +308,15 @@ public class WebSocketTest {
   @Test
   public void sendCustomSuccessAndErr() throws Exception {
     Object data = new Object();
-    WebSocket.SuccessCallback SUCCESS_ = () -> {};
-    WebSocket.ErrCallback ERR_ = (ex) -> {};
+    WebSocket.SuccessCallback SUCCESS_ = () -> {
+    };
+    WebSocket.OnError ERR_ = (ex) -> {
+    };
     LinkedList<Object> dataList = new LinkedList<>();
     WebSocket ws = new WebSocketMock() {
       @Override
-      public void send(final Object data, final SuccessCallback success, final ErrCallback err) throws Exception {
+      public void send(final Object data, final SuccessCallback success, final OnError err)
+          throws Exception {
         dataList.add(data);
         assertEquals(SUCCESS_, success);
         assertEquals(ERR_, err);

--- a/jooby/src/test/java/org/jooby/internal/WebSocketImplTest.java
+++ b/jooby/src/test/java/org/jooby/internal/WebSocketImplTest.java
@@ -25,8 +25,9 @@ import org.jooby.Mutant;
 import org.jooby.Renderer;
 import org.jooby.Request;
 import org.jooby.WebSocket;
-import org.jooby.WebSocket.Callback;
 import org.jooby.WebSocket.CloseStatus;
+import org.jooby.WebSocket.OnClose;
+import org.jooby.WebSocket.OnMessage;
 import org.jooby.internal.parser.ParserExecutor;
 import org.jooby.spi.NativeWebSocket;
 import org.jooby.test.MockUnit;
@@ -45,8 +46,8 @@ import com.google.inject.TypeLiteral;
 public class WebSocketImplTest {
 
   private Block connect = unit -> {
-    WebSocket.Handler handler = unit.get(WebSocket.Handler.class);
-    handler.connect(eq(unit.get(Request.class)), isA(WebSocketImpl.class));
+    WebSocket.OnOpen1 handler = unit.get(WebSocket.OnOpen1.class);
+    handler.onOpen(eq(unit.get(Request.class)), isA(WebSocketImpl.class));
 
     Injector injector = unit.get(Injector.class);
 
@@ -78,8 +79,8 @@ public class WebSocketImplTest {
     Map<Object, String> vars = new HashMap<>();
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
-    new MockUnit(WebSocket.Handler.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, WebSocket.SuccessCallback.class,
+        WebSocket.OnError.class, Injector.class, Request.class, NativeWebSocket.class)
             .expect(connect)
             .expect(callbacks)
             .expect(locale)
@@ -93,22 +94,22 @@ public class WebSocketImplTest {
                   new Class[]{List.class, NativeWebSocket.class, MediaType.class, Charset.class,
                       Locale.class,
                       WebSocket.SuccessCallback.class,
-                      WebSocket.ErrCallback.class },
+                      WebSocket.OnError.class },
                   renderers, ws,
                   produces, StandardCharsets.UTF_8,
                   Locale.CANADA,
                   unit.get(WebSocket.SuccessCallback.class),
-                  unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.OnError.class));
               ctx.render(data);
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
 
               ws.send(data, unit.get(WebSocket.SuccessCallback.class),
-                  unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.OnError.class));
             });
   }
 
@@ -121,8 +122,8 @@ public class WebSocketImplTest {
     Map<Object, String> vars = new HashMap<>();
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
-    new MockUnit(WebSocket.Handler.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, WebSocket.SuccessCallback.class,
+        WebSocket.OnError.class, Injector.class, Request.class, NativeWebSocket.class)
             .expect(connect)
             .expect(callbacks)
             .expect(locale)
@@ -132,12 +133,12 @@ public class WebSocketImplTest {
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
 
               ws.send(data, unit.get(WebSocket.SuccessCallback.class),
-                  unit.get(WebSocket.ErrCallback.class));
+                  unit.get(WebSocket.OnError.class));
             });
   }
 
@@ -150,10 +151,10 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class)
+    new MockUnit(WebSocket.OnOpen1.class)
         .run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           assertEquals("WS /\n" +
               "  pattern: /pattern\n" +
               "  vars: {}\n" +
@@ -171,8 +172,8 @@ public class WebSocketImplTest {
     Map<Object, String> vars = new HashMap<>();
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
-    new MockUnit(WebSocket.Handler.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, WebSocket.SuccessCallback.class,
+        WebSocket.OnError.class, Injector.class, Request.class, NativeWebSocket.class)
             .expect(connect)
             .expect(callbacks)
             .expect(locale)
@@ -182,7 +183,7 @@ public class WebSocketImplTest {
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
 
@@ -199,7 +200,7 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class)
         .expect(connect)
         .expect(callbacks)
         .expect(locale)
@@ -211,7 +212,7 @@ public class WebSocketImplTest {
         })
         .run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           ws.connect(unit.get(Injector.class), unit.get(Request.class),
               unit.get(NativeWebSocket.class));
           ws.pause();
@@ -232,7 +233,7 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class)
         .expect(connect)
         .expect(callbacks)
         .expect(locale)
@@ -241,7 +242,7 @@ public class WebSocketImplTest {
           ws.close(WebSocket.NORMAL.code(), WebSocket.NORMAL.reason());
         }).run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           ws.connect(unit.get(Injector.class), unit.get(Request.class),
               unit.get(NativeWebSocket.class));
           ws.close(WebSocket.NORMAL);
@@ -257,7 +258,7 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class)
         .expect(connect)
         .expect(callbacks)
         .expect(locale)
@@ -267,7 +268,7 @@ public class WebSocketImplTest {
         })
         .run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           ws.connect(unit.get(Injector.class), unit.get(Request.class),
               unit.get(NativeWebSocket.class));
           ws.terminate();
@@ -283,10 +284,10 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class)
+    new MockUnit(WebSocket.OnOpen1.class)
         .run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           assertEquals(pattern, ws.pattern());
           assertEquals(path, ws.path());
           assertEquals(consumes, ws.consumes());
@@ -304,7 +305,7 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     Object instance = new Object();
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class)
         .expect(connect)
         .expect(locale)
         .expect(unit -> {
@@ -320,7 +321,7 @@ public class WebSocketImplTest {
         })
         .run(unit -> {
           WebSocketImpl ws = new WebSocketImpl(
-              unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+              unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
           ws.connect(unit.get(Injector.class), unit.get(Request.class),
               unit.get(NativeWebSocket.class));
           assertEquals(instance, ws.require(Object.class));
@@ -336,7 +337,7 @@ public class WebSocketImplTest {
     MediaType consumes = MediaType.all;
     MediaType produces = MediaType.all;
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Callback.class, Request.class,
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, OnMessage.class, Request.class,
         NativeWebSocket.class,
         Mutant.class)
             .expect(connect)
@@ -349,8 +350,8 @@ public class WebSocketImplTest {
               nws.onCloseMessage(isA(BiConsumer.class));
             })
             .expect(unit -> {
-              Callback<Mutant> callback = unit.get(Callback.class);
-              callback.invoke(isA(Mutant.class));
+              OnMessage<Mutant> callback = unit.get(OnMessage.class);
+              callback.onMessage(isA(Mutant.class));
             })
             .expect(unit -> {
               Injector injector = unit.get(Injector.class);
@@ -359,10 +360,10 @@ public class WebSocketImplTest {
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onMessage(unit.get(Callback.class));
+              ws.onMessage(unit.get(OnMessage.class));
             }, unit -> {
               unit.captured(Consumer.class).iterator().next().accept("something");
             });
@@ -378,8 +379,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     Exception ex = new Exception();
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class,
-        WebSocket.ErrCallback.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class,
+        WebSocket.OnError.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -392,15 +393,15 @@ public class WebSocketImplTest {
               expect(nws.isOpen()).andReturn(false);
             })
             .expect(unit -> {
-              WebSocket.ErrCallback callback = unit.get(WebSocket.ErrCallback.class);
-              callback.invoke(ex);
+              WebSocket.OnError callback = unit.get(WebSocket.OnError.class);
+              callback.onError(ex);
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onError(unit.get(WebSocket.ErrCallback.class));
+              ws.onError(unit.get(WebSocket.OnError.class));
             }, unit -> {
               unit.captured(Consumer.class).iterator().next().accept(ex);
             });
@@ -416,8 +417,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     Exception ex = new ClosedChannelException();
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class,
-        WebSocket.ErrCallback.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class,
+        WebSocket.OnError.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -431,10 +432,10 @@ public class WebSocketImplTest {
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onError(unit.get(WebSocket.ErrCallback.class));
+              ws.onError(unit.get(WebSocket.OnError.class));
             }, unit -> {
               unit.captured(Consumer.class).iterator().next().accept(ex);
             });
@@ -450,8 +451,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     Exception ex = new Exception();
 
-    new MockUnit(WebSocket.Handler.class, Injector.class, Request.class, NativeWebSocket.class,
-        WebSocket.ErrCallback.class)
+    new MockUnit(WebSocket.OnOpen1.class, Injector.class, Request.class, NativeWebSocket.class,
+        WebSocket.OnError.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -465,15 +466,15 @@ public class WebSocketImplTest {
               nws.close(1011, "Server error");
             })
             .expect(unit -> {
-              WebSocket.ErrCallback callback = unit.get(WebSocket.ErrCallback.class);
-              callback.invoke(ex);
+              WebSocket.OnError callback = unit.get(WebSocket.OnError.class);
+              callback.onError(ex);
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onError(unit.get(WebSocket.ErrCallback.class));
+              ws.onError(unit.get(WebSocket.OnError.class));
             }, unit -> {
               unit.captured(Consumer.class).iterator().next().accept(ex);
             });
@@ -489,8 +490,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     WebSocket.CloseStatus status = WebSocket.NORMAL;
 
-    new MockUnit(WebSocket.Handler.class, Callback.class, Request.class, NativeWebSocket.class,
-        Injector.class)
+    new MockUnit(WebSocket.OnOpen1.class, OnMessage.class, OnClose.class, Request.class,
+        NativeWebSocket.class, Injector.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -501,15 +502,15 @@ public class WebSocketImplTest {
               nws.onCloseMessage(unit.capture(BiConsumer.class));
             })
             .expect(unit -> {
-              Callback<WebSocket.CloseStatus> callback = unit.get(Callback.class);
-              callback.invoke(unit.capture(WebSocket.CloseStatus.class));
+              OnClose callback = unit.get(OnClose.class);
+              callback.onClose(unit.capture(WebSocket.CloseStatus.class));
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onClose(unit.get(Callback.class));
+              ws.onClose(unit.get(WebSocket.OnClose.class));
             }, unit -> {
               unit.captured(BiConsumer.class).iterator().next()
                   .accept(status.code(), Optional.of(status.reason()));
@@ -530,8 +531,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     WebSocket.CloseStatus status = WebSocket.CloseStatus.of(1000);
 
-    new MockUnit(WebSocket.Handler.class, Callback.class, NativeWebSocket.class, Request.class,
-        Injector.class)
+    new MockUnit(WebSocket.OnOpen1.class, OnMessage.class, OnClose.class, NativeWebSocket.class,
+        Request.class, Injector.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -542,15 +543,15 @@ public class WebSocketImplTest {
               nws.onCloseMessage(unit.capture(BiConsumer.class));
             })
             .expect(unit -> {
-              Callback<WebSocket.CloseStatus> callback = unit.get(Callback.class);
-              callback.invoke(unit.capture(WebSocket.CloseStatus.class));
+              OnClose callback = unit.get(OnClose.class);
+              callback.onClose(unit.capture(WebSocket.CloseStatus.class));
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onClose(unit.get(Callback.class));
+              ws.onClose(unit.get(OnClose.class));
             }, unit -> {
               unit.captured(BiConsumer.class).iterator().next()
                   .accept(status.code(), Optional.empty());
@@ -571,8 +572,8 @@ public class WebSocketImplTest {
     MediaType produces = MediaType.all;
     WebSocket.CloseStatus status = WebSocket.CloseStatus.of(1000, "");
 
-    new MockUnit(WebSocket.Handler.class, Callback.class, NativeWebSocket.class, Request.class,
-        Injector.class)
+    new MockUnit(WebSocket.OnOpen1.class, OnMessage.class, NativeWebSocket.class, Request.class,
+        Injector.class, OnClose.class)
             .expect(connect)
             .expect(locale)
             .expect(unit -> {
@@ -583,15 +584,15 @@ public class WebSocketImplTest {
               nws.onCloseMessage(unit.capture(BiConsumer.class));
             })
             .expect(unit -> {
-              Callback<WebSocket.CloseStatus> callback = unit.get(Callback.class);
-              callback.invoke(unit.capture(WebSocket.CloseStatus.class));
+              OnClose callback = unit.get(OnClose.class);
+              callback.onClose(unit.capture(WebSocket.CloseStatus.class));
             })
             .run(unit -> {
               WebSocketImpl ws = new WebSocketImpl(
-                  unit.get(WebSocket.Handler.class), path, pattern, vars, consumes, produces);
+                  unit.get(WebSocket.OnOpen1.class), path, pattern, vars, consumes, produces);
               ws.connect(unit.get(Injector.class), unit.get(Request.class),
                   unit.get(NativeWebSocket.class));
-              ws.onClose(unit.get(Callback.class));
+              ws.onClose(unit.get(OnClose.class));
             }, unit -> {
               unit.captured(BiConsumer.class).iterator().next()
                   .accept(status.code(), Optional.of(""));

--- a/jooby/src/test/java/org/jooby/internal/WebSocketRendererContextTest.java
+++ b/jooby/src/test/java/org/jooby/internal/WebSocketRendererContextTest.java
@@ -26,7 +26,7 @@ public class WebSocketRendererContextTest {
   public void fileChannel() throws Exception {
     MediaType produces = MediaType.json;
     new MockUnit(Renderer.class, NativeWebSocket.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class)
+        WebSocket.OnError.class)
         .run(unit -> {
           WebSocketRendererContext ctx = new WebSocketRendererContext(
               Lists.newArrayList(unit.get(Renderer.class)),
@@ -35,7 +35,7 @@ public class WebSocketRendererContextTest {
               StandardCharsets.UTF_8,
               Locale.US,
               unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
           ctx.send(newFileChannel());
         });
   }
@@ -44,7 +44,7 @@ public class WebSocketRendererContextTest {
   public void inputStream() throws Exception {
     MediaType produces = MediaType.json;
     new MockUnit(Renderer.class, NativeWebSocket.class, WebSocket.SuccessCallback.class,
-        WebSocket.ErrCallback.class, InputStream.class)
+        WebSocket.OnError.class, InputStream.class)
         .run(unit -> {
           WebSocketRendererContext ctx = new WebSocketRendererContext(
               Lists.newArrayList(unit.get(Renderer.class)),
@@ -53,7 +53,7 @@ public class WebSocketRendererContextTest {
               StandardCharsets.UTF_8,
               Locale.US,
               unit.get(WebSocket.SuccessCallback.class),
-              unit.get(WebSocket.ErrCallback.class));
+              unit.get(WebSocket.OnError.class));
           ctx.send(unit.get(InputStream.class));
         });
   }

--- a/jooby/src/test/java/org/jooby/internal/mvc/MvcWebSocketTest.java
+++ b/jooby/src/test/java/org/jooby/internal/mvc/MvcWebSocketTest.java
@@ -1,0 +1,270 @@
+package org.jooby.internal.mvc;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+
+import java.util.List;
+
+import org.jooby.Mutant;
+import org.jooby.Request;
+import org.jooby.WebSocket;
+import org.jooby.WebSocket.CloseStatus;
+import org.jooby.test.MockUnit;
+import org.jooby.test.MockUnit.Block;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.AnnotatedBindingBuilder;
+import com.google.inject.util.Types;
+
+public class MvcWebSocketTest {
+
+  public static class ImNotACallback {
+  }
+
+  @SuppressWarnings("rawtypes")
+  public static class CallbackWithoutType implements WebSocket.OnMessage {
+    @Override
+    public void onMessage(final Object message) throws Exception {
+    }
+  }
+
+  public static class StringSocket implements WebSocket.OnMessage<String> {
+    @Override
+    public void onMessage(final String message) throws Exception {
+    }
+  }
+
+  public static class Pojo {
+
+  }
+
+  public static class PojoSocket implements WebSocket.OnMessage<Pojo> {
+    @Override
+    public void onMessage(final Pojo message) throws Exception {
+    }
+  }
+
+  public static class PojoListSocket implements WebSocket.OnMessage<List<Pojo>> {
+    @Override
+    public void onMessage(final List<Pojo> message) throws Exception {
+    }
+  }
+
+  public static class MySocket
+      implements WebSocket.OnMessage<String>, WebSocket.OnClose, WebSocket.OnError,
+      WebSocket.OnOpen {
+
+    @Override
+    public void onMessage(final String data) throws Exception {
+    }
+
+    @Override
+    public void onOpen(final Request req, final WebSocket ws) throws Exception {
+    }
+
+    @Override
+    public void onError(final Throwable err) {
+    }
+
+    @Override
+    public void onClose(final CloseStatus status) throws Exception {
+    }
+
+  }
+
+  @Test
+  public void newInstance() throws Exception {
+    new MockUnit(WebSocket.class, Injector.class, MySocket.class, Binder.class)
+        .expect(childInjector(MySocket.class))
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), MySocket.class);
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void onClose() throws Exception {
+    new MockUnit(WebSocket.class, Injector.class, MySocket.class, Binder.class)
+        .expect(childInjector(MySocket.class))
+        .expect(unit -> {
+          unit.get(MySocket.class).onClose(WebSocket.NORMAL);
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), MySocket.class).onClose(WebSocket.NORMAL);
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void shouldIgnoreOnClose() throws Exception {
+    new MockUnit(WebSocket.class, Injector.class, StringSocket.class, Binder.class)
+        .expect(childInjector(StringSocket.class))
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), StringSocket.class).onClose(WebSocket.NORMAL);
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void onStringMessage() throws Exception {
+    new MockUnit(WebSocket.class, Injector.class, StringSocket.class, Binder.class, Mutant.class)
+        .expect(childInjector(StringSocket.class))
+        .expect(mutant(TypeLiteral.get(String.class), "string"))
+        .expect(unit -> {
+          StringSocket socket = unit.get(StringSocket.class);
+          socket.onMessage("string");
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), StringSocket.class)
+              .onMessage(unit.get(Mutant.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void onPojoMessage() throws Exception {
+    Pojo pojo = new Pojo();
+    new MockUnit(WebSocket.class, Injector.class, PojoSocket.class, Binder.class, Mutant.class)
+        .expect(childInjector(PojoSocket.class))
+        .expect(mutant(TypeLiteral.get(Pojo.class), pojo))
+        .expect(unit -> {
+          PojoSocket socket = unit.get(PojoSocket.class);
+          socket.onMessage(pojo);
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), PojoSocket.class)
+              .onMessage(unit.get(Mutant.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void onListPojoMessage() throws Exception {
+    Pojo pojo = new Pojo();
+    new MockUnit(WebSocket.class, Injector.class, PojoListSocket.class, Binder.class, Mutant.class)
+        .expect(childInjector(PojoListSocket.class))
+        .expect(mutant(TypeLiteral.get(Types.listOf(Pojo.class)), ImmutableList.of(pojo)))
+        .expect(unit -> {
+          PojoListSocket socket = unit.get(PojoListSocket.class);
+          socket.onMessage(ImmutableList.of(pojo));
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), PojoListSocket.class)
+              .onMessage(unit.get(Mutant.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void messageTypeShouldFailOnWrongCallback() throws Exception {
+    MvcWebSocket.messageType(ImNotACallback.class);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void messageTypeShouldFailOnCallbackWithoutType() throws Exception {
+    MvcWebSocket.messageType(CallbackWithoutType.class);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private <T> Block mutant(final TypeLiteral type, final T value) {
+    return unit -> {
+      Mutant mutant = unit.get(Mutant.class);
+      expect(mutant.<T> to(type)).andReturn(value);
+    };
+  }
+
+  @Test
+  public void onOpen() throws Exception {
+    new MockUnit(Request.class, WebSocket.class, Injector.class, MySocket.class, Binder.class)
+        .expect(childInjector(MySocket.class))
+        .expect(unit -> {
+          unit.get(MySocket.class).onOpen(unit.get(Request.class), unit.get(WebSocket.class));
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), MySocket.class)
+              .onOpen(unit.get(Request.class), unit.get(WebSocket.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void onError() throws Exception {
+    new MockUnit(Throwable.class, WebSocket.class, Injector.class, MySocket.class, Binder.class)
+        .expect(childInjector(MySocket.class))
+        .expect(unit -> {
+          unit.get(MySocket.class).onError(unit.get(Throwable.class));
+        })
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), MySocket.class)
+              .onError(unit.get(Throwable.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @Test
+  public void shouldIgnoreOnError() throws Exception {
+    new MockUnit(Throwable.class, WebSocket.class, Injector.class, StringSocket.class, Binder.class)
+        .expect(childInjector(StringSocket.class))
+        .run(unit -> {
+          new MvcWebSocket(unit.get(WebSocket.class), StringSocket.class)
+              .onError(unit.get(Throwable.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void newWebSocket() throws Exception {
+    new MockUnit(Request.class, WebSocket.class, Injector.class, MySocket.class, Binder.class)
+        .expect(unit -> {
+          WebSocket ws = unit.get(WebSocket.class);
+          MySocket mvc = unit.get(MySocket.class);
+          mvc.onOpen(unit.get(Request.class), unit.get(WebSocket.class));
+          ws.onClose(isA(WebSocket.OnClose.class));
+          ws.onError(isA(WebSocket.OnError.class));
+          ws.onMessage(isA(WebSocket.OnMessage.class));
+        })
+        .expect(childInjector(MySocket.class))
+        .run(unit -> {
+          MvcWebSocket.newWebSocket(MySocket.class)
+              .onOpen(unit.get(Request.class), unit.get(WebSocket.class));
+        }, unit -> {
+          unit.captured(Module.class).iterator().next().configure(unit.get(Binder.class));
+        });
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked" })
+  private <T extends WebSocket.OnMessage> Block childInjector(final Class<T> class1) {
+    return unit -> {
+      Injector childInjector = unit.mock(Injector.class);
+      T socket = unit.get(class1);
+      expect(childInjector.getInstance(class1)).andReturn(socket);
+
+      Injector injector = unit.get(Injector.class);
+      expect(injector.createChildInjector(unit.capture(Module.class))).andReturn(childInjector);
+
+      WebSocket ws = unit.get(WebSocket.class);
+      expect(ws.require(Injector.class)).andReturn(injector);
+
+      AnnotatedBindingBuilder<WebSocket> aabbws = unit.mock(AnnotatedBindingBuilder.class);
+      aabbws.toInstance(ws);
+
+      Binder binder = unit.get(Binder.class);
+      expect(binder.bind(WebSocket.class)).andReturn(aabbws);
+    };
+  }
+}

--- a/md/.web-sockets.md.html
+++ b/md/.web-sockets.md.html
@@ -1,0 +1,758 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Strict//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>/Users/edgar/Source/jooby-project/md/.web-sockets.md.html</title>
+
+
+<style type="text/css">
+body {
+	color: #333;
+	font: 13px/1.4 "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
+	padding: 0;
+	margin: 0;
+}
+
+a {
+	background: transparent;
+	color: #4183c4;
+	text-decoration: none;
+}
+
+a:active,
+a:hover {
+	outline: 0 none;
+	text-decoration: underline;
+}
+
+abbr[title] {
+	border-bottom: 1px dotted;
+}
+
+b,
+strong {
+	font-weight: bold;
+}
+
+dfn {
+	font-style: italic;
+}
+h1 {
+	font-size: 2em;
+	margin: 0.67em 0;
+}
+mark {
+	background: #ff0;
+	color: #000;
+}
+small {
+	font-size: 80%;
+}
+sub, sup {
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+sup {
+	top: -0.5em;
+}
+sub {
+	bottom: -0.25em;
+}
+img {
+	border: 0 none;
+}
+svg:not(:root) {
+	overflow: hidden;
+}
+figure {
+	margin: 1em 40px;
+}
+hr {
+	box-sizing: content-box;
+	height: 0;
+}
+
+code,
+kbd,
+pre,
+samp {
+	font-family: monospace,monospace;
+	font-size: 1em;
+}
+
+pre {
+	overflow: auto;
+	font: 12px Consolas,"Liberation Mono",Menlo,Courier,monospace;
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+.markdown-body {
+	padding: 30px;
+	font-size: 16px;
+	line-height: 1.6;
+	word-wrap: break-word;
+}
+
+.markdown-body>*:first-child {
+	margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+	margin-bottom: 0 !important;
+}
+
+.markdown-body .absent {
+	color: #c00;
+}
+
+.markdown-body .anchor {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	display: block;
+	padding-right: 6px;
+	padding-left: 30px;
+	margin-left: -30px;
+}
+
+.markdown-body .anchor:focus {
+	outline: none;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+	position: relative;
+	margin-top: 1em;
+	margin-bottom: 16px;
+	font-weight: bold;
+	line-height: 1.4;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+	display: none;
+	color: #000;
+	vertical-align: middle;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+	padding-left: 8px;
+	margin-left: -30px;
+	line-height: 1;
+	text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+	display: inline-block;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+	font-size: inherit;
+}
+
+.markdown-body h1 {
+	padding-bottom: 0.3em;
+	font-size: 2.25em;
+	line-height: 1.2;
+	border-bottom: 1px solid #eee;
+}
+
+.markdown-body h2 {
+	padding-bottom: 0.3em;
+	font-size: 1.75em;
+	line-height: 1.225;
+	border-bottom: 1px solid #eee;
+}
+
+.markdown-body h3 {
+	font-size: 1.5em;
+	line-height: 1.43;
+}
+
+.markdown-body h4 {
+	font-size: 1.25em;
+}
+
+.markdown-body h5 {
+	font-size: 1em;
+}
+
+.markdown-body h6 {
+	font-size: 1em;
+	color: #777;
+}
+
+.markdown-body p,.markdown-body blockquote,
+.markdown-body ul,.markdown-body ol,
+.markdown-body dl,.markdown-body table,
+.markdown-body pre {
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
+.markdown-body hr {
+	height: 4px;
+	padding: 0;
+	margin: 16px 0;
+	background-color: #e7e7e7;
+	border: 0 none;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+	padding-left: 2em;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+	padding: 0;
+	list-style-type: none;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.markdown-body li>p {
+	margin-top: 16px;
+}
+
+.markdown-body dl {
+	padding: 0;
+}
+
+.markdown-body dl dt {
+	padding: 0;
+	margin-top: 16px;
+	font-size: 1em;
+	font-style: italic;
+	font-weight: bold;
+}
+
+.markdown-body dl dd {
+	padding: 0 16px;
+	margin-bottom: 16px;
+}
+
+.markdown-body blockquote {
+	padding: 0 15px;
+	color: #777;
+	border-left: 4px solid #ddd;
+}
+
+.markdown-body blockquote>:first-child {
+	margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+	margin-bottom: 0;
+}
+
+.markdown-body table {
+	display: block;
+	width: 100%;
+	overflow: auto;
+	word-break: normal;
+	word-break: keep-all;
+}
+
+.markdown-body table th {
+	font-weight: bold;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+	padding: 6px 13px;
+	border: 1px solid #ddd;
+}
+
+.markdown-body table tr {
+	background-color: #fff;
+	border-top: 1px solid #ccc;
+}
+
+.markdown-body table tr:nth-child(2n) {
+	background-color: #f8f8f8;
+}
+
+.markdown-body img {
+	max-width: 100%;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+.markdown-body span.frame {
+	display: block;
+	overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+	display: block;
+	float: left;
+	width: auto;
+	padding: 7px;
+	margin: 13px 0 0;
+	overflow: hidden;
+	border: 1px solid #ddd;
+}
+
+.markdown-body span.frame span img {
+	display: block;
+	float: left;
+}
+
+.markdown-body span.frame span span {
+	display: block;
+	padding: 5px 0 0;
+	clear: both;
+	color: #333;
+}
+
+.markdown-body span.align-center {
+	display: block;
+	overflow: hidden;
+	clear: both;
+}
+
+.markdown-body span.align-center>span {
+	display: block;
+	margin: 13px auto 0;
+	overflow: hidden;
+	text-align: center;
+}
+
+.markdown-body span.align-center span img {
+	margin: 0 auto;
+	text-align: center;
+}
+
+.markdown-body span.align-right {
+	display: block;
+	overflow: hidden;
+	clear: both;
+}
+
+.markdown-body span.align-right>span {
+	display: block;
+	margin: 13px 0 0;
+	overflow: hidden;
+	text-align: right;
+}
+
+.markdown-body span.align-right span img {
+	margin: 0;
+	text-align: right;
+}
+
+.markdown-body span.float-left {
+	display: block;
+	float: left;
+	margin-right: 13px;
+	overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+	margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+	display: block;
+	float: right;
+	margin-left: 13px;
+	overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+	display: block;
+	margin: 13px auto 0;
+	overflow: hidden;
+	text-align: right;
+}
+
+.markdown-body code,.markdown-body tt {
+	padding: 0;
+	padding-top: 0.2em;
+	padding-bottom: 0.2em;
+	margin: 0;
+	font-size: 85%;
+	background-color: rgba(0,0,0,0.04);
+	border-radius: 3px;
+}
+
+.markdown-body code:before,
+.markdown-body code:after,
+.markdown-body tt:before,
+.markdown-body tt:after {
+	letter-spacing: -0.2em;
+	content: "\00a0";
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+	display: none;
+}
+
+.markdown-body del code {
+	text-decoration: inherit;
+}
+
+.markdown-body pre>code {
+	padding: 0;
+	margin: 0;
+	font-size: 100%;
+	word-break: normal;
+	white-space: pre;
+	background: transparent;
+	border: 0;
+}
+
+.markdown-body .highlight {
+	margin-bottom: 16px;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+	padding: 16px;
+	overflow: auto;
+	font-size: 85%;
+	line-height: 1.45;
+	background-color: #f7f7f7;
+	border-radius: 3px;
+}
+
+.markdown-body .highlight pre {
+	margin-bottom: 0;
+	word-break: normal;
+}
+
+.markdown-body pre {
+	word-wrap: normal;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+	display: inline;
+	max-width: initial;
+	padding: 0;
+	margin: 0;
+	overflow: initial;
+	line-height: inherit;
+	word-wrap: normal;
+	background-color: transparent;
+	border: 0;
+}
+
+.markdown-body pre code:before,
+.markdown-body pre code:after,
+.markdown-body pre tt:before,
+.markdown-body pre tt:after {
+	content: normal;
+}
+
+.highlight .pl-coc,
+.highlight .pl-entl,
+.highlight .pl-entm,
+.highlight .pl-eoa,
+.highlight .pl-mai .pl-sf,
+.highlight .pl-mm,
+.highlight .pl-pdv,
+.highlight .pl-sc,
+.highlight .pl-som,
+.highlight .pl-sr,
+.highlight .pl-v,
+.highlight .pl-vpf {
+	color: #0086b3;
+}
+.highlight .pl-eoac,
+.highlight .pl-mdht,
+.highlight .pl-mi1,
+.highlight .pl-mri,
+.highlight .pl-va,
+.highlight .pl-vpu {
+	color: #008080;
+}
+.highlight .pl-c,
+.highlight .pl-pdc {
+	color: #b4b7b4;
+	font-style: italic;
+}
+.highlight .pl-k,
+.highlight .pl-ko,
+.highlight .pl-kolp,
+.highlight .pl-mc,
+.highlight .pl-mr,
+.highlight .pl-ms,
+.highlight .pl-s,
+.highlight .pl-sok,
+.highlight .pl-st {
+	color: #6e5494;
+}
+.highlight .pl-ef,
+.highlight .pl-enf,
+.highlight .pl-enm,
+.highlight .pl-entc,
+.highlight .pl-eoi,
+.highlight .pl-sf,
+.highlight .pl-smc {
+	color: #d12089;
+}
+.highlight .pl-ens,
+.highlight .pl-eoai,
+.highlight .pl-kos,
+.highlight .pl-mh .pl-pdh,
+.highlight .pl-mp,
+.highlight .pl-pde,
+.highlight .pl-stp {
+	color: #458;
+}
+.highlight .pl-enti {
+	color: #d12089;
+	font-weight: bold;
+}
+.highlight .pl-cce,
+.highlight .pl-enc,
+.highlight .pl-kou,
+.highlight .pl-mq {
+	color: #f93;
+}
+.highlight .pl-mp1 .pl-sf {
+	color: #458;
+	font-weight: bold;
+}
+.highlight .pl-cos,
+.highlight .pl-ent,
+.highlight .pl-md,
+.highlight .pl-mdhf,
+.highlight .pl-ml,
+.highlight .pl-pdc1,
+.highlight .pl-pds,
+.highlight .pl-s1,
+.highlight .pl-scp,
+.highlight .pl-sol {
+	color: #df5000;
+}
+.highlight .pl-c1,
+.highlight .pl-cn,
+.highlight .pl-pse,
+.highlight .pl-pse .pl-s2,
+.highlight .pl-vi {
+	color: #a31515;
+}
+.highlight .pl-mb,
+.highlight .pl-pdb {
+	color: #df5000;
+	font-weight: bold;
+}
+.highlight .pl-mi,
+.highlight .pl-pdi {
+	color: #6e5494;
+	font-style: italic;
+}
+.highlight .pl-ms1 {
+	background-color: #f5f5f5;
+}
+.highlight .pl-mdh,
+.highlight .pl-mdi {
+	font-weight: bold;
+}
+.highlight .pl-mdr {
+	color: #0086b3;
+	font-weight: bold;
+}
+.highlight .pl-s2 {
+	color: #333;
+}
+.highlight .pl-ii {
+	background-color: #df5000;
+	color: #fff;
+}
+.highlight .pl-ib {
+	background-color: #f93;
+}
+.highlight .pl-id {
+	background-color: #a31515;
+	color: #fff;
+}
+.highlight .pl-iu {
+	background-color: #b4b7b4;
+}
+.highlight .pl-mo {
+	color: #969896;
+}
+
+</style>
+
+
+<script type="text/javascript">
+
+function getDocumentScrollTop() 
+{
+   var res = document.body.scrollTop || document.documentElement.scrollTop || window.pageYOffset || 0;
+   // alert(res);
+   return res;
+}
+
+function setDocumentScrollTop(ypos) 
+{
+	window.scrollTo(0, ypos);
+}
+
+</script>
+
+
+</head>
+<body class="markdown-body">
+<h1> <a id="web-sockets" class="anchor" href="#web-sockets" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>web sockets</h1> 
+<h2> <a id="usage" class="anchor" href="#usage" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>usage</h2> 
+<div class="highlight highlight-source-java">
+ <pre>{
+  ws(<span class="pl-s"><span class="pl-pds">&quot;</span>/<span class="pl-pds">&quot;</span></span>, ws <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+    ws<span class="pl-k">.</span>onMessage(message <span class="pl-k">-</span><span class="pl-k">&gt;</span> <span class="pl-smi">System</span><span class="pl-k">.</span>out<span class="pl-k">.</span>println(message<span class="pl-k">.</span>value()));
+
+    ws<span class="pl-k">.</span>send(<span class="pl-s"><span class="pl-pds">&quot;</span>connected<span class="pl-pds">&quot;</span></span>);
+  });
+}</pre>
+</div> 
+<p>A <a href="%7B%7Bdefdocs%7D%7D/WebSocket.html">web socket</a> consist of a <strong>path pattern</strong> and a <a href="%7B%7Bdefdocs%7D%7D/WebSocket.Handler.html">handler</a>.</p> 
+<p>A <strong>path pattern</strong> can be as simple or complex as you need. All the path patterns supported by routes are supported here.</p> 
+<p>The <a href="%7B%7Bdefdocs%7D%7D/WebSocket.OnOpen.html">onOpen</a> listener is executed on new connections, from there we can listen for message, errors and/or send data to the client.</p> 
+<p>Keep in mind that <strong>web socket</strong> are not like routes. There is no stack/pipe or chain.</p> 
+<p>You can mount a socket to a path used by a route, but you can't have two or more web sockets under the same path.</p> 
+<h2> <a id="require" class="anchor" href="#require" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>require</h2> 
+<p>Access to existing services is provided via <a href="%7B%7Bdefdocs%7D%7D/WebSocket.html#require-com.google.inject.Key-">ws.require(type)</a> method:</p> 
+<div class="highlight highlight-source-java">
+ <pre>ws(<span class="pl-s"><span class="pl-pds">&quot;</span>/<span class="pl-pds">&quot;</span></span>, ws <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+  <span class="pl-smi">A</span> a <span class="pl-k">=</span> ws<span class="pl-k">.</span>require(<span class="pl-smi">A</span><span class="pl-k">.</span>class);
+});</pre>
+</div> 
+<h2> <a id="listener" class="anchor" href="#listener" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>listener</h2> 
+<p>As with <strong>routes</strong> we do provide <strong>two flavors</strong> for <code>WebSockets</code>:</p> 
+<p>script:</p> 
+<div class="highlight highlight-source-java">
+ <pre>{
+  ws(<span class="pl-s"><span class="pl-pds">&quot;</span>/ws<span class="pl-pds">&quot;</span></span>, ws <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+    <span class="pl-smi">MyDatabase</span> db <span class="pl-k">=</span> ws<span class="pl-k">.</span>require(<span class="pl-smi">MyDatabase</span><span class="pl-k">.</span>class);
+    ws<span class="pl-k">.</span>onMessage(msg <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+      <span class="pl-smi">String</span> value <span class="pl-k">=</span> msg<span class="pl-k">.</span>value();
+      database<span class="pl-k">.</span>save(value);
+      ws<span class="pl-k">.</span>send(<span class="pl-s"><span class="pl-pds">&quot;</span>Got: <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> value);
+    });
+  });
+}</pre>
+</div> 
+<p>class:</p> 
+<div class="highlight highlight-source-java">
+ <pre>{
+  ws(<span class="pl-smi">MyHandler</span><span class="pl-k">.</span>class);
+}
+
+<span class="pl-k">@Path</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>/ws<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">class</span> <span class="pl-en">MyHandler</span> <span class="pl-k">implements</span> <span class="pl-e">WebSocket</span>.<span class="pl-e">OnMessage&lt;<span class="pl-smi">String</span>&gt;</span> {
+
+  <span class="pl-smi">WebSocket</span> ws;
+
+  <span class="pl-smi">MyDatabase</span> db;
+
+  <span class="pl-k">@Inject</span>
+  <span class="pl-k">public</span> <span class="pl-en">MyHandle</span>(<span class="pl-smi">WebSocket</span> <span class="pl-v">ws</span>, <span class="pl-smi">MyDatabase</span> <span class="pl-v">db</span>) {
+    <span class="pl-c1">this</span><span class="pl-k">.</span>ws <span class="pl-k">=</span> ws;
+    <span class="pl-c1">this</span><span class="pl-k">.</span>db <span class="pl-k">=</span> db;
+  }
+
+  <span class="pl-k">@Override</span>
+  <span class="pl-k">public</span> <span class="pl-k">void</span> <span class="pl-en">onMessage</span>(<span class="pl-smi">String</span> <span class="pl-v">message</span>) {
+    database<span class="pl-k">.</span>save(value);
+    ws<span class="pl-k">.</span>send(<span class="pl-s"><span class="pl-pds">&quot;</span>Got: <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> message);
+  }
+}</pre>
+</div> 
+<p>Optionally, your listener could implements <a href="%7B%7Bdefdocs%7D%7D/WebSocket.OnOpen.html">onOpen</a>, <a href="%7B%7Bdefdocs%7D%7D/WebSocket.OnClose.html">onClose</a> or <a href="%7B%7Bdefdocs%7D%7D/WebSocket.OnError.html">onError</a>. If you need them all then use <a href="%7B%7Bdefdocs%7D%7D/WebSocket.Handler.html">handler</a> interface.</p> 
+<h2> <a id="consumes" class="anchor" href="#consumes" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>consumes</h2> 
+<p>Web socket can define a type to consume:</p> 
+<div class="highlight highlight-source-java">
+ <pre>{
+  ws(<span class="pl-s"><span class="pl-pds">&quot;</span>/<span class="pl-pds">&quot;</span></span>, ws <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+    ws<span class="pl-k">.</span>onMessage(message <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+      <span class="pl-smi">MyObject</span> object <span class="pl-k">=</span> message<span class="pl-k">.</span>to(<span class="pl-smi">MyObject</span><span class="pl-k">.</span>class);
+    });
+
+    ws<span class="pl-k">.</span>send(<span class="pl-s"><span class="pl-pds">&quot;</span>connected<span class="pl-pds">&quot;</span></span>);
+  })
+  .consumes(<span class="pl-s"><span class="pl-pds">&quot;</span>json<span class="pl-pds">&quot;</span></span>);
+}</pre>
+</div> 
+<p>Or via annotation for class listeners:</p> 
+<div class="highlight highlight-source-java">
+ <pre><span class="pl-k">@Path</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>/ws<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">@Consumes</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>json<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">class</span> <span class="pl-en">MyHandler</span> <span class="pl-k">implements</span> <span class="pl-e">WebSocket</span>.<span class="pl-e">OnMessage&lt;<span class="pl-smi">MyObject</span>&gt;</span> {
+
+  <span class="pl-k">public</span> <span class="pl-k">void</span> <span class="pl-en">onMessage</span>(<span class="pl-smi">MyObject</span> <span class="pl-v">object</span>) {
+   <span class="pl-c1">...</span>
+  }
+}</pre>
+</div> 
+<p>This is just an utility method for parsing socket message to Java Object. Consumes in web sockets has nothing to do with content negotiation. Content negotiation is route concept, it doesn't apply for web sockets.</p> 
+<h2> <a id="produces" class="anchor" href="#produces" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>produces</h2> 
+<p>Web socket can define a type to produce: </p> 
+<div class="highlight highlight-source-java">
+ <pre>{
+  ws(<span class="pl-s"><span class="pl-pds">&quot;</span>/<span class="pl-pds">&quot;</span></span>, ws <span class="pl-k">-</span><span class="pl-k">&gt;</span> {
+    <span class="pl-smi">MyResponseObject</span> object <span class="pl-k">=</span> <span class="pl-c1">..</span>;
+    ws<span class="pl-k">.</span>send(object);
+  })
+  .produces(<span class="pl-s"><span class="pl-pds">&quot;</span>json<span class="pl-pds">&quot;</span></span>);
+}</pre>
+</div> 
+<p>Or via annotation for class listeners:</p> 
+<div class="highlight highlight-source-java">
+ <pre><span class="pl-k">@Path</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>/ws<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">@Consumes</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>json<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">@Produces</span>(<span class="pl-s"><span class="pl-pds">&quot;</span>json<span class="pl-pds">&quot;</span></span>)
+<span class="pl-k">class</span> <span class="pl-en">MyHandler</span> <span class="pl-k">implements</span> <span class="pl-e">WebSocket</span>.<span class="pl-e">OnMessage&lt;<span class="pl-smi">MyObject</span>&gt;</span> {
+
+  <span class="pl-k">public</span> <span class="pl-k">void</span> <span class="pl-en">onMessage</span>(<span class="pl-smi">MyObject</span> <span class="pl-v">object</span>) {
+   ws<span class="pl-k">.</span>send(<span class="pl-k">new</span> <span class="pl-smi">MyResponseObject</span>());
+  }
+}</pre>
+</div> 
+<p>This is just an utility method for formatting Java Objects as text message. Produces in web sockets has nothing to do with content negotiation. Content negotiation is route concept, it doesn't apply for web sockets.</p>
+</body>
+</html>


### PR DESCRIPTION
* rename web socket callbacks
* implement class/mvc listener using new callbacks
```java
@Path("/ws")
@Consumes("json")
@Produces("json")
class MyHandler implements WebSocket.OnMessage<MyObject> {

  public void onMessage(MyObject object) {
   ws.send(new MyResponseObject());
  }
}
```

/cc @jschneider 