### PR TITLE
jooby raml ignore class hidden properties

### DIFF
--- a/jooby-raml/src/main/java/org/jooby/internal/raml/RamlType.java
+++ b/jooby-raml/src/main/java/org/jooby/internal/raml/RamlType.java
@@ -150,14 +150,16 @@ public class RamlType {
         Field[] fields = rawType.getDeclaredFields();
         Map<String, RamlType> props = new LinkedHashMap<>();
         for (Field field : fields) {
-          RamlType ftype = parse(field.getGenericType(), ctx);
-          if (field.getType().isArray()) {
-            String ctype = ramlTypeName(field.getType());
-            ftype.type = (ctype == null ? ftype.type() : ctype) + "[]";
-            ftype.name = null;
-            ftype.properties = null;
+          if(!field.getName().startsWith("_")) { // only not hidden properties
+            RamlType ftype = parse(field.getGenericType(), ctx);
+            if (field.getType().isArray()) {
+              String ctype = ramlTypeName(field.getType());
+              ftype.type = (ctype == null ? ftype.type() : ctype) + "[]";
+              ftype.name = null;
+              ftype.properties = null;
+            }
+            props.put(field.getName(), ftype);
           }
-          props.put(field.getName(), ftype);
         }
         ramlType.properties = props;
       }


### PR DESCRIPTION
Jooby RamlType ignore properties starting with `_`, for example `_ebeanServer`.

This resolves the issue #718 
