### PR TITLE
add UUID type to raml spec

### DIFF
--- a/jooby-raml/src/main/java/org/jooby/internal/raml/RamlBuilder.java
+++ b/jooby-raml/src/main/java/org/jooby/internal/raml/RamlBuilder.java
@@ -272,7 +272,7 @@ public class RamlBuilder {
     Consumer<Type> typeCollector = type -> {
       if (type != Object.class && type != void.class) {
         RamlType.parseAll(type).stream()
-            .filter(t -> t.isObject() || t.isEnum())
+            .filter(t -> t.isCustom())
             .forEach(types::add);
       }
     };

--- a/jooby-raml/src/main/java/org/jooby/internal/raml/RamlType.java
+++ b/jooby-raml/src/main/java/org/jooby/internal/raml/RamlType.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableList;
 
@@ -49,6 +50,8 @@ public class RamlType {
 
   private List<String> values;
 
+  private String pattern;
+
   public RamlType(final String type) {
     this.type = type;
   }
@@ -64,6 +67,8 @@ public class RamlType {
   public Map<String, RamlType> properties() {
     return properties;
   }
+
+  public String pattern(){ return pattern; }
 
   @Override
   public boolean equals(final Object obj) {
@@ -114,6 +119,9 @@ public class RamlType {
     }
     if (values != null) {
       buff.append(indent(level)).append("enum: ").append(values.toString()).append("\n");
+    }
+    if (pattern != null) {
+      buff.append(indent(level)).append("pattern: ").append(pattern).append("\n");
     }
     buff.setLength(buff.length() - 1);
     return buff.toString();
@@ -196,6 +204,10 @@ public class RamlType {
         enums.add(((Enum) value).name());
       }
       complex.values = enums;
+    } else if(UUID.class.isAssignableFrom(rawType)){
+      complex = new RamlType("string");
+      complex.name = "uuid";
+      complex.pattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
     } else {
       complex = new RamlType("object");
       complex.name = rawType.getSimpleName();
@@ -280,6 +292,12 @@ public class RamlType {
       }
     }
     return null;
+  }
+
+  public boolean isCustom() {
+    return properties != null ||
+            values != null ||
+            pattern != null;
   }
 
   public boolean isObject() {

--- a/jooby-raml/src/test/java/org/jooby/raml/RamlTypeTest.java
+++ b/jooby-raml/src/test/java/org/jooby/raml/RamlTypeTest.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Type;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.jooby.Upload;
 import org.jooby.internal.raml.RamlType;
@@ -64,6 +65,13 @@ public class RamlTypeTest {
         "    age:\n" +
         "      type: integer\n" +
         "      required: false", RamlType.parse(Person.class).toString());
+  }
+
+  @Test
+  public void uuid() {
+    assertEquals("uuid:\n" +
+            "  type: string\n" +
+            "  pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", RamlType.parse(UUID.class).toString());
   }
 
   private Type optional(final Class<?> type) {


### PR DESCRIPTION
When RAML spec builder tries to parse a POJO that has a property of type UUID, it tries to parse like a normal class. 

But the output should be something like this:

```
types:
  UUID:
    type: string
    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
```
(reference: https://github.com/raml-org/raml-spec/issues/483#issuecomment-219048271)

This is what this PR resolves for the `java.util.UUID`.