### PR TITLE
Err.Missing is thrown when req.param(name) encounters name missing - …

### DIFF
--- a/coverage-report/src/test/java/org/jooby/issues/Issue791.java
+++ b/coverage-report/src/test/java/org/jooby/issues/Issue791.java
@@ -1,0 +1,24 @@
+package org.jooby.issues;
+
+import org.jooby.Err;
+import org.jooby.test.ServerFeature;
+import org.junit.Test;
+
+public class Issue791 extends ServerFeature {
+
+  {
+    get("/791", req -> req.param("missingParam").value());
+
+    err(Err.Missing.class, (req, rsp, x) -> {
+      rsp.send("Missing");
+    });
+  }
+
+  @Test
+  public void specializedErrHandlerShouldCatchErrExceptions() throws Exception {
+    request()
+        .get("/791")
+        .expect("Missing");
+  }
+
+}

--- a/jooby/src/main/java/org/jooby/Router.java
+++ b/jooby/src/main/java/org/jooby/Router.java
@@ -2437,10 +2437,9 @@ public interface Router {
    * @return This jooby instance.
    */
   default Router err(final Class<? extends Throwable> type, final Err.Handler handler) {
-    return err((req, rsp, err) -> {
-      Throwable cause = err.getCause();
-      if (type.isInstance(cause)) {
-        handler.handle(req, rsp, err);
+    return err((req, rsp, x) -> {
+      if (type.isInstance(x) || type.isInstance(x.getCause())) {
+        handler.handle(req, rsp, x);
       }
     });
   }
@@ -2454,9 +2453,9 @@ public interface Router {
    * @return This jooby instance.
    */
   default Router err(final int statusCode, final Err.Handler handler) {
-    return err((req, rsp, err) -> {
-      if (statusCode == err.statusCode()) {
-        handler.handle(req, rsp, err);
+    return err((req, rsp, x) -> {
+      if (statusCode == x.statusCode()) {
+        handler.handle(req, rsp, x);
       }
     });
   }
@@ -2470,9 +2469,9 @@ public interface Router {
    * @return This jooby instance.
    */
   default Router err(final Status code, final Err.Handler handler) {
-    return err((req, rsp, err) -> {
-      if (code.value() == err.statusCode()) {
-        handler.handle(req, rsp, err);
+    return err((req, rsp, x) -> {
+      if (code.value() == x.statusCode()) {
+        handler.handle(req, rsp, x);
       }
     });
   }


### PR DESCRIPTION
…documentation needed fix #791