### PR TITLE
remove force recompilation of classes from jooby:spec

### DIFF
--- a/modules/jooby-maven-plugin/src/main/java/org/jooby/RouteProcessorMojo.java
+++ b/modules/jooby-maven-plugin/src/main/java/org/jooby/RouteProcessorMojo.java
@@ -37,7 +37,6 @@ import org.jooby.spec.RouteSpec;
 
 @Mojo(name = "spec", requiresDependencyResolution = ResolutionScope.COMPILE,
     defaultPhase = LifecyclePhase.PROCESS_CLASSES)
-@Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class RouteProcessorMojo extends AbstractMojo {
 
   @Component


### PR DESCRIPTION
I was having issues with my build cycle and the main reason was because `jooby:spec` forks the compilation to generate the spec file and after this the default compilation occurs.

`jooby:spec` executes the build to the `process-classes` phase.

Besides my compilation problems (mainly because of ebean and querybean enhacement), another down side of this is that the compilation is much slower (2 compilations).

This PR just removes the execution of the `process-classes` and if the plugin is set to execute in the phase `process-classes` everything works as expected.