### PR TITLE
added dependency for native epoll

### DIFF
--- a/doc/doc/gradle/gradle.md
+++ b/doc/doc/gradle/gradle.md
@@ -50,6 +50,18 @@ repositories {
 dependencies {
   compile group: 'org.jooby', name: 'jooby', version: '{{version}}'
   compile group: 'org.jooby', name: 'jooby-netty', version: '{{version}}'
+  
+  /*
+   * If using netty and getting native-epoll related errors ensure you have the native transport as an
+   * included dependancy for your platform.
+   */
+   
+   // Using linux
+  compile group:'io.netty', name: 'netty-transport-native-epoll', version: '4.1.12.Final', classifier: 'linux-x86_64'
+  
+  // Using macos
+  compile group:'io.netty', name: 'netty-transport-native-epoll', version: '4.1.12.Final', classifier: 'macos-x86_64'
+  
 }
 
 /*


### PR DESCRIPTION
Found related native transport libraries for any issues related to it not existing. 
[Netty documentation](http://netty.io/wiki/native-transports.html)