### PR TITLE
Making the src extensions that trigger rebuild configurable

### DIFF
--- a/doc/doc/maven-plugin/maven.md
+++ b/doc/doc/maven-plugin/maven.md
@@ -56,6 +56,7 @@ It's worth to mention that dynamic reload of classes is done via {{jboss-modules
     </includes>
     <excludes>
     </excludes>
+    <srcExtensions>.java,.kt,.conf,.properties</srcExtensions>
   </configuration>
 </plugin>
 ```
@@ -150,4 +151,8 @@ Make sure to enable the ```fork``` option too, otherwise ```vmArgs``` are ignore
 
 ### includes / excludes
 
-List of file patterns to listen for file changes.
+List of file patterns to listen for file changes and trigger restarting the server.
+
+### srcExtensions
+
+List of file extensions to listen for file changes and trigger re-compilation.

--- a/doc/gradle-jooby-run.md
+++ b/doc/gradle-jooby-run.md
@@ -62,6 +62,7 @@ joobyRun {
   includes = ['**/*.class', '**/*.conf', '**/*.properties']
   excludes = []
   logLevel = 'info'
+  srcExtensions = [".java", ".kt", ".conf", ".properties"]
 }
 
 ```
@@ -86,4 +87,8 @@ Compilation success or error messages are displayed in the console (not in the b
 
 ### includes / excludes
 
-List of file patterns to watch for file changes.
+List of file patterns to watch for file changes and trigger restarting the server.
+
+### srcExtensions
+
+List of file extensions watch for changes and trigger re-compilation.

--- a/modules/jooby-gradle-plugin/src/main/java/org/jooby/run/JoobyPlugin.java
+++ b/modules/jooby-gradle-plugin/src/main/java/org/jooby/run/JoobyPlugin.java
@@ -250,6 +250,8 @@ public class JoobyPlugin implements Plugin<Project> {
 
           mapping.map("mainClassName", () -> project.getProperties().get("mainClassName"));
 
+          mapping.map("srcExtensions", () -> new String[] {".java", ".conf", ".properties"});
+
           mapping.map("compiler", () -> {
             File eclipseClasspath = new File(project.getProjectDir(), ".classpath");
             return eclipseClasspath.exists() ? "off" : "on";

--- a/modules/jooby-gradle-plugin/src/main/java/org/jooby/run/JoobyTask.java
+++ b/modules/jooby-gradle-plugin/src/main/java/org/jooby/run/JoobyTask.java
@@ -248,6 +248,8 @@ public class JoobyTask extends ConventionTask {
 
   private List<String> watchDirs;
 
+  private List<String> srcExtensions;
+
   private String mainClassName;
 
   private String compiler;
@@ -284,10 +286,8 @@ public class JoobyTask extends ConventionTask {
           .toArray(new Path[0]);
       // don't start watcher if continuous is ON
       new Watcher((k, path) -> {
-        if (path.toString().endsWith(".java")) {
-          runTask(project, path, "classes");
-        } else if (path.toString().endsWith(".conf")
-            || path.toString().endsWith(".properties")) {
+        if (getSrcExtensions().stream()
+                .anyMatch(ext -> path.toString().endsWith(ext))) {
           runTask(project, path, "classes");
         }
       }, watchDirs).start();
@@ -409,6 +409,14 @@ public class JoobyTask extends ConventionTask {
     this.watchDirs = watchDirs;
   }
 
+  public List<String> getSrcExtensions() {
+    return srcExtensions;
+  }
+
+  public void setSrcExtensions(final List<String> srcExtensions) {
+    this.srcExtensions = srcExtensions;
+  }
+
   public String getCompiler() {
     return compiler;
   }
@@ -416,4 +424,5 @@ public class JoobyTask extends ConventionTask {
   public void setCompiler(final String compiler) {
     this.compiler = compiler;
   }
+
 }


### PR DESCRIPTION
This will allow people to configure the src extensions that trigger rebuild so that they can add Kotlin or Rocker file extensions to trigger re-compilation.