### PR TITLE
Change default behavior of Request.locale()

### DIFF
--- a/jooby/src/main/java/org/jooby/Request.java
+++ b/jooby/src/main/java/org/jooby/Request.java
@@ -1150,8 +1150,7 @@ public interface Request extends Registry {
    * @return A matching locale.
    */
   default Locale locale() {
-    return locale((ranges, locales) -> Locale.filter(ranges, locales).stream()
-        .findFirst()
+    return locale((priorityList, locales) -> Optional.ofNullable(Locale.lookup(priorityList, locales))
         .orElse(locales.get(0)));
   }
 

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue273.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue273.java
@@ -48,7 +48,7 @@ public class Issue273 extends ServerFeature {
 
     request().get("/273")
         .header("Accept-Language", "en-AU")
-        .expect("fr-CA");
+        .expect("en");
   }
 
   @Test

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue877.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue877.java
@@ -1,0 +1,31 @@
+package org.jooby.issues;
+
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+import org.jooby.test.ServerFeature;
+import org.junit.Test;
+
+public class Issue877 extends ServerFeature {
+
+  {
+    use(ConfigFactory.empty()
+        .withValue("application.lang",
+          ConfigValueFactory.fromAnyRef("en, de")));
+
+    get("/877", req -> req.locale().toLanguageTag());
+  }
+
+  @Test
+  public void lookupCommonLanguageInsteadOfDefault() throws Exception {
+    request().get("/877")
+        .header("Accept-Language", "de-DE")
+        .expect("de");
+  }
+
+  @Test
+  public void fallbackToDefaultInCaseNothingMatches() throws Exception {
+    request().get("/877")
+        .header("Accept-Language", "fr-CA")
+        .expect("en");
+  }
+}


### PR DESCRIPTION
Uses `Locale#lookup` instead of `Locale#filter` + findFirst and fallback. As a result, it will return the locale with the closest match in case that is possible.

Example: with a language setting of "en, de", a request with the `Accept-Language` header set to `de-CH` will now return `de` instead of `en`.

Closes #877