### PR TITLE
Enable client certificate authentication. Fix #904.

### DIFF
--- a/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettySslContext.java
+++ b/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettySslContext.java
@@ -222,6 +222,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -239,7 +240,8 @@ public class NettySslContext {
         ? conf.getString("ssl.keystore.password") : null;
     SslContextBuilder scb = SslContextBuilder.forServer(keyStoreCert, keyStoreKey, keyStorePass);
     if (conf.hasPath("ssl.trust.cert")) {
-      scb.trustManager(toFile(conf.getString("ssl.trust.cert"), tmpdir));
+      scb.trustManager(toFile(conf.getString("ssl.trust.cert"), tmpdir))
+         .clientAuth(ClientAuth.REQUIRE);
     }
     if (http2) {
       SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;

--- a/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettySslContextTest.java
+++ b/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettySslContextTest.java
@@ -26,6 +26,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -61,6 +62,7 @@ public class NettySslContextTest {
         .expect(unit-> {
           SslContextBuilder scb = unit.get(SslContextBuilder.class);
           expect(scb.trustManager(Paths.get("target", "unsecure.crt").toFile())).andReturn(scb);
+          expect(scb.clientAuth(ClientAuth.REQUIRE)).andReturn(scb);
         })
         .run(unit -> {
           assertNotNull(NettySslContext.build(conf.withValue("ssl.trust.cert",


### PR DESCRIPTION
- NettySslContext now explicitly requests client auth when `ssl.trust.cert` is used.
- NettySslContextTest now checks for this setting.