### PR TITLE
Experimental RoutePattern encoding and routing on Request.rawPath

### DIFF
--- a/jooby/src/main/java/org/jooby/Router.java
+++ b/jooby/src/main/java/org/jooby/Router.java
@@ -204,17 +204,15 @@
 package org.jooby;
 
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import com.google.common.escape.Escaper;
-import com.google.common.net.PercentEscaper;
 import org.jooby.Route.Mapper;
 import org.jooby.funzy.Try;
 import org.jooby.handlers.AssetHandler;
@@ -236,6 +234,10 @@ public interface Router {
    */
   static String decode(String path) {
     return Try.apply(() -> URLDecoder.decode(path, "UTF-8")).get();
+  }
+
+  static String encode(String path) {
+    return Try.apply(() -> URLEncoder.encode(path, "UTF-8")).get();
   }
 
   /**

--- a/jooby/src/main/java/org/jooby/internal/HttpHandlerImpl.java
+++ b/jooby/src/main/java/org/jooby/internal/HttpHandlerImpl.java
@@ -423,7 +423,7 @@ public class HttpHandlerImpl implements HttpHandler {
     Map<Object, Object> scope = new HashMap<>(16);
 
     String method = _method == null ? request.method() : method(_method, request);
-    String path = normalizeURI(request.path());
+    String path = normalizeURI(request.rawPath());
     if (rpath != null) {
       path = rpath.apply(path);
     }

--- a/jooby/src/main/java/org/jooby/internal/RegexRouteMatcher.java
+++ b/jooby/src/main/java/org/jooby/internal/RegexRouteMatcher.java
@@ -210,6 +210,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
+import org.jooby.Router;
+
 public class RegexRouteMatcher implements RouteMatcher {
 
   private final Matcher matcher;
@@ -239,15 +241,12 @@ public class RegexRouteMatcher implements RouteMatcher {
       int varCount = varNames.size();
       int groupCount = matcher.groupCount();
       for (int idx = 0; idx < groupCount; idx++) {
-        String var = matcher.group(idx + 1);
-        if (var.startsWith("/")) {
-          var = var.substring(1);
-        }
+        String var = Router.decode(matcher.group(idx + 1));
         // idx indices
         vars.put(idx, var);
         // named vars
         if (idx < varCount) {
-          vars.put(varNames.get(idx), matcher.group("v" + idx));
+          vars.put(varNames.get(idx), var);
         }
       }
     }

--- a/jooby/src/main/java/org/jooby/internal/RoutePattern.java
+++ b/jooby/src/main/java/org/jooby/internal/RoutePattern.java
@@ -215,6 +215,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jooby.Router;
+
 public class RoutePattern {
 
   private static class Rewrite {
@@ -282,7 +284,14 @@ public class RoutePattern {
 
   public String reverse(final Map<String, Object> vars) {
     return reverse.stream()
-        .map(segment -> vars.getOrDefault(segment, segment).toString())
+        .map(segment -> {
+          Object replacement = vars.get(segment);
+          if (replacement != null) {
+            return Router.encode(replacement.toString());
+          } else {
+            return segment;
+          }
+        })
         .collect(Collectors.joining(""));
   }
 

--- a/modules/jooby-netty/src/test/java/org/jooby/netty/issues/Issue900.java
+++ b/modules/jooby-netty/src/test/java/org/jooby/netty/issues/Issue900.java
@@ -1,0 +1,54 @@
+package org.jooby.netty.issues;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.jooby.Jooby;
+import org.jooby.internal.RoutePattern;
+import org.jooby.test.Client;
+import org.jooby.test.JoobyRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class Issue900 {
+  public static class ArticleApp extends Jooby {
+    static final RoutePattern USER_TITLE = new RoutePattern("GET", "/:user/:title");
+
+    {
+      get(USER_TITLE.pattern(), req -> {
+        return req.param("title").value() + " written by " + req.param("user").value();
+      });
+    }
+
+    public static String urlUserTitle(String user, String title) {
+      return USER_TITLE.reverse(user, title);
+    }
+  }
+
+  @ClassRule
+  public static JoobyRule app = new JoobyRule(new ArticleApp());
+
+  @ClassRule
+  public static Client client = new Client();
+
+  @Test
+  public void clean() throws Exception {
+    client.get(ArticleApp.urlUserTitle("shakespeare", "othello"))
+      .execute()
+      .expect("othello written by shakespeare");
+  }
+
+  @Test
+  public void slash() throws Exception {
+    client.get(ArticleApp.urlUserTitle("not/shakespeare", "othello"))
+      .execute()
+      .expect("othello written by not/shakespeare");
+  }
+
+  @Test
+  public void encodedSlash() throws Exception {
+    client.get(ArticleApp.urlUserTitle("not%2Fshakespeare", "othello"))
+      .execute()
+      .expect("othello written by not%2Fshakespeare");
+  }
+}


### PR DESCRIPTION
As an experiment, I made two modifications:

1. `RoutePattern` calls UrlEncode on `reverse()`, and UrlDecode when populating the `Route.vars()` map.
2. `HttpHandler` now routes based on `rawPath()`.

The sum total is that code like this works:

```java
  public static class ArticleApp extends Jooby {
    static final RoutePattern USER_TITLE = new RoutePattern("GET", "/:user/:title");

    {
      get(USER_TITLE.pattern(), req -> {
        return req.param("title").value() + " written by " + req.param("user").value();
      });
    }

    public static String urlUserTitle(String user, String title) {
      return USER_TITLE.reverse(user, title);
    }
  }

  @Test
  public void test() throws Exception {
    client.get(ArticleApp.urlUserTitle("shakespeare", "othello")).execute()
      .expect("othello written by shakespeare");

    client.get(ArticleApp.urlUserTitle("not/shakespeare", "othello")).execute()
      .expect("othello written by not/shakespeare");

    client.get(ArticleApp.urlUserTitle("not%2Fshakespeare", "othello")).execute()
      .expect("othello written by not%2Fshakespeare");
  }
```

I should note that my changes to `RoutePattern` broke some tests in `RoutePatternTest`.