### PR TITLE
Support path when using MVC class

### DIFF
--- a/jooby/src/main/java/org/jooby/Jooby.java
+++ b/jooby/src/main/java/org/jooby/Jooby.java
@@ -1931,8 +1931,14 @@ public class Jooby implements Router, LifeCycle, Registry {
 
   @Override
   public Route.Collection use(final Class<?> routeClass) {
+      return use("", routeClass);
+  }
+
+  @Override
+  public Route.Collection use(final String path, final Class<?> routeClass) {
     requireNonNull(routeClass, "Route class is required.");
-    MvcClass mvc = new MvcClass(routeClass, "", prefix);
+    requireNonNull(path, "Path is required");
+    MvcClass mvc = new MvcClass(routeClass, path, prefix);
     bag.add(mvc);
     return new Route.Collection(mvc);
   }

--- a/jooby/src/main/java/org/jooby/Router.java
+++ b/jooby/src/main/java/org/jooby/Router.java
@@ -2140,6 +2140,44 @@ public interface Router {
   Route.Collection use(Class<?> routeClass);
 
   /**
+   * <p>
+   * Append MVC routes from a controller like class:
+   * </p>
+   *
+   * <pre>
+   *   use("/pets", MyRoute.class);
+   * </pre>
+   *
+   * Where MyRoute.java is:
+   *
+   * <pre>
+   *   {@literal @}Path("/")
+   *   public class MyRoute {
+   *
+   *    {@literal @}GET
+   *    public String hello() {
+   *      return "Hello Jooby";
+   *    }
+   *   }
+   * </pre>
+   * <p>
+   * Programming model is quite similar to JAX-RS/Jersey with some minor differences and/or
+   * simplifications.
+   * </p>
+   *
+   * <p>
+   * To learn more about Mvc Routes, please check {@link org.jooby.mvc.Path},
+   * {@link org.jooby.mvc.Produces} {@link org.jooby.mvc.Consumes}.
+   * </p>
+   *
+   * @param path Path to mount the route.
+   * @param routeClass A route(s) class.
+   * @return This router.
+   */
+  @Nonnull
+  Route.Collection use(String path, Class<?> routeClass);
+
+  /**
    * <h2>before</h2>
    *
    * Allows for customized handler execution chains. It will be invoked before the actual handler.

--- a/jooby/src/test/java/org/jooby/JoobyTest.java
+++ b/jooby/src/test/java/org/jooby/JoobyTest.java
@@ -2241,8 +2241,10 @@ public class JoobyTest {
 
           LinkedBindingBuilder<Route.Definition> binding = unit
               .mock(LinkedBindingBuilder.class);
-          expect(multibinder.addBinding()).andReturn(binding).times(5);
+          expect(multibinder.addBinding()).andReturn(binding).times(7);
 
+          binding.toInstance(unit.capture(Route.Definition.class));
+          binding.toInstance(unit.capture(Route.Definition.class));
           binding.toInstance(unit.capture(Route.Definition.class));
           binding.toInstance(unit.capture(Route.Definition.class));
           binding.toInstance(unit.capture(Route.Definition.class));
@@ -2268,6 +2270,7 @@ public class JoobyTest {
               jooby.use(SingletonTestRoute.class);
               jooby.use(GuiceSingletonTestRoute.class);
               jooby.use(ProtoTestRoute.class);
+              jooby.use("/test", SingletonTestRoute.class);
               jooby.start();
 
             },
@@ -2275,7 +2278,7 @@ public class JoobyTest {
             unit -> {
               // assert routes
               List<Route.Definition> defs = unit.captured(Route.Definition.class);
-              assertEquals(5, defs.size());
+              assertEquals(7, defs.size());
 
               assertEquals("GET", defs.get(0).method());
               assertEquals("/singleton", defs.get(0).pattern());
@@ -2296,6 +2299,14 @@ public class JoobyTest {
               assertEquals("GET", defs.get(4).method());
               assertEquals("/proto", defs.get(4).pattern());
               assertEquals("/ProtoTestRoute.m1", defs.get(4).name());
+
+              assertEquals("GET", defs.get(5).method());
+              assertEquals("/test/singleton", defs.get(5).pattern());
+              assertEquals("/SingletonTestRoute.m1", defs.get(5).name());
+
+              assertEquals("POST", defs.get(6).method());
+              assertEquals("/test/singleton", defs.get(6).pattern());
+              assertEquals("/SingletonTestRoute.m1", defs.get(6).name());
             });
   }
 


### PR DESCRIPTION
Now you can specify the `path` when using an MVC route.

Example:

```java
use("/pets", MyMVCRoute.class);
```