### PR TITLE
Sass README has an invalid configuration example

### DIFF
--- a/doc/doc/assets-sass/sass.md
+++ b/doc/doc/assets-sass/sass.md
@@ -43,7 +43,7 @@ assets {
 
     syntax: scss
     dev {
-      sourceMap: inline
+      sourcemap: inline
     }
     dist {
       style: compressed

--- a/modules/jooby-assets-sass/README.md
+++ b/modules/jooby-assets-sass/README.md
@@ -46,7 +46,7 @@ assets {
 
     syntax: scss
     dev {
-      sourceMap: inline
+      sourcemap: inline
     }
     dist {
       style: compressed


### PR DESCRIPTION
The Sass README.md file provides an example with camelcased `sourceMap` property, while the code and tests expect an all lowercase `sourcemap`. This leads to the configuration not being picked up when you follow the example. See [this test](https://github.com/yholkamp/jooby/blob/8ae900fe3a3b724e40becec7bd1671785faa01ff/modules/jooby-assets-sass/src/test/java/org/jooby/assets/JSassTest.java#L170) and [this code](https://github.com/yholkamp/jooby/blob/19889ea7c0a2af0764d4c3aab2ca86bf98cbe8a7/modules/jooby-assets-sass/src/main/java/org/jooby/assets/Sass.java#L398) for reference.