### PR TITLE
Sass module file resolver patching

### DIFF
--- a/modules/jooby-assets-sass/src/main/java/org/jooby/assets/Sass.java
+++ b/modules/jooby-assets-sass/src/main/java/org/jooby/assets/Sass.java
@@ -279,29 +279,8 @@ import java.util.stream.Collectors;
  * @author edgar
  * @since 0.11.0
  */
-public class Sass extends AssetProcessor {
-
-  enum FileResolver implements Function<String, URI> {
-    FS {
-      @Override
-      public URI apply(final String it) {
-        File file = new File(it);
-        return file.exists() ? file.toURI() : null;
-      }
-
-    },
-
-    CLASSPATH {
-      @Override
-      public URI apply(final String it) {
-        URL resource = Sass.class.getResource(it);
-        return resource == null ? null : Try.apply(resource::toURI).get();
-      }
-
-    };
-
-  }
-
+public class Sass extends FileLoadingAssetProcessor {
+  
   static class SassImporter implements Importer {
 
     private String ext;
@@ -351,17 +330,45 @@ public class Sass extends AssetProcessor {
   }
 
   static final Pattern LOCATION = Pattern.compile("\"(.+?)\":\\s+(\\d+)");
-
-  static final Function<String, URI> FS = it -> {
+  
+  private static final Function<String, URI> FS = it -> {
     File file = new File(it);
     return file.exists() ? file.toURI() : null;
   };
-
-  static final Function<String, URI> CP = it -> {
-    URL resource = Sass.class.getResource(it);
+  
+  /**
+   * Function that wraps a ClassLoader in a function that takes a filename and returns a URI.
+   */
+  private static final Function<ClassLoader, Function<String, URI>> CP = classLoader -> filename -> {
+    // strip the first backslash to support relative paths, similar to the behavior of Class.getResource(name)
+    if(filename.startsWith("/")) {
+      filename = filename.substring(1);
+    }
+    URL resource;
+    if(classLoader == null) {
+      resource = Sass.class.getResource(filename);
+    } else {
+      resource = classLoader.getResource(filename);
+    }
     return resource == null ? null : Try.apply(resource::toURI).get();
   };
-
+  
+  private static Function<String, URI> createClasspathFunction(ClassLoader classLoader) {
+    return filename -> {
+      // strip the first backslash to support relative paths, similar to the behavior of Class.getResource(name)
+      if(filename.startsWith("/")) {
+        filename = filename.substring(1);
+      }
+      URL resource;
+      if(classLoader == null) {
+        resource = Sass.class.getResource(filename);
+      } else {
+        resource = classLoader.getResource(filename);
+      }
+      return resource == null ? null : Try.apply(resource::toURI).get();
+    };
+  }
+  
   public Sass() {
     set("syntax", "scss");
     set("style", "nested");
@@ -379,10 +386,16 @@ public class Sass extends AssetProcessor {
   }
 
   @Override
-  public String process(final String filename, final String source, final Config conf)
+  public String process(final String filename, final String source, final Config conf, final ClassLoader loader)
       throws Exception {
     String syntax = get("syntax");
-    FileResolver resolver = FileResolver.valueOf(get("importer").toString().toUpperCase());
+    String importer = get("importer").toString().toUpperCase();
+    Function<String, URI> resolver;
+    if("FILE".equals(importer)) {
+      resolver = FS;
+    } else {
+      resolver = CP.apply(loader);
+    }
     OutputStyle style = OutputStyle.valueOf(get("style").toString().toUpperCase());
 
     Options options = new Options();
@@ -414,10 +427,9 @@ public class Sass extends AssetProcessor {
       }
       int line = location.getOrDefault("line", -1);
       int column = location.getOrDefault("column", -1);
-      AssetException aex = new AssetException(name(),
+      throw new AssetException(name(),
           new AssetProblem(Optional.ofNullable(x.getErrorFile()).orElse(filename), line, column,
               x.getErrorText(), null));
-      throw aex;
     }
   }
 

--- a/modules/jooby-assets-sass/src/test/resources/relative/nested/bar.scss
+++ b/modules/jooby-assets-sass/src/test/resources/relative/nested/bar.scss
@@ -1,0 +1,3 @@
+.bar {
+  color: green;
+}

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
@@ -290,14 +290,14 @@ public class AssetCompiler {
     String basedir = conf.hasPath("assets.basedir") ? spath(conf.getString("assets.basedir")) : "";
     this.charset = Charset.forName(this.conf.getString("assets.charset"));
     if (this.conf.hasPath("assets.fileset")) {
-      this.fileset = fileset(loader, basedir, this.conf, aggregators::add);
+      this.fileset = fileset(this.loader, basedir, this.conf, aggregators::add);
     } else {
       this.fileset = new HashMap<>();
     }
     this.scripts = predicate(this.conf, ".js", ".coffee", ".ts");
     this.styles = predicate(this.conf, ".css", ".scss", ".sass", ".less");
     if (this.fileset.size() > 0) {
-      this.pipeline = pipeline(loader, this.conf.getConfig("assets"));
+      this.pipeline = pipeline(this.loader, this.conf.getConfig("assets"));
     } else {
       this.pipeline = Collections.emptyMap();
     }

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
@@ -595,7 +595,11 @@ public class AssetCompiler {
         long start = System.currentTimeMillis();
         try {
           log.debug("    executing: {}", pname);
-          contents = processor.process(filename, contents, conf);
+          if(processor instanceof FileLoadingAssetProcessor) {
+            contents = ((FileLoadingAssetProcessor)processor).process(filename, contents, conf, loader);
+          } else {
+            contents = processor.process(filename, contents, conf);
+          }
         } finally {
           long end = System.currentTimeMillis();
           log.debug("    {} took {}ms", pname, end - start);

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/FileLoadingAssetProcessor.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/FileLoadingAssetProcessor.java
@@ -1,0 +1,241 @@
+/**
+ *                                  Apache License
+ *                            Version 2.0, January 2004
+ *                         http://www.apache.org/licenses/
+ *
+ *    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ *
+ *    1. Definitions.
+ *
+ *       "License" shall mean the terms and conditions for use, reproduction,
+ *       and distribution as defined by Sections 1 through 9 of this document.
+ *
+ *       "Licensor" shall mean the copyright owner or entity authorized by
+ *       the copyright owner that is granting the License.
+ *
+ *       "Legal Entity" shall mean the union of the acting entity and all
+ *       other entities that control, are controlled by, or are under common
+ *       control with that entity. For the purposes of this definition,
+ *       "control" means (i) the power, direct or indirect, to cause the
+ *       direction or management of such entity, whether by contract or
+ *       otherwise, or (ii) ownership of fifty percent (50%) or more of the
+ *       outstanding shares, or (iii) beneficial ownership of such entity.
+ *
+ *       "You" (or "Your") shall mean an individual or Legal Entity
+ *       exercising permissions granted by this License.
+ *
+ *       "Source" form shall mean the preferred form for making modifications,
+ *       including but not limited to software source code, documentation
+ *       source, and configuration files.
+ *
+ *       "Object" form shall mean any form resulting from mechanical
+ *       transformation or translation of a Source form, including but
+ *       not limited to compiled object code, generated documentation,
+ *       and conversions to other media types.
+ *
+ *       "Work" shall mean the work of authorship, whether in Source or
+ *       Object form, made available under the License, as indicated by a
+ *       copyright notice that is included in or attached to the work
+ *       (an example is provided in the Appendix below).
+ *
+ *       "Derivative Works" shall mean any work, whether in Source or Object
+ *       form, that is based on (or derived from) the Work and for which the
+ *       editorial revisions, annotations, elaborations, or other modifications
+ *       represent, as a whole, an original work of authorship. For the purposes
+ *       of this License, Derivative Works shall not include works that remain
+ *       separable from, or merely link (or bind by name) to the interfaces of,
+ *       the Work and Derivative Works thereof.
+ *
+ *       "Contribution" shall mean any work of authorship, including
+ *       the original version of the Work and any modifications or additions
+ *       to that Work or Derivative Works thereof, that is intentionally
+ *       submitted to Licensor for inclusion in the Work by the copyright owner
+ *       or by an individual or Legal Entity authorized to submit on behalf of
+ *       the copyright owner. For the purposes of this definition, "submitted"
+ *       means any form of electronic, verbal, or written communication sent
+ *       to the Licensor or its representatives, including but not limited to
+ *       communication on electronic mailing lists, source code control systems,
+ *       and issue tracking systems that are managed by, or on behalf of, the
+ *       Licensor for the purpose of discussing and improving the Work, but
+ *       excluding communication that is conspicuously marked or otherwise
+ *       designated in writing by the copyright owner as "Not a Contribution."
+ *
+ *       "Contributor" shall mean Licensor and any individual or Legal Entity
+ *       on behalf of whom a Contribution has been received by Licensor and
+ *       subsequently incorporated within the Work.
+ *
+ *    2. Grant of Copyright License. Subject to the terms and conditions of
+ *       this License, each Contributor hereby grants to You a perpetual,
+ *       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *       copyright license to reproduce, prepare Derivative Works of,
+ *       publicly display, publicly perform, sublicense, and distribute the
+ *       Work and such Derivative Works in Source or Object form.
+ *
+ *    3. Grant of Patent License. Subject to the terms and conditions of
+ *       this License, each Contributor hereby grants to You a perpetual,
+ *       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *       (except as stated in this section) patent license to make, have made,
+ *       use, offer to sell, sell, import, and otherwise transfer the Work,
+ *       where such license applies only to those patent claims licensable
+ *       by such Contributor that are necessarily infringed by their
+ *       Contribution(s) alone or by combination of their Contribution(s)
+ *       with the Work to which such Contribution(s) was submitted. If You
+ *       institute patent litigation against any entity (including a
+ *       cross-claim or counterclaim in a lawsuit) alleging that the Work
+ *       or a Contribution incorporated within the Work constitutes direct
+ *       or contributory patent infringement, then any patent licenses
+ *       granted to You under this License for that Work shall terminate
+ *       as of the date such litigation is filed.
+ *
+ *    4. Redistribution. You may reproduce and distribute copies of the
+ *       Work or Derivative Works thereof in any medium, with or without
+ *       modifications, and in Source or Object form, provided that You
+ *       meet the following conditions:
+ *
+ *       (a) You must give any other recipients of the Work or
+ *           Derivative Works a copy of this License; and
+ *
+ *       (b) You must cause any modified files to carry prominent notices
+ *           stating that You changed the files; and
+ *
+ *       (c) You must retain, in the Source form of any Derivative Works
+ *           that You distribute, all copyright, patent, trademark, and
+ *           attribution notices from the Source form of the Work,
+ *           excluding those notices that do not pertain to any part of
+ *           the Derivative Works; and
+ *
+ *       (d) If the Work includes a "NOTICE" text file as part of its
+ *           distribution, then any Derivative Works that You distribute must
+ *           include a readable copy of the attribution notices contained
+ *           within such NOTICE file, excluding those notices that do not
+ *           pertain to any part of the Derivative Works, in at least one
+ *           of the following places: within a NOTICE text file distributed
+ *           as part of the Derivative Works; within the Source form or
+ *           documentation, if provided along with the Derivative Works; or,
+ *           within a display generated by the Derivative Works, if and
+ *           wherever such third-party notices normally appear. The contents
+ *           of the NOTICE file are for informational purposes only and
+ *           do not modify the License. You may add Your own attribution
+ *           notices within Derivative Works that You distribute, alongside
+ *           or as an addendum to the NOTICE text from the Work, provided
+ *           that such additional attribution notices cannot be construed
+ *           as modifying the License.
+ *
+ *       You may add Your own copyright statement to Your modifications and
+ *       may provide additional or different license terms and conditions
+ *       for use, reproduction, or distribution of Your modifications, or
+ *       for any such Derivative Works as a whole, provided Your use,
+ *       reproduction, and distribution of the Work otherwise complies with
+ *       the conditions stated in this License.
+ *
+ *    5. Submission of Contributions. Unless You explicitly state otherwise,
+ *       any Contribution intentionally submitted for inclusion in the Work
+ *       by You to the Licensor shall be under the terms and conditions of
+ *       this License, without any additional terms or conditions.
+ *       Notwithstanding the above, nothing herein shall supersede or modify
+ *       the terms of any separate license agreement you may have executed
+ *       with Licensor regarding such Contributions.
+ *
+ *    6. Trademarks. This License does not grant permission to use the trade
+ *       names, trademarks, service marks, or product names of the Licensor,
+ *       except as required for reasonable and customary use in describing the
+ *       origin of the Work and reproducing the content of the NOTICE file.
+ *
+ *    7. Disclaimer of Warranty. Unless required by applicable law or
+ *       agreed to in writing, Licensor provides the Work (and each
+ *       Contributor provides its Contributions) on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *       implied, including, without limitation, any warranties or conditions
+ *       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+ *       PARTICULAR PURPOSE. You are solely responsible for determining the
+ *       appropriateness of using or redistributing the Work and assume any
+ *       risks associated with Your exercise of permissions under this License.
+ *
+ *    8. Limitation of Liability. In no event and under no legal theory,
+ *       whether in tort (including negligence), contract, or otherwise,
+ *       unless required by applicable law (such as deliberate and grossly
+ *       negligent acts) or agreed to in writing, shall any Contributor be
+ *       liable to You for damages, including any direct, indirect, special,
+ *       incidental, or consequential damages of any character arising as a
+ *       result of this License or out of the use or inability to use the
+ *       Work (including but not limited to damages for loss of goodwill,
+ *       work stoppage, computer failure or malfunction, or any and all
+ *       other commercial damages or losses), even if such Contributor
+ *       has been advised of the possibility of such damages.
+ *
+ *    9. Accepting Warranty or Additional Liability. While redistributing
+ *       the Work or Derivative Works thereof, You may choose to offer,
+ *       and charge a fee for, acceptance of support, warranty, indemnity,
+ *       or other liability obligations and/or rights consistent with this
+ *       License. However, in accepting such obligations, You may act only
+ *       on Your own behalf and on Your sole responsibility, not on behalf
+ *       of any other Contributor, and only if You agree to indemnify,
+ *       defend, and hold each Contributor harmless for any liability
+ *       incurred by, or claims asserted against, such Contributor by reason
+ *       of your accepting any such warranty or additional liability.
+ *
+ *    END OF TERMS AND CONDITIONS
+ *
+ *    APPENDIX: How to apply the Apache License to your work.
+ *
+ *       To apply the Apache License to your work, attach the following
+ *       boilerplate notice, with the fields enclosed by brackets "{}"
+ *       replaced with your own identifying information. (Don't include
+ *       the brackets!)  The text should be enclosed in the appropriate
+ *       comment syntax for the file format. We also recommend that a
+ *       file or class name and description of purpose be included on the
+ *       same "printed page" as the copyright notice for easier
+ *       identification within third-party archives.
+ *
+ *    Copyright 2014 Edgar Espina
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.jooby.assets;
+
+import com.typesafe.config.Config;
+
+/**
+ * Abstract class that indicates that he AssetProcessors that extend this can access a classLoader internally to load
+ * additional resources from disk, i.e. imports.
+ *
+ * @author yholkamp
+ */
+public abstract class FileLoadingAssetProcessor extends AssetProcessor {
+  
+  /**
+   * Method that processes the
+   *
+   * @param filename name of the file
+   * @param source   contents of the file
+   * @param conf     application configuration
+   * @param loader   loader to use if any additional files need to be loaded from disk
+   * @return the processed file contents
+   * @throws Exception if any error occurred
+   */
+  abstract String process(String filename, String source, Config conf, ClassLoader loader) throws Exception;
+  
+  /**
+   * Backwards version of the process method, which does not receive a new ClassLoader.
+   *
+   * @param filename name of the file
+   * @param source   contents of the file
+   * @param conf     application configuration
+   * @return the processed file contents
+   * @throws Exception if any error occurred
+   */
+  public String process(String filename, String source, Config conf) throws Exception {
+    return process(filename, source, conf, FileLoadingAssetProcessor.class.getClassLoader());
+  }
+  
+}


### PR DESCRIPTION
This pull request aims to resolve issue #968. To do so I've added a new parent class for `AssetProcessor`s, one that features a `process` method that takes a ClassLoader. I've updated the `AssetCompiler` to call this method when applicable for backwards compatibility with existing asset processors.

The Sass class had unused `FS` and `CP` constants that I've adapted to include the provided ClassLoader, removing the FileResolver enum as it's become redundant.

Let me know if you'd like me to change any of this!