### PR TITLE
Assets-sass module file resolver patching

### DIFF
--- a/modules/jooby-assets-sass/src/test/resources/relative/nested/bar.scss
+++ b/modules/jooby-assets-sass/src/test/resources/relative/nested/bar.scss
@@ -1,0 +1,3 @@
+.bar {
+  color: green;
+}

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
@@ -595,7 +595,7 @@ public class AssetCompiler {
         long start = System.currentTimeMillis();
         try {
           log.debug("    executing: {}", pname);
-          contents = processor.process(filename, contents, conf);
+          contents = processor.process(filename, contents, conf, loader);
         } finally {
           long end = System.currentTimeMillis();
           log.debug("    {} took {}ms", pname, end - start);

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
@@ -290,14 +290,14 @@ public class AssetCompiler {
     String basedir = conf.hasPath("assets.basedir") ? spath(conf.getString("assets.basedir")) : "";
     this.charset = Charset.forName(this.conf.getString("assets.charset"));
     if (this.conf.hasPath("assets.fileset")) {
-      this.fileset = fileset(loader, basedir, this.conf, aggregators::add);
+      this.fileset = fileset(this.loader, basedir, this.conf, aggregators::add);
     } else {
       this.fileset = new HashMap<>();
     }
     this.scripts = predicate(this.conf, ".js", ".coffee", ".ts");
     this.styles = predicate(this.conf, ".css", ".scss", ".sass", ".less");
     if (this.fileset.size() > 0) {
-      this.pipeline = pipeline(loader, this.conf.getConfig("assets"));
+      this.pipeline = pipeline(this.loader, this.conf.getConfig("assets"));
     } else {
       this.pipeline = Collections.emptyMap();
     }

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetProcessor.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetProcessor.java
@@ -338,8 +338,31 @@ public abstract class AssetProcessor extends AssetOptions {
   }
 
   public abstract boolean matches(final MediaType type);
-
+  
+  /**
+   * Method that processes the provided source and returns the processed contents. 
+   *
+   * @param filename name of the file
+   * @param source   contents of the file
+   * @param conf     application configuration
+   * @return the processed file contents
+   * @throws Exception if any error occurred
+   */
   public abstract String process(String filename, String source, Config conf) throws Exception;
+  
+  /**
+   * Method that processes the provided source and returns the processed contents, with access to the ClassLoader.
+   *
+   * @param filename name of the file
+   * @param source   contents of the file
+   * @param conf     application configuration
+   * @param loader   loader to use if any additional files need to be loaded from disk
+   * @return the processed file contents
+   * @throws Exception if any error occurred
+   */
+  public String process(String filename, String source, Config conf, ClassLoader loader) throws Exception {
+    return process(filename, source, conf);
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION
This pull request aims to resolve issue #968, with a cleaner solution than suggested in pull request #974 . To provide access to the `ClassLoader` instance, I've added a new `process` method to the `AssetProcessor` that takes an additional parameter (the class loader instance) and calls the existing `process` method for backwards compatibility. I've then updated the `Sass` class to overwrite the new process method.

The Sass class had unused `FS` and `CP` constants that I've adapted to include the provided ClassLoader, removing the FileResolver enum as it's become redundant.