### PR TITLE
fix ebean: add query-beans maven integration

### DIFF
--- a/modules/jooby-maven-plugin/src/main/java/org/jooby/JoobyMojo.java
+++ b/modules/jooby-maven-plugin/src/main/java/org/jooby/JoobyMojo.java
@@ -498,7 +498,7 @@ public class JoobyMojo extends AbstractMojo {
     synchronized (LOCK) {
       Map<String, String> xml = new HashMap<>();
       XML_PROPS.forEach(p -> xml.put(p, (String) System.getProperties().remove(p)));
-      task.accept("compile");
+      task.accept("process-classes");
       xml.forEach((k, v) -> {
         if (v != null) {
           System.setProperty(k, v);


### PR DESCRIPTION
When `jooby:run` was reloading a project with ebean, entity classes where not being enhanced.