### PR TITLE
Clarifying the @Local injection documentation & injection error

### DIFF
--- a/doc/req.md
+++ b/doc/req.md
@@ -390,26 +390,33 @@ Local attributes (a.k.a request attributes) are bound to the current request. Th
 }
 ```
 
-In ```mvc routes``` request locals can be injected via the ```@Local``` annotation:
+In ```mvc routes``` request locals can be injected via the ```@Local``` annotation by defining a method parameter with the same name as a request local:
 
 ```java
 
   @GET
   public Result localAttr(@Local String var) {
-    ...
+    // either var will be set to a previously configured value or an error is thrown when this method is requested
   }
 
   @GET
   public Result ifLocalAttr(@Local Optional<String> var) {
-    ...
+    // var will contain an optional that may be empty if no value was previously configured
   }
 
   @GET
   public Result attributes(@Local Map<String, Object> attributes) {
-    ...
+    // attributes contains the map of local attributes
   }
 
 ```
+
+Locals that are available by default include:
+
+* `path`: the request path, i.e. `/myroute`
+* `contextPath`: application path (a.k.a context path). It is the value defined by: `application.path`.
+* When the `Assets` module is enabled: your asset filesets postfixed with `_css` and `_js`
+* When the `Flash` module is enabled: `flash`, the map of flash key/values
 
 ## flash scope
 

--- a/jooby/src/main/java/org/jooby/internal/mvc/RequestParam.java
+++ b/jooby/src/main/java/org/jooby/internal/mvc/RequestParam.java
@@ -212,14 +212,7 @@ import java.util.Optional;
 
 import javax.inject.Named;
 
-import org.jooby.Cookie;
-import org.jooby.Err;
-import org.jooby.Mutant;
-import org.jooby.Request;
-import org.jooby.Response;
-import org.jooby.Route;
-import org.jooby.Session;
-import org.jooby.Upload;
+import org.jooby.*;
 import org.jooby.mvc.Body;
 import org.jooby.mvc.Flash;
 import org.jooby.mvc.Header;
@@ -316,7 +309,11 @@ public class RequestParam {
       if (param.optional) {
         return local;
       }
-      return local.get();
+      if(local.isPresent()) {
+        return local.get();
+      } else {
+        throw new Err(Status.SERVER_ERROR, "Could not find required local '" + param.name + "', which was required on " + req.path());
+      }
     });
 
     /**

--- a/jooby/src/test/java/org/jooby/internal/mvc/RequestParamTest.java
+++ b/jooby/src/test/java/org/jooby/internal/mvc/RequestParamTest.java
@@ -67,14 +67,14 @@ public class RequestParamTest {
     RequestParam requestParam = new RequestParam(param, "myLocal", param.getParameterizedType());
     
     // verify that with a mock request we can indeed retrieve the 'myLocal' value
-    new MockUnit(RequestParam.class, Request.class, Response.class, Route.Chain.class)
+    new MockUnit(Request.class)
         .expect(unit -> {
           Request request = unit.get(Request.class);
           expect(request.ifGet("myLocal")).andReturn(Optional.of("myCustomValue"));
           verify();
         })
         .run((unit) -> {
-          Object output = requestParam.value(unit.get(Request.class), unit.get(Response.class), unit.get(Route.Chain.class));
+          Object output = requestParam.value(unit.get(Request.class), null, null);
           assertEquals("myCustomValue", output);
         });
   }
@@ -85,7 +85,7 @@ public class RequestParamTest {
     RequestParam requestParam = new RequestParam(param, "myLocal", param.getParameterizedType());
     
     // verify that we return a descriptive error when myLocal could not be located
-    new MockUnit(RequestParam.class, Request.class, Response.class, Route.Chain.class)
+    new MockUnit(Request.class)
         .expect(unit -> {
           Request request = unit.get(Request.class);
           expect(request.path()).andReturn("/mypath");
@@ -95,10 +95,9 @@ public class RequestParamTest {
         .run((unit) -> {
           RuntimeException exception = null;
           try {
-            requestParam.value(unit.get(Request.class), unit.get(Response.class), unit.get(Route.Chain.class));
+            requestParam.value(unit.get(Request.class), null, null);
           } catch(RuntimeException e) {
             exception = e;
-            e.printStackTrace();
           }
           assertNotNull("Should have thrown an exception because the myLocal is not present", exception);
           assertEquals("Server Error(500): Could not find required local 'myLocal', which was required on /mypath", exception.getMessage());

--- a/jooby/src/test/java/org/jooby/internal/mvc/RequestParamTest.java
+++ b/jooby/src/test/java/org/jooby/internal/mvc/RequestParamTest.java
@@ -1,14 +1,22 @@
 package org.jooby.internal.mvc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.lang.reflect.Parameter;
+import org.jooby.Request;
+import org.jooby.Response;
+import org.jooby.Route;
+import org.jooby.mvc.Header;
+import org.jooby.mvc.Local;
+import org.jooby.test.MockUnit;
+import org.junit.Test;
 
 import javax.inject.Named;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
 
-import org.jooby.mvc.Header;
-import org.junit.Test;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class RequestParamTest {
 
@@ -30,7 +38,11 @@ public class RequestParamTest {
 
   public void eheader(@Header final String s) {
   }
-
+  
+  public void local(@Local String myLocal) {
+    
+  }
+  
   @Test
   public void name() throws Exception {
     assertEquals("javax", RequestParam.nameFor(param("javax")));
@@ -48,7 +60,51 @@ public class RequestParamTest {
         || "s".equals(RequestParam.nameFor(param("eheader"))));
 
   }
-
+  
+  @Test
+  public void requestParam_mvcLocal_valuePresent() throws Throwable {
+    Parameter param = param("local");
+    RequestParam requestParam = new RequestParam(param, "myLocal", param.getParameterizedType());
+    
+    // verify that with a mock request we can indeed retrieve the 'myLocal' value
+    new MockUnit(RequestParam.class, Request.class, Response.class, Route.Chain.class)
+        .expect(unit -> {
+          Request request = unit.get(Request.class);
+          expect(request.ifGet("myLocal")).andReturn(Optional.of("myCustomValue"));
+          verify();
+        })
+        .run((unit) -> {
+          Object output = requestParam.value(unit.get(Request.class), unit.get(Response.class), unit.get(Route.Chain.class));
+          assertEquals("myCustomValue", output);
+        });
+  }
+  
+  @Test
+  public void requestParam_mvcLocal_valueAbsent() throws Throwable {
+    Parameter param = param("local");
+    RequestParam requestParam = new RequestParam(param, "myLocal", param.getParameterizedType());
+    
+    // verify that we return a descriptive error when myLocal could not be located
+    new MockUnit(RequestParam.class, Request.class, Response.class, Route.Chain.class)
+        .expect(unit -> {
+          Request request = unit.get(Request.class);
+          expect(request.path()).andReturn("/mypath");
+          expect(request.ifGet("myLocal")).andReturn(Optional.empty());
+          verify();
+        })
+        .run((unit) -> {
+          RuntimeException exception = null;
+          try {
+            requestParam.value(unit.get(Request.class), unit.get(Response.class), unit.get(Route.Chain.class));
+          } catch(RuntimeException e) {
+            exception = e;
+            e.printStackTrace();
+          }
+          assertNotNull("Should have thrown an exception because the myLocal is not present", exception);
+          assertEquals("Server Error(500): Could not find required local 'myLocal', which was required on /mypath", exception.getMessage());
+        });
+  }
+  
   private Parameter param(final String name) throws Exception {
     return RequestParamTest.class.getDeclaredMethod(name, String.class).getParameters()[0];
   }


### PR DESCRIPTION
While debugging my application I ran in to some `@Local` behavior that I didn't immediately expect, in that matching happens based on the parameter name rather than type (like with injection). In hindsight this makes perfect sense and I figured I'd add a note about this in the documentation to help others who run in to this.

Additionally I noticed that currently the error you receive when you define an mvc route with has a non-optional `@Local` field, i.e. `@Local String myLocal` and this value is not present, you receive the following exception/trace, which provides little debug information:
```
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135)
	at org.jooby.internal.mvc.RequestParam.lambda$static$16(RequestParam.java:319)
	at org.jooby.internal.mvc.RequestParam.value(RequestParam.java:368)
```
I've added a commit that replaces this exception with a `Jooby.Err` exception that includes the route and parameter in which this occurred, which should help a lot while debugging this kind of errors. I've also added test coverage for this.

The new exception then becomes:
```
org.jooby.Err: Server Error(500): Could not find required local 'myLocal', which was required on /mypath
	at org.jooby.internal.mvc.RequestParam.lambda$static$16(RequestParam.java:315)
	at org.jooby.internal.mvc.RequestParam.value(RequestParam.java:365)
```