### PR TITLE
Updating the Jdbi3 dependency version

### DIFF
--- a/modules/jooby-jdbi3/pom.xml
+++ b/modules/jooby-jdbi3/pom.xml
@@ -40,7 +40,7 @@
     <!-- JDBI -->
     <dependency>
       <groupId>org.jdbi</groupId>
-      <artifactId>jdbi3</artifactId>
+      <artifactId>jdbi3-core</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -890,7 +890,7 @@
 
       <dependency>
         <groupId>org.jdbi</groupId>
-        <artifactId>jdbi3</artifactId>
+        <artifactId>jdbi3-core</artifactId>
         <version>${jdbi3.version}</version>
       </dependency>
 
@@ -2999,7 +2999,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <asm.version>5.0.3</asm.version>
     <quartz.version>2.2.2</quartz.version>
     <jdbi.version>2.78</jdbi.version>
-    <jdbi3.version>3.0.0-beta2</jdbi3.version>
+    <jdbi3.version>3.0.1</jdbi3.version>
     <freemarker.version>2.3.26-incubating</freemarker.version>
     <camel.version>2.18.3</camel.version>
     <jedis.version>2.9.0</jedis.version>


### PR DESCRIPTION
Per [the Jdbi changelog](https://github.com/jdbi/jdbi/blob/ff1ee02/RELEASE_NOTES#L54-L55), Jdbi has moved to using `jdbi3-core` rather than `jdbi3` as artifact name after 3.0.0-beta2, which is the version currently in use in Jooby. 

Since there are quite a number of bugfixes that were added after this beta, in particular relating to Kotlin and nested bean mapping, I'd like to propose that we upgrade the Jdbi3 version to the latest, which is 3.0.1 on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jdbi%22%20).