### PR TITLE
Updating AssetMojo to honor the Maven project.baseDir

### DIFF
--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetClassLoader.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetClassLoader.java
@@ -220,7 +220,7 @@ public class AssetClassLoader {
    * @throws IOException if an exception occurred
    */
   public static ClassLoader classLoader(final ClassLoader parent) throws IOException {
-    return classLoader(parent, new File(""));
+    return classLoader(parent, new File(System.getProperty("user.dir")));
   }
   
   /**

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetClassLoader.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetClassLoader.java
@@ -210,13 +210,32 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-class AssetClassLoader {
-
+public class AssetClassLoader {
+  
+  /**
+   * Constructs a new AssetClassLoader that includes the 'public' dir if present in the current working dir
+   *
+   * @param parent parent classloader
+   * @return classloader that includes the public dir if present
+   * @throws IOException if an exception occurred
+   */
   public static ClassLoader classLoader(final ClassLoader parent) throws IOException {
+    return classLoader(parent, new File(""));
+  }
+  
+  /**
+   * Constructs a new AssetClassLoader that includes the 'public' dir if present in the provided working dir
+   *
+   * @param parent parent classloader
+   * @param projectDir working dir to use
+   * @return classloader that includes the public dir if present
+   * @throws IOException if an exception occurred
+   */
+  public static ClassLoader classLoader(final ClassLoader parent, File projectDir) throws IOException {
     requireNonNull(parent, "ClassLoader required.");
-    File publicDir = new File("public");
-    if (publicDir.exists()) {
-      return new URLClassLoader(new URL[]{publicDir.toURI().toURL() }, parent);
+    File publicDir = new File(projectDir, "public");
+    if(publicDir.exists()) {
+      return new URLClassLoader(new URL[]{publicDir.toURI().toURL()}, parent);
     }
     return parent;
   }

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/AssetCompiler.java
@@ -281,11 +281,11 @@ public class AssetCompiler {
   private ClassLoader loader;
 
   public AssetCompiler(final Config conf) throws Exception {
-    this(conf.getClass().getClassLoader(), conf);
+    this(AssetClassLoader.classLoader(conf.getClass().getClassLoader()), conf);
   }
 
   public AssetCompiler(final ClassLoader loader, final Config conf) throws Exception {
-    this.loader = AssetClassLoader.classLoader(loader);
+    this.loader = loader;
     this.conf = requireNonNull(conf, "Assets conf is required.");
     String basedir = conf.hasPath("assets.basedir") ? spath(conf.getString("assets.basedir")) : "";
     this.charset = Charset.forName(this.conf.getString("assets.charset"));

--- a/modules/jooby-assets/src/main/java/org/jooby/assets/Assets.java
+++ b/modules/jooby-assets/src/main/java/org/jooby/assets/Assets.java
@@ -494,7 +494,8 @@ public class Assets implements Jooby.Module {
     ClassLoader loader = getClass().getClassLoader();
     Config conf = conf(dev, loader, config);
     String cpath = config.getString("application.path");
-    AssetCompiler compiler = new AssetCompiler(loader, conf);
+    ClassLoader assetClassLoader = AssetClassLoader.classLoader(loader);
+    AssetCompiler compiler = new AssetCompiler(assetClassLoader, conf);
 
     Router routes = env.router();
     List<String> dist = dev ? ImmutableList.of("dev") : ImmutableList.of(envname, "dist");

--- a/modules/jooby-assets/src/test/java/org/jooby/assets/AssetClassLoaderTest.java
+++ b/modules/jooby-assets/src/test/java/org/jooby/assets/AssetClassLoaderTest.java
@@ -43,8 +43,10 @@ public class AssetClassLoaderTest {
 
   private Block publicDir(final boolean exists, final File file) {
     return unit -> {
+      File root = unit.constructor(File.class)
+          .build("");
       File f = unit.constructor(File.class)
-          .build("public");
+          .build(root, "public");
       expect(f.exists()).andReturn(exists);
       if (exists) {
         expect(f.toURI()).andReturn(file.toURI());

--- a/modules/jooby-assets/src/test/java/org/jooby/assets/AssetClassLoaderTest.java
+++ b/modules/jooby-assets/src/test/java/org/jooby/assets/AssetClassLoaderTest.java
@@ -44,7 +44,7 @@ public class AssetClassLoaderTest {
   private Block publicDir(final boolean exists, final File file) {
     return unit -> {
       File root = unit.constructor(File.class)
-          .build("");
+          .build(System.getProperty("user.dir"));
       File f = unit.constructor(File.class)
           .build(root, "public");
       expect(f.exists()).andReturn(exists);

--- a/modules/jooby-maven-plugin/src/main/java/org/jooby/AssetMojo.java
+++ b/modules/jooby-maven-plugin/src/main/java/org/jooby/AssetMojo.java
@@ -220,6 +220,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.jooby.assets.AssetClassLoader;
 import org.jooby.assets.AssetCompiler;
 
 import com.google.common.base.Throwables;
@@ -278,8 +279,8 @@ public class AssetMojo extends AbstractMojo {
           .withFallback(conf);
 
       getLog().debug("assets.conf: " + assetConf.getConfig("assets"));
-
-      AssetCompiler compiler = new AssetCompiler(loader, assetConf);
+      ClassLoader assetLoader = AssetClassLoader.classLoader(loader, mavenProject.getBasedir());
+      AssetCompiler compiler = new AssetCompiler(assetLoader, assetConf);
 
       Map<String, List<File>> fileset = compiler.build(env, output);
 


### PR DESCRIPTION
Currently if you run the `AssetMojo` from another directory than the project root, asset compilation fails. Examples where this would happen are using Jooby in a Maven module of a larger project, in that case running `mvn package` on the main project would break as `package` is invoked on the Jooby submodule from the parent directory. Another example would be perhaps on a CI server compiling the app without changing directories via `mvn -f projectdir/pom.xml package`.

I'm aware that this isn't the recommended way to run Jooby but it'd be convenient to support this nonetheless as it makes it easier to integrate Jooby in to existing projects.

Since the `AssetMojo` has access to `mavenProject.basedir` which returns the proper base directory irrespective of the working directory, I've made the following changes:
* The `AssetClassLoader` now has an extended version that takes a projectBaseDir, with an overloaded variant that defaults to the current directory.
* The `AssetCompiler` now assumes the provided classLoader is an instance that was optionally pre wrapped by `AssetClassLoader`, allowing the `AssetMojo` to pass in an `AssetClassLoader` that uses the Maven basedir.