### PR TITLE
Adding support for modules with @Provides annotated methods

### DIFF
--- a/jooby/src/main/java/org/jooby/Jooby.java
+++ b/jooby/src/main/java/org/jooby/Jooby.java
@@ -220,6 +220,7 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Stage;
 import com.google.inject.TypeLiteral;
+import com.google.inject.internal.ProviderMethodsModule;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
@@ -3419,6 +3420,7 @@ public class Jooby implements Router, LifeCycle, Registry {
   private static void install(final Jooby.Module module, final Env env, final Config config,
       final Binder binder) throws Throwable {
     module.configure(env, config, binder);
+    binder.install(ProviderMethodsModule.forObject(module));
   }
 
   /**

--- a/jooby/src/test/java/org/jooby/JoobyTest.java
+++ b/jooby/src/test/java/org/jooby/JoobyTest.java
@@ -15,6 +15,7 @@ import com.google.inject.binder.AnnotatedConstantBindingBuilder;
 import com.google.inject.binder.ConstantBindingBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.binder.ScopedBindingBuilder;
+import com.google.inject.internal.ProviderMethodsModule;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Named;
@@ -23,10 +24,7 @@ import com.google.inject.util.Types;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.isA;
+import org.easymock.EasyMock;
 import org.jooby.Session.Definition;
 import org.jooby.Session.Store;
 import org.jooby.internal.AppPrinter;
@@ -60,6 +58,8 @@ import org.jooby.spi.Server;
 import org.jooby.test.MockUnit;
 import org.jooby.test.MockUnit.Block;
 import org.jooby.funzy.Throwing;
+
+import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -519,6 +519,8 @@ public class JoobyTest {
     expect(serverBinding.to(isA(Class.class))).andReturn(serverScope).times(0, 1);
 
     Binder binder = unit.get(Binder.class);
+    binder.install(anyObject(ProviderMethodsModule.class));
+    EasyMock.expectLastCall().atLeastOnce();
     expect(binder.bind(Server.class)).andReturn(serverBinding).times(0, 1);
 
     // ConfigOrigin configOrigin = unit.mock(ConfigOrigin.class);
@@ -574,6 +576,7 @@ public class JoobyTest {
               expect(serverBinding.to(isA(Class.class))).andReturn(serverScope).times(0, 1);
 
               Binder binder = unit.get(Binder.class);
+              binder.install(anyObject(ProviderMethodsModule.class));
               expect(binder.bind(Server.class)).andReturn(serverBinding).times(0, 1);
 
               // ConfigOrigin configOrigin = unit.mock(ConfigOrigin.class);
@@ -1059,6 +1062,7 @@ public class JoobyTest {
               expect(serverBinding.to(isA(Class.class))).andReturn(serverScope).times(0, 1);
 
               Binder binder = unit.get(Binder.class);
+              binder.install(anyObject(ProviderMethodsModule.class));
               expect(binder.bind(Server.class)).andReturn(serverBinding).times(0, 1);
 
               // ConfigOrigin configOrigin = unit.mock(ConfigOrigin.class);

--- a/modules/coverage-report/src/test/java/org/jooby/ModuleProvidesFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/ModuleProvidesFeature.java
@@ -1,0 +1,66 @@
+package org.jooby;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.jooby.mvc.GET;
+import org.jooby.mvc.Path;
+import org.jooby.test.ServerFeature;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.math.BigDecimal;
+
+import static java.util.Objects.requireNonNull;
+
+public class ModuleProvidesFeature extends ServerFeature {
+
+  public static class M2 implements Module {
+    @Override
+    public void configure(Env env, Config conf, Binder binder) throws Throwable {
+    }
+    
+    @Provides
+    public BigDecimal magicNumber(@Named("m1.prop") final String property) {
+      return new BigDecimal(42);
+    }
+  }
+  
+  @Path("/p")
+  public static class ProvidesInject {
+    
+    private BigDecimal magicNumber;
+    
+    @Inject
+    public ProvidesInject(BigDecimal magicNumber) {
+      this.magicNumber = requireNonNull(magicNumber, "The magicNumber is required.");
+    }
+    
+    @GET
+    @Path("/property")
+    public Object property() {
+      return magicNumber;
+    }
+  }
+
+  {
+
+    // don't use application.conf
+    use(ConfigFactory.empty());
+
+    use(new ModulePropertiesFeature.M1());
+  
+    use(new M2());
+
+    use(ProvidesInject.class);
+  }
+  
+  @Test
+  public void providesProperty() throws Exception {
+    request()
+        .get("/p/property")
+        .expect("42");
+  }
+}


### PR DESCRIPTION
When using dependency injection for modules that rely heavily on providers, Guice's `@Provides` support (https://github.com/google/guice/wiki/ProvidesMethods) can be used to reduce the boilerplate that's otherwise required when registering `Provider` classes. Currently these annotations are not supported by Jooby.

With this pull request I'm proposing to add a method call in the Jooby `install` method that binds these annotated methods by using existing Guice functionality to generate a module for this. If a module has no such methods, the call will essentially be a no-op.

I'm curious to hear what you think about this proposal @jknack and thanks in advance for considering it.