### PR TITLE
Update jQuery to 2.2.4, jquery-ui to 1.12.1

### DIFF
--- a/modules/coverage-report/src/test/java/org/jooby/AssetFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/AssetFeature.java
@@ -71,7 +71,7 @@ public class AssetFeature extends ServerFeature {
         .get("/assets/jquery-2.1.4.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", 247597)
+        .header("Content-Length", 257551)
         .header("Last-Modified", lastModified -> {
           request()
               .get("/assets/file.js")

--- a/modules/coverage-report/src/test/java/org/jooby/AssetHandlerFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/AssetHandlerFeature.java
@@ -69,10 +69,10 @@ public class AssetHandlerFeature extends ServerFeature {
   @Test
   public void largeFile() throws Exception {
     request()
-        .get("/assets/jquery-2.1.4.js")
+        .get("/assets/jquery-2.2.4.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", 247597)
+        .header("Content-Length", 257551)
         .header("Last-Modified", lastModified -> {
           request()
               .get("/assets/file.js")

--- a/modules/coverage-report/src/test/java/org/jooby/AssetLocationFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/AssetLocationFeature.java
@@ -32,25 +32,25 @@ public class AssetLocationFeature extends ServerFeature {
   @Test
   public void webjars() throws Exception {
     request()
-        .get("/js/jquery/2.1.3/jquery.js")
+        .get("/js/jquery/2.2.4/jquery.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", "247387");
+        .header("Content-Length", "257551");
 
     request()
-        .get("/js/jquery/2.1.3/jquery.min.js")
+        .get("/js/jquery/2.2.4/jquery.min.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", "84355");
+        .header("Content-Length", "85613");
   }
 
   @Test
   public void webjarsMapping() throws Exception {
     request()
-        .get("/js/lib/jquery-2.1.3.js")
+        .get("/js/lib/jquery-2.1.4.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", "247387");
+        .header("Content-Length", "257551");
 
   }
 

--- a/modules/coverage-report/src/test/java/org/jooby/AssetResolveNextFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/AssetResolveNextFeature.java
@@ -22,7 +22,7 @@ public class AssetResolveNextFeature extends ServerFeature {
   @Test
   public void secondLocation() throws Exception {
     request()
-        .get("/assets/js/jquery-2.1.3.js")
+        .get("/assets/js/jquery-2.1.4.js")
         .expect(200);
   }
 

--- a/modules/coverage-report/src/test/java/org/jooby/WebJarFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/WebJarFeature.java
@@ -13,22 +13,22 @@ public class WebJarFeature extends ServerFeature {
   @Test
   public void jquery() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", 247387);
+        .header("Content-Length", 257551);
 
     request()
-        .get("/webjars/jquery/2.1.3/jquery.min.js")
+        .get("/webjars/jquery/2.2.4/jquery.min.js")
         .expect(200)
         .header("Content-Type", "application/javascript;charset=UTF-8")
-        .header("Content-Length", 84355);
+        .header("Content-Length", 85613);
 
     request()
-        .get("/webjars/jquery/2.1.3/jquery.min.map")
+        .get("/webjars/jquery/2.2.4/jquery.min.map")
         .expect(200)
         .header("Content-Type", "text/plain;charset=UTF-8")
-        .header("Content-Length", 127542);
+        .header("Content-Length", 129572);
   }
 
   @Test

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue1194.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue1194.java
@@ -1,0 +1,22 @@
+package org.jooby.issues;
+
+import org.jooby.Results;
+import org.jooby.test.JoobySuite;
+import org.jooby.test.ServerFeature;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JoobySuite.class)
+public class Issue1194 extends ServerFeature {
+
+    {
+        get("/async", promise(deferred -> deferred.resolve(Results.ok())));
+    }
+
+    @Test
+    public void deferredResolveWithEmptyBodyShouldCloseRequest() throws Exception {
+        request().get("/async").expect(200).header("Content-Length", "0");
+    }
+}

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue131.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue131.java
@@ -7,7 +7,7 @@ public class Issue131 extends ServerFeature {
 
   {
 
-    assets("/swagger/ui/**", "/META-INF/resources/webjars/swagger-ui/3.14.2/{0}");
+    assets("/swagger/ui/**", "/META-INF/resources/webjars/swagger-ui/3.17.1/{0}");
 
   }
 
@@ -16,6 +16,6 @@ public class Issue131 extends ServerFeature {
     request()
         .get("/swagger/ui/swagger-ui.js")
         .expect(200)
-        .header("Content-Length", 366799);
+        .header("Content-Length", 635428);
   }
 }

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue498.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue498.java
@@ -6,7 +6,8 @@ import static org.junit.Assert.assertTrue;
 import org.jooby.test.ServerFeature;
 import org.junit.Test;
 
-import com.couchbase.client.deps.io.netty.util.internal.chmv8.ForkJoinPool;
+import java.util.concurrent.ForkJoinPool;
+
 
 public class Issue498 extends ServerFeature {
 

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue542b.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue542b.java
@@ -51,7 +51,7 @@ public class Issue542b extends ServerFeature {
         .expect(206)
         .expect(bytes(0, 257551))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 0-247386/257551")
+        .header("Content-Range", "bytes 0-257550/257551")
         .header("Content-Length", "257551");
   }
 
@@ -63,7 +63,7 @@ public class Issue542b extends ServerFeature {
         .expect(206)
         .expect(bytes(257551 - 100, 257551))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 247287-247386/257551")
+        .header("Content-Range", "bytes 257451-257550/257551")
         .header("Content-Length", "100");
   }
 

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue542b.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue542b.java
@@ -17,68 +17,68 @@ public class Issue542b extends ServerFeature {
   @Test
   public void shouldGetFullContent() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .expect(200)
-        .header("Content-Length", "247387");
+        .header("Content-Length", "257551");
   }
 
   @Test
   public void shouldGetPartialContent() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .header("Range", "bytes=0-99")
         .expect(206)
         .expect(bytes(0, 100))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 0-99/247387")
+        .header("Content-Range", "bytes 0-99/257551")
         .header("Content-Length", "100");
 
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .header("Range", "bytes=100-199")
         .expect(206)
         .expect(bytes(100, 200))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 100-199/247387")
+        .header("Content-Range", "bytes 100-199/257551")
         .header("Content-Length", "100");
   }
 
   @Test
   public void shouldGetPartialContentByPrefix() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .header("Range", "bytes=0-")
         .expect(206)
-        .expect(bytes(0, 247387))
+        .expect(bytes(0, 257551))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 0-247386/247387")
-        .header("Content-Length", "247387");
+        .header("Content-Range", "bytes 0-247386/257551")
+        .header("Content-Length", "257551");
   }
 
   @Test
   public void shouldGetPartialContentBySuffix() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .header("Range", "bytes=-100")
         .expect(206)
-        .expect(bytes(247387 - 100, 247387))
+        .expect(bytes(257551 - 100, 257551))
         .header("Accept-Ranges", "bytes")
-        .header("Content-Range", "bytes 247287-247386/247387")
+        .header("Content-Range", "bytes 247287-247386/257551")
         .header("Content-Length", "100");
   }
 
   @Test
   public void shouldGet416() throws Exception {
     request()
-        .get("/webjars/jquery/2.1.3/jquery.js")
+        .get("/webjars/jquery/2.2.4/jquery.js")
         .header("Range", "bytes=200-100")
         .expect(416)
-        .header("Content-Range", "bytes */247387");
+        .header("Content-Range", "bytes */257551");
   }
 
   private byte[] bytes(final int offset, final int len) throws IOException {
     try (InputStream stream = getClass()
-        .getResourceAsStream("/META-INF/resources/webjars/jquery/2.1.3/jquery.js")) {
+        .getResourceAsStream("/META-INF/resources/webjars/jquery/2.2.4/jquery.js")) {
       byte[] range = new byte[len - offset];
       byte[] bytes = ByteStreams.toByteArray(stream);
       System.arraycopy(bytes, offset, range, 0, len - offset);

--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue616.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue616.java
@@ -9,8 +9,8 @@ public class Issue616 extends ServerFeature {
   public static class Person {
 
     // mandatory fields
-    private final String name;
-    private final String surname;
+    private String name = null;
+    private String surname = null;
 
     // optional fields
     private String nickname;
@@ -18,6 +18,9 @@ public class Issue616 extends ServerFeature {
     public Person(final String name, final String surname) {
       this.name = name;
       this.surname = surname;
+    }
+
+    public Person() {
     }
 
     public String getName() {

--- a/modules/jooby-couchbase/src/main/java/org/jooby/couchbase/Couchbase.java
+++ b/modules/jooby-couchbase/src/main/java/org/jooby/couchbase/Couchbase.java
@@ -203,7 +203,6 @@
  */
 package org.jooby.couchbase;
 
-import com.couchbase.client.deps.io.netty.util.internal.MessagePassingQueue.Supplier;
 import com.couchbase.client.java.AsyncBucket;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.ConnectionString;
@@ -641,7 +640,7 @@ public class Couchbase implements Module {
    * @param env Environment provider.
    * @return This module.
    */
-  public Couchbase environment(final Supplier<CouchbaseEnvironment> env) {
+  public Couchbase environment(final java.util.function.Supplier<CouchbaseEnvironment> env) {
     return environment(c -> env.get());
   }
 

--- a/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyResponse.java
+++ b/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyResponse.java
@@ -483,6 +483,7 @@ public class NettyResponse implements NativeResponse {
         } else {
           ctx.write(rsp).addListener(CLOSE);
         }
+        ctx.flush();
         committed = true;
       }
       ctx = null;

--- a/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettyResponseTest.java
+++ b/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettyResponseTest.java
@@ -1005,6 +1005,7 @@ public class NettyResponseTest {
           expect(ctx.voidPromise()).andReturn(promise);
           expect(ctx.write(unit.get(HttpResponse.class), promise))
               .andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class), bufferSize, true)
@@ -1041,6 +1042,7 @@ public class NettyResponseTest {
         .expect(unit -> {
           ChannelHandlerContext ctx = unit.get(ChannelHandlerContext.class);
           expect(ctx.write(unit.get(HttpResponse.class))).andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class), bufferSize, false)
@@ -1083,6 +1085,7 @@ public class NettyResponseTest {
           expect(ctx.voidPromise()).andReturn(promise);
           expect(ctx.write(unit.get(HttpResponse.class), promise))
               .andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class),

--- a/pom.xml
+++ b/pom.xml
@@ -1974,6 +1974,17 @@
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>${depencency-check-maven.version}</version>
+          <configuration>
+            <skipProvidedScope>true</skipProvidedScope>
+            <skipRuntimeScope>true</skipRuntimeScope>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -3017,84 +3028,84 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
 
   <properties>
     <!-- Dependencies -->
-    <akka.version>2.5.9</akka.version>
+    <akka.version>2.5.13</akka.version>
     <antlr4-runtime.version>4.7</antlr4-runtime.version>
     <api-console.version>3.0.17</api-console.version>
     <asm.version>6.2</asm.version>
-    <async-http-client.version>1.9.36</async-http-client.version>
+    <async-http-client.version>1.9.40</async-http-client.version>
     <avaje-agentloader.version>2.1.2</avaje-agentloader.version>
-    <aws-java-sdk.version>1.11.273</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.356</aws-java-sdk.version>
     <bootstrap.version>3.3.4</bootstrap.version>
     <boringssl.version>2.0.8.Final</boringssl.version>
-    <bson4jackson.version>2.9.0</bson4jackson.version>
-    <caffeine.version>2.6.1</caffeine.version>
+    <bson4jackson.version>2.9.2</bson4jackson.version>
+    <caffeine.version>2.6.2</caffeine.version>
     <camel.version>2.18.3</camel.version>
-    <cglib.version>3.2.0</cglib.version>
-    <closure-compiler.version>v20180204</closure-compiler.version>
+    <cglib.version>3.2.6</cglib.version>
+    <closure-compiler.version>v20180610</closure-compiler.version>
     <commons-compress.version>1.17</commons-compress.version>
     <commons-email.version>1.5</commons-email.version>
     <lucene-queryparser.version>5.5.5</lucene-queryparser.version>
     <bcprov-jdk15on.version>1.59</bcprov-jdk15on.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-lang3.version>3.4</commons-lang3.version>
-    <config.version>1.3.2</config.version>
-    <consul.version>1.0.1</consul.version>
-    <crash.version>1.3.1</crash.version>
+    <commons-lang3.version>3.7</commons-lang3.version>
+    <config.version>1.3.3</config.version>
+    <consul.version>1.2.1</consul.version>
+    <crash.version>1.3.2</crash.version>
     <dse-driver.version>1.1.2</dse-driver.version>
     <ebean-agent.version>11.11.1</ebean-agent.version>
     <ebean-maven-plugin.version>11.11.2</ebean-maven-plugin.version>
-    <ebean.version>11.16.1</ebean.version>
-    <ehcache.version>2.10.0</ehcache.version>
+    <ebean.version>11.18.2</ebean.version>
+    <ehcache.version>2.10.5</ehcache.version>
     <elasticsearch>5.5.3</elasticsearch>
-    <flyway.version>5.0.7</flyway.version>
+    <flyway.version>5.1.3</flyway.version>
     <freemarker.version>2.3.28</freemarker.version>
     <frontend-plugin-core.version>1.6</frontend-plugin-core.version>
     <funzy.version>0.1.0</funzy.version>
     <groovy.version>2.4.7</groovy.version>
-    <gson.version>2.8.2</gson.version>
+    <gson.version>2.8.5</gson.version>
     <guava.version>21.0</guava.version> <!-- TODO: upgrade to =< 24.1.1 -->
     <guice.version>4.2.0</guice.version>
-    <h2.version>1.4.196</h2.version>
-    <handlebars.version>4.0.7</handlebars.version>
-    <hazelcast.version>3.9.2</hazelcast.version>
+    <h2.version>1.4.197</h2.version>
+    <handlebars.version>4.1.0</handlebars.version>
+    <hazelcast.version>3.10.2</hazelcast.version>
     <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
     <hibernate.version>5.2.1.Final</hibernate.version>
     <hikariCP.version>3.2.0</hikariCP.version>
-    <http-client.version>4.5.2</http-client.version>
+    <http-client.version>4.5.5</http-client.version>
     <j2v8.version>4.6.0</j2v8.version>
-    <jackson.version>2.9.5</jackson.version>
+    <jackson.version>2.9.6</jackson.version>
     <jade4j.version>1.2.7</jade4j.version>
     <javassist.version>3.22.0-GA</javassist.version>
-    <javax.el-api.version>2.2.5</javax.el-api.version>
-    <javax.el-ref.version>2.2.6</javax.el-ref.version>
+    <javax.el-api.version>2.2.5</javax.el-api.version> <!-- TODO: upgrade to 3.0.0 -->
+    <javax.el-ref.version>2.2.6</javax.el-ref.version> <!-- TODO: upgrade to 3.0.0 -->
     <javax.inject.version>1</javax.inject.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <jboss-modules.version>1.8.5.Final</jboss-modules.version>
     <jcypher.version>3.9.0</jcypher.version>
     <jdbi.version>2.78</jdbi.version>
-    <jdbi3.version>3.2.1</jdbi3.version>
+    <jdbi3.version>3.3.0</jdbi3.version>
     <jedis.version>2.9.0</jedis.version>
     <jersey-client.version>1.19.1</jersey-client.version>
     <jetty.version>9.4.10.v20180503</jetty.version>
     <jongo.version>1.4.0</jongo.version>
     <jquery-ui.version>1.11.3</jquery-ui.version>
     <jquery.version>2.1.3</jquery.version> <!-- TODO: update to 3.1.1 -->
-    <jruby.version>9.0.1.0</jruby.version>
+    <jruby.version>9.2.0.0</jruby.version>
     <jsass.version>5.2.0</jsass.version>
-    <jsoup.version>1.8.3</jsoup.version>
+    <jsoup.version>1.11.3</jsoup.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <kotlin.version>1.2.41</kotlin.version>
-    <less4j.version>1.13.0</less4j.version>
+    <kotlin.version>1.2.50</kotlin.version>
+    <less4j.version>1.17.2</less4j.version>
     <log4jdbc.version>1.2</log4jdbc.version>
     <logback-classic.version>1.2.3</logback-classic.version>
-    <metrics.version>3.1.2</metrics.version>
-    <mongo-driver-core.version>3.2.2</mongo-driver-core.version>
-    <mongo-java-driver.version>3.2.2</mongo-java-driver.version>
+    <metrics.version>4.0.2</metrics.version>
+    <mongo-driver-core.version>3.8.0</mongo-driver-core.version> <!-- TODO: upgrade to 3.8.0 -->
+    <mongo-java-driver.version>3.8.0</mongo-java-driver.version> <!-- TODO: upgrade to 3.8.0 -->
     <mongodb-driver-async.version>${mongo-java-driver.version}</mongodb-driver-async.version>
-    <morphia.version>1.1.1</morphia.version>
-    <mysql-connector-java.version>5.1.42</mysql-connector-java.version>
-    <neo4j.expire.version>3.3.2.52.4</neo4j.expire.version>
-    <neo4j.runtime.version>3.3.2.52</neo4j.runtime.version>
+    <morphia.version>1.3.2</morphia.version>
+    <mysql-connector-java.version>5.1.42</mysql-connector-java.version> <!-- TODO: upgrade to 8.0.11 -->
+    <neo4j.expire.version>3.4.0.52.4</neo4j.expire.version>
+    <neo4j.runtime.version>3.4.0.52</neo4j.runtime.version>
     <neo4j.version>3.3.2</neo4j.version>
     <netty.version>4.1.25.Final</netty.version>
     <pac4j.version>1.9.9</pac4j.version>
@@ -3102,24 +3113,24 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <pebble.version>2.4.0</pebble.version>
     <pgjdbc-ng.version>0.7.1</pgjdbc-ng.version>
     <progressbar.version>0.6.0</progressbar.version>
-    <quartz.version>2.2.2</quartz.version>
+    <quartz.version>2.3.0</quartz.version>
     <reactor.version>2.5.0.M3</reactor.version>
-    <requery.version>1.4.0</requery.version>
+    <requery.version>1.5.1</requery.version>
     <rest-assured.version>3.1.0</rest-assured.version>
-    <rocker.version>0.23.0</rocker.version>
-    <rxjava-jdbc.version>0.7</rxjava-jdbc.version>
+    <rocker.version>0.24.0</rocker.version>
+    <rxjava-jdbc.version>0.7.16</rxjava-jdbc.version>
     <rxjava-math.version>1.0.0</rxjava-math.version>
-    <rxjava-string.version>1.1.0</rxjava-string.version>
-    <rxjava.version>1.1.5</rxjava.version>
+    <rxjava-string.version>1.1.1</rxjava-string.version>
+    <rxjava.version>1.1.5</rxjava.version> <!-- TODO: update to 1.3.8 -->
     <rxjava2.version>2.0.7</rxjava2.version>
     <servlet.version>3.1.0</servlet.version>
     <slf4j-api.version>1.7.25</slf4j-api.version>
     <slf4j-ext.version>1.7.25</slf4j-ext.version>
     <snakeyaml.version>1.19</snakeyaml.version>
-    <spymemcached.version>2.12.0</spymemcached.version>
+    <spymemcached.version>2.12.3</spymemcached.version>
     <swagger-parser.version>1.0.36</swagger-parser.version>
     <swagger-ui-themes.version>3.0.0</swagger-ui-themes.version>
-    <swagger-ui.version>3.14.2</swagger-ui.version>
+    <swagger-ui.version>3.17.1</swagger-ui.version>
     <swagger.version>1.5.20</swagger.version>
     <thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
     <undertow.version>1.4.25.Final</undertow.version>
@@ -3131,7 +3142,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <ebean.agent.args>debug=0</ebean.agent.args>
 
     <!-- jooq -->
-    <jooq.version>3.7.3</jooq.version>
+    <jooq.version>3.11.2</jooq.version>
 
     <!-- QueryDSL -->
     <querydsl.version>4.1.4</querydsl.version>
@@ -3140,15 +3151,15 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <javaslang.version>2.0.4</javaslang.version>
 
     <batik.version>1.10</batik.version>
-    <cassandra.version>3.4.0</cassandra.version>
-    <couchbase-client.version>2.3.1</couchbase-client.version>
+    <cassandra.version>3.5.0</cassandra.version>
+    <couchbase-client.version>2.5.9</couchbase-client.version>
     <coverity-escapers.version>1.1.1</coverity-escapers.version>
-    <fast-classpath-scanner.version>2.8.1</fast-classpath-scanner.version>
-    <jfiglet.version>0.0.7</jfiglet.version>
-    <jsitemapgenerator.version>2.1</jsitemapgenerator.version>
+    <fast-classpath-scanner.version>3.1.6</fast-classpath-scanner.version>
+    <jfiglet.version>0.0.8</jfiglet.version>
+    <jsitemapgenerator.version>2.2</jsitemapgenerator.version>
     <mongo-driver-driver-rx.version>1.2.0</mongo-driver-driver-rx.version>
-    <unbescape.version>1.1.3.RELEASE</unbescape.version>
-    <zt-zip.version>1.9</zt-zip.version>
+    <unbescape.version>1.1.6.RELEASE</unbescape.version>
+    <zt-zip.version>1.13</zt-zip.version>
 
     <!-- Test dependencies -->
     <easymock.version>3.6</easymock.version>
@@ -3173,7 +3184,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
     <dokka-maven-plugin.version>0.9.13</dokka-maven-plugin.version>
     <duplicate-finder-maven-plugin.version>1.2.1</duplicate-finder-maven-plugin.version>
-    <exec-maven-plugin.version>1.3.2</exec-maven-plugin.version>
+    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>${jacoco.version}</jacoco-maven-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
@@ -3181,7 +3192,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-    <maven-core.version>3.3.3</maven-core.version>
+    <maven-core.version>3.5.4</maven-core.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
@@ -3189,8 +3200,8 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
     <maven-java-formatter-plugin.version>0.4</maven-java-formatter-plugin.version>
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-    <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
-    <maven-plugin-api.version>3.3.3</maven-plugin-api.version>
+    <maven-plugin-annotations.version>3.5.2</maven-plugin-annotations.version>
+    <maven-plugin-api.version>3.5.4</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
     <maven-project.version>2.2.1</maven-project.version>
     <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
@@ -3199,7 +3210,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <maven-source-plugin.version>2.4</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
-    <mojo-executor.version>2.2.0</mojo-executor.version>
+    <mojo-executor.version>2.3.0</mojo-executor.version>
     <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
     <plexus-utils.version>3.1.0</plexus-utils.version>
     <stork-maven-plugin.version>2.7.0</stork-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3088,8 +3088,8 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <jersey-client.version>1.19.1</jersey-client.version>
     <jetty.version>9.4.10.v20180503</jetty.version>
     <jongo.version>1.4.0</jongo.version>
-    <jquery-ui.version>1.11.3</jquery-ui.version>
-    <jquery.version>2.1.3</jquery.version> <!-- TODO: update to 3.1.1 -->
+    <jquery-ui.version>1.12.1</jquery-ui.version>
+    <jquery.version>2.2.4</jquery.version> <!-- TODO: update to 3.1.1 -->
     <jruby.version>9.2.0.0</jruby.version>
     <jsass.version>5.2.0</jsass.version>
     <jsoup.version>1.11.3</jsoup.version>


### PR DESCRIPTION
Hey there,
I did a little busywork upgrading jQuery to the latest stable 2.x release in the same vein as @feffi's version update crusade.
It's mostly a find & replace job, as the specific version of the artifact was referenced across a lot of different tests (maybe we could reduce that?). The whole thing is largely only relevant for testing but it posed a good starter, as I'm currently familiarizing myself with Jooby's test suites