### PR TITLE
Fix missing flush on Netty context

### DIFF
--- a/modules/coverage-report/src/test/java/org/jooby/issues/Issue1194.java
+++ b/modules/coverage-report/src/test/java/org/jooby/issues/Issue1194.java
@@ -1,0 +1,22 @@
+package org.jooby.issues;
+
+import org.jooby.Results;
+import org.jooby.test.JoobySuite;
+import org.jooby.test.ServerFeature;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JoobySuite.class)
+public class Issue1194 extends ServerFeature {
+
+    {
+        get("/async", promise(deferred -> deferred.resolve(Results.ok())));
+    }
+
+    @Test
+    public void deferredResolveWithEmptyBodyShouldCloseRequest() throws Exception {
+        request().get("/async").expect(200).header("Content-Length", "0");
+    }
+}

--- a/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyResponse.java
+++ b/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyResponse.java
@@ -483,6 +483,7 @@ public class NettyResponse implements NativeResponse {
         } else {
           ctx.write(rsp).addListener(CLOSE);
         }
+        ctx.flush();
         committed = true;
       }
       ctx = null;

--- a/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettyResponseTest.java
+++ b/modules/jooby-netty/src/test/java/org/jooby/internal/netty/NettyResponseTest.java
@@ -1005,6 +1005,7 @@ public class NettyResponseTest {
           expect(ctx.voidPromise()).andReturn(promise);
           expect(ctx.write(unit.get(HttpResponse.class), promise))
               .andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class), bufferSize, true)
@@ -1041,6 +1042,7 @@ public class NettyResponseTest {
         .expect(unit -> {
           ChannelHandlerContext ctx = unit.get(ChannelHandlerContext.class);
           expect(ctx.write(unit.get(HttpResponse.class))).andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class), bufferSize, false)
@@ -1083,6 +1085,7 @@ public class NettyResponseTest {
           expect(ctx.voidPromise()).andReturn(promise);
           expect(ctx.write(unit.get(HttpResponse.class), promise))
               .andReturn(unit.get(ChannelFuture.class));
+          expect(ctx.flush()).andReturn(ctx);
         })
         .run(unit -> {
           new NettyResponse(unit.get(ChannelHandlerContext.class), unit.get(HttpHeaders.class),


### PR DESCRIPTION
Fixes #1194

Seems like in that case, there was no context flush occurring, thus the response stayed in the context's buffer indefinitely.

At least I hope I parsed that right as this was my first experience debugging Netty-related code.