### PR TITLE
Fix broken module name badges

### DIFF
--- a/modules/jooby-assets-autoprefixer/README.md
+++ b/modules/jooby-assets-autoprefixer/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-autoprefixer/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-autoprefixer)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-autoprefixer.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-autoprefixer/1.4.1)
-[![jooby-assets-autoprefixer website](https://img.shields.io/badge/jooby-assets-autoprefixer-brightgreen.svg)](http://jooby.org/doc/assets-autoprefixer)
+[![jooby-assets-autoprefixer website](https://img.shields.io/badge/jooby-assets--autoprefixer-brightgreen.svg)](http://jooby.org/doc/assets-autoprefixer)
 # auto-prefixer
 
 <a href="https://github.com/postcss/postcss">PostCSS</a> plugin to parse CSS and add vendor prefixes to CSS rules using values from <a href="http://caniuse.com">Can I Use</a>. It is recommended by Google and used in Twitter, and Taobao.

--- a/modules/jooby-assets-babel/README.md
+++ b/modules/jooby-assets-babel/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-babel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-babel)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-babel.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-babel/1.4.1)
-[![jooby-assets-babel website](https://img.shields.io/badge/jooby-assets-babel-brightgreen.svg)](http://jooby.org/doc/assets-babel)
+[![jooby-assets-babel website](https://img.shields.io/badge/jooby-assets--babel-brightgreen.svg)](http://jooby.org/doc/assets-babel)
 # babel
 
 <a href="http://babeljs.io/">Babel</a> is a JavaScript compiler with a set of ES2015 syntax transformers that allow you to use new syntax, right now without waiting for browser support.

--- a/modules/jooby-assets-clean-css/README.md
+++ b/modules/jooby-assets-clean-css/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-clean-css/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-clean-css)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-clean-css.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-clean-css/1.4.1)
-[![jooby-assets-clean-css website](https://img.shields.io/badge/jooby-assets-clean-css-brightgreen.svg)](http://jooby.org/doc/assets-clean-css)
+[![jooby-assets-clean-css website](https://img.shields.io/badge/jooby-assets--clean--css-brightgreen.svg)](http://jooby.org/doc/assets-clean-css)
 # clean-css
 
 A fast, efficient, and well tested CSS minifier, via: <a href="https://github.com/jakubpawlowicz/clean-css">clean-css</a>

--- a/modules/jooby-assets-closure-compiler/README.md
+++ b/modules/jooby-assets-closure-compiler/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-closure-compiler/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-closure-compiler)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-closure-compiler.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-closure-compiler/1.4.1)
-[![jooby-assets-closure-compiler website](https://img.shields.io/badge/jooby-assets-closure-compiler-brightgreen.svg)](http://jooby.org/doc/assets-closure-compiler)
+[![jooby-assets-closure-compiler website](https://img.shields.io/badge/jooby-assets--closure--compiler-brightgreen.svg)](http://jooby.org/doc/assets-closure-compiler)
 # closure-compiler
 
 <a href="https://developers.google.com/closure/compiler">Closure Compiler</a> is a tool for making JavaScript download and run faster.

--- a/modules/jooby-assets-csslint/README.md
+++ b/modules/jooby-assets-csslint/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-csslint/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-csslint)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-csslint.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-csslint/1.4.1)
-[![jooby-assets-csslint website](https://img.shields.io/badge/jooby-assets-csslint-brightgreen.svg)](http://jooby.org/doc/assets-csslint)
+[![jooby-assets-csslint website](https://img.shields.io/badge/jooby-assets--csslint-brightgreen.svg)](http://jooby.org/doc/assets-csslint)
 # csslint
 
 <a href="http://csslint.net/">CSSLint</a> automated linting of Cascading Stylesheets.

--- a/modules/jooby-assets-jscs/README.md
+++ b/modules/jooby-assets-jscs/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-jscs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-jscs)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-jscs.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-jscs/1.4.1)
-[![jooby-assets-jscs website](https://img.shields.io/badge/jooby-assets-jscs-brightgreen.svg)](http://jooby.org/doc/assets-jscs)
+[![jooby-assets-jscs website](https://img.shields.io/badge/jooby-assets--jscs-brightgreen.svg)](http://jooby.org/doc/assets-jscs)
 # jscs
 
 <a href="http://jscs.info/">JavaScript Code Style checker</a>.

--- a/modules/jooby-assets-jshint/README.md
+++ b/modules/jooby-assets-jshint/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-jshint/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-jshint)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-jshint.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-jshint/1.4.1)
-[![jooby-assets-jshint website](https://img.shields.io/badge/jooby-assets-jshint-brightgreen.svg)](http://jooby.org/doc/assets-jshint)
+[![jooby-assets-jshint website](https://img.shields.io/badge/jooby-assets--jshint-brightgreen.svg)](http://jooby.org/doc/assets-jshint)
 # jshint
 
 <a href="http://jshint.com/">JSHint</a>, helps to detect errors and potential problems in code.

--- a/modules/jooby-assets-less/README.md
+++ b/modules/jooby-assets-less/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-less/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-less)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-less.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-less/1.4.1)
-[![jooby-assets-less website](https://img.shields.io/badge/jooby-assets-less-brightgreen.svg)](http://jooby.org/doc/assets-less)
+[![jooby-assets-less website](https://img.shields.io/badge/jooby-assets--less-brightgreen.svg)](http://jooby.org/doc/assets-less)
 # less
 
 <a href="http://lesscss.org/">Less</a> is a CSS pre-processor, meaning that it extends the CSS language, adding features that allow variables, mixins, functions and many other techniques that allow you to make CSS that is more maintainable, themable and extendable.

--- a/modules/jooby-assets-less4j/README.md
+++ b/modules/jooby-assets-less4j/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-less4j/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-less4j)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-less4j.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-less4j/1.4.1)
-[![jooby-assets-less4j website](https://img.shields.io/badge/jooby-assets-less4j-brightgreen.svg)](http://jooby.org/doc/assets-less4j)
+[![jooby-assets-less4j website](https://img.shields.io/badge/jooby-assets--less4j-brightgreen.svg)](http://jooby.org/doc/assets-less4j)
 # less4j
 
 <a href="https://github.com/SomMeri/less4j">Less4j</a> is a port of <a href="http://lesscss.org/">Less</a> written in Java. <a href="http://lesscss.org/">Less</a> is a CSS pre-processor, meaning that it extends the CSS language, adding features that allow variables, mixins, functions and many other techniques that allow you to make CSS that is more maintainable, themable and extendable.

--- a/modules/jooby-assets-ng-annotate/README.md
+++ b/modules/jooby-assets-ng-annotate/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-ng-annotate/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-ng-annotate)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-ng-annotate.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-ng-annotate/1.4.1)
-[![jooby-assets-ng-annotate website](https://img.shields.io/badge/jooby-assets-ng-annotate-brightgreen.svg)](http://jooby.org/doc/assets-ng-annotate)
+[![jooby-assets-ng-annotate website](https://img.shields.io/badge/jooby-assets--ng--annotate-brightgreen.svg)](http://jooby.org/doc/assets-ng-annotate)
 # ng-annotate
 
 <a href="https://github.com/olov/ng-annotate">ng-annotate</a> add, remove and rebuild AngularJS dependency injection annotations.

--- a/modules/jooby-assets-requirejs/README.md
+++ b/modules/jooby-assets-requirejs/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-requirejs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-requirejs)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-requirejs.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-requirejs/1.4.1)
-[![jooby-assets-requirejs website](https://img.shields.io/badge/jooby-assets-requirejs-brightgreen.svg)](http://jooby.org/doc/assets-requirejs)
+[![jooby-assets-requirejs website](https://img.shields.io/badge/jooby-assets--requirejs-brightgreen.svg)](http://jooby.org/doc/assets-requirejs)
 # rjs
 
 <a href="http://requirejs.org/docs/optimization.html">require.js optimizer</a> resolve and optimize require.js files.

--- a/modules/jooby-assets-rollup/README.md
+++ b/modules/jooby-assets-rollup/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-rollup/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-rollup)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-rollup.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-rollup/1.4.1)
-[![jooby-assets-rollup website](https://img.shields.io/badge/jooby-assets-rollup-brightgreen.svg)](http://jooby.org/doc/assets-rollup)
+[![jooby-assets-rollup website](https://img.shields.io/badge/jooby-assets--rollup-brightgreen.svg)](http://jooby.org/doc/assets-rollup)
 # rollup.js
 
 <a href="http://rollupjs.org/">rollup.js</a> the next-generation ES6 module bundler.

--- a/modules/jooby-assets-sass/README.md
+++ b/modules/jooby-assets-sass/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-sass/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-sass)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-sass.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-sass/1.4.1)
-[![jooby-assets-sass website](https://img.shields.io/badge/jooby-assets-sass-brightgreen.svg)](http://jooby.org/doc/assets-sass)
+[![jooby-assets-sass website](https://img.shields.io/badge/jooby-assets--sass-brightgreen.svg)](http://jooby.org/doc/assets-sass)
 # sass
 
 <a href="http://sass-lang.com/">sass-lang</a> implementation from <a href="https://github.com/bit3/jsass">Java sass compiler</a>. Sass is the most mature, stable, and powerful professional grade CSS extension language in the world.

--- a/modules/jooby-assets-svg-sprites/README.md
+++ b/modules/jooby-assets-svg-sprites/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-svg-sprites/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-svg-sprites)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-svg-sprites.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-svg-sprites/1.4.1)
-[![jooby-assets-svg-sprites website](https://img.shields.io/badge/jooby-assets-svg-sprites-brightgreen.svg)](http://jooby.org/doc/assets-svg-sprites)
+[![jooby-assets-svg-sprites website](https://img.shields.io/badge/jooby-assets--svg--sprites-brightgreen.svg)](http://jooby.org/doc/assets-svg-sprites)
 # svg-sprites
 
 An [AssetAggregator](/apidocs/org/jooby/assets/AssetAggregator.html) that creates SVG sprites with PNG fallbacks at needed sizes via <a href="https://github.com/drdk/dr-svg-sprites">dr-svg-sprites</a>.

--- a/modules/jooby-assets-svg-symbol/README.md
+++ b/modules/jooby-assets-svg-symbol/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-svg-symbol/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-svg-symbol)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-svg-symbol.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-svg-symbol/1.4.1)
-[![jooby-assets-svg-symbol website](https://img.shields.io/badge/jooby-assets-svg-symbol-brightgreen.svg)](http://jooby.org/doc/assets-svg-symbol)
+[![jooby-assets-svg-symbol website](https://img.shields.io/badge/jooby-assets--svg--symbol-brightgreen.svg)](http://jooby.org/doc/assets-svg-symbol)
 # svg-symbol
 
 SVG ```symbol``` for icons: merge svg files from a folder and generates a ```sprite.svg``` and ```sprite.css``` files.

--- a/modules/jooby-assets-uglify/README.md
+++ b/modules/jooby-assets-uglify/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-uglify/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-uglify)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-uglify.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-uglify/1.4.1)
-[![jooby-assets-uglify website](https://img.shields.io/badge/jooby-assets-uglify-brightgreen.svg)](http://jooby.org/doc/assets-uglify)
+[![jooby-assets-uglify website](https://img.shields.io/badge/jooby-assets--uglify-brightgreen.svg)](http://jooby.org/doc/assets-uglify)
 # uglify
 
 <a href="https://github.com/mishoo/UglifyJS2">UglifyJs2</a> JavaScript parser / mangler / compressor / beautifier toolkit.

--- a/modules/jooby-assets-yui-compressor/README.md
+++ b/modules/jooby-assets-yui-compressor/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-yui-compressor/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-assets-yui-compressor)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-assets-yui-compressor.svg)](https://javadoc.io/doc/org.jooby/jooby-assets-yui-compressor/1.4.1)
-[![jooby-assets-yui-compressor website](https://img.shields.io/badge/jooby-assets-yui-compressor-brightgreen.svg)](http://jooby.org/doc/assets-yui-compressor)
+[![jooby-assets-yui-compressor website](https://img.shields.io/badge/jooby-assets--yui--compressor-brightgreen.svg)](http://jooby.org/doc/assets-yui-compressor)
 # yui-css
 
 <a href="http://yui.github.io/yuicompressor">Yui compressor</a>.

--- a/modules/jooby-commons-email/README.md
+++ b/modules/jooby-commons-email/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-commons-email/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-commons-email)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-commons-email.svg)](https://javadoc.io/doc/org.jooby/jooby-commons-email/1.4.1)
-[![jooby-commons-email website](https://img.shields.io/badge/jooby-commons-email-brightgreen.svg)](http://jooby.org/doc/commons-email)
+[![jooby-commons-email website](https://img.shields.io/badge/jooby-commons--email-brightgreen.svg)](http://jooby.org/doc/commons-email)
 # commons-email
 
 Email supports via [Apache Commons Email](https://commons.apache.org/proper/commons-email).

--- a/modules/jooby-gradle-plugin/README.md
+++ b/modules/jooby-gradle-plugin/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-gradle-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-gradle-plugin)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-gradle-plugin.svg)](https://javadoc.io/doc/org.jooby/jooby-gradle-plugin/1.4.1)
-[![jooby-gradle-plugin website](https://img.shields.io/badge/jooby-gradle-plugin-brightgreen.svg)](http://jooby.org/doc/gradle-plugin)
+[![jooby-gradle-plugin website](https://img.shields.io/badge/jooby-gradle--plugin-brightgreen.svg)](http://jooby.org/doc/gradle-plugin)
 # gradle plugin
 
 Collection of [Gradle](http://gradle.org) plugins for [Jooby](http://jooby.org) applications.

--- a/modules/jooby-guava-cache/README.md
+++ b/modules/jooby-guava-cache/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-guava-cache/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-guava-cache)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-guava-cache.svg)](https://javadoc.io/doc/org.jooby/jooby-guava-cache/1.4.1)
-[![jooby-guava-cache website](https://img.shields.io/badge/jooby-guava-cache-brightgreen.svg)](http://jooby.org/doc/guava-cache)
+[![jooby-guava-cache website](https://img.shields.io/badge/jooby-guava--cache-brightgreen.svg)](http://jooby.org/doc/guava-cache)
 # guava-cache
 
 Provides cache solution and session storage via: <a href="https://github.com/google/guava">Guava</a>.

--- a/modules/jooby-lang-kotlin/README.md
+++ b/modules/jooby-lang-kotlin/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-lang-kotlin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-lang-kotlin)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-lang-kotlin.svg)](https://javadoc.io/doc/org.jooby/jooby-lang-kotlin/1.4.1)
-[![jooby-lang-kotlin website](https://img.shields.io/badge/jooby-lang-kotlin-brightgreen.svg)](http://jooby.org/doc/lang-kotlin)
+[![jooby-lang-kotlin website](https://img.shields.io/badge/jooby-lang--kotlin-brightgreen.svg)](http://jooby.org/doc/lang-kotlin)
 # kotlin
 
 A tiny module that makes a Jooby application more Kotlin idiomatic.

--- a/modules/jooby-maven-plugin/README.md
+++ b/modules/jooby-maven-plugin/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-maven-plugin)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-maven-plugin.svg)](https://javadoc.io/doc/org.jooby/jooby-maven-plugin/1.4.1)
-[![jooby-maven-plugin website](https://img.shields.io/badge/jooby-maven-plugin-brightgreen.svg)](http://jooby.org/doc/maven-plugin)
+[![jooby-maven-plugin website](https://img.shields.io/badge/jooby-maven--plugin-brightgreen.svg)](http://jooby.org/doc/maven-plugin)
 # maven
 
 [Maven 3+](http://maven.apache.org/) plugin for running, debugging and reloading your application.

--- a/modules/jooby-mongodb-rx/README.md
+++ b/modules/jooby-mongodb-rx/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-mongodb-rx/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-mongodb-rx)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-mongodb-rx.svg)](https://javadoc.io/doc/org.jooby/jooby-mongodb-rx/1.4.1)
-[![jooby-mongodb-rx website](https://img.shields.io/badge/jooby-mongodb-rx-brightgreen.svg)](http://jooby.org/doc/mongodb-rx)
+[![jooby-mongodb-rx website](https://img.shields.io/badge/jooby-mongodb--rx-brightgreen.svg)](http://jooby.org/doc/mongodb-rx)
 # mongodb-rx
 
 <a href="http://mongodb.github.io/mongo-java-driver-rx/">MongoDB RxJava Driver: </a> provides composable asynchronous and event-based observable sequences for MongoDB.

--- a/modules/jooby-rxjava-jdbc/README.md
+++ b/modules/jooby-rxjava-jdbc/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-rxjava-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jooby/jooby-rxjava-jdbc)
 [![javadoc](https://javadoc.io/badge/org.jooby/jooby-rxjava-jdbc.svg)](https://javadoc.io/doc/org.jooby/jooby-rxjava-jdbc/1.4.1)
-[![jooby-rxjava-jdbc website](https://img.shields.io/badge/jooby-rxjava-jdbc-brightgreen.svg)](http://jooby.org/doc/rxjava-jdbc)
+[![jooby-rxjava-jdbc website](https://img.shields.io/badge/jooby-rxjava--jdbc-brightgreen.svg)](http://jooby.org/doc/rxjava-jdbc)
 # rxjdbc
 
 <a href="https://github.com/davidmoten/rxjava-jdbc">rxjava-jdbc</a> efficient execution, concise code, and functional composition of database calls using JDBC and RxJava Observable.


### PR DESCRIPTION
A backslash needs to be escaped by a backslash in status.

see https://shields.io/#your-badge