### PR TITLE
added info about empty folder

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -17,7 +17,7 @@ requirements
 quickstart
 =====
 
-Just paste this into a terminal (make sure [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [Maven 3.x](http://maven.apache.org/download.cgi) are installed):
+Just paste this into a terminal (make sure you are in an empty folder, and [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [Maven 3.x](http://maven.apache.org/download.cgi) are installed):
 
 ```bash
 mvn archetype:generate -B -DgroupId=com.mycompany -DartifactId=my-app -Dversion=1.0-SNAPSHOT -DarchetypeArtifactId=jooby-archetype -DarchetypeGroupId=org.jooby -DarchetypeVersion={{version}}


### PR DESCRIPTION
If you execute archetype:generate in a non-empty folder, if may fail with this exception:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.0.1:generate (default-cli) on project XYZ: org.apache.maven.archetype.exception.InvalidPackaging: Unable to add module to the current project as it is not of packaging type 'pom'.

Therefore I added the text "make sure you are in an empty folder,..." to the quickstart.md.