### PR TITLE
Upgrade to Hibernate 5.3.9

### DIFF
--- a/modules/jooby-hbm/pom.xml
+++ b/modules/jooby-hbm/pom.xml
@@ -37,10 +37,16 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- CDI Api; https://hibernate.atlassian.net/browse/HHH-11370 -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+    </dependency>
+
     <!-- Hibernate -->
     <dependency>
       <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-entitymanager</artifactId>
+      <artifactId>hibernate-core</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/modules/jooby-hbm/src/main/java/org/jooby/hbm/Hbm.java
+++ b/modules/jooby-hbm/src/main/java/org/jooby/hbm/Hbm.java
@@ -765,7 +765,10 @@ public class Hbm implements Jooby.Module {
     this.ssrb.accept(ssrb, conf);
 
     ssrb.applySetting(AvailableSettings.DATASOURCE, ds);
-    ssrb.applySetting(org.hibernate.jpa.AvailableSettings.DELAY_CDI_ACCESS, true);
+    ssrb.applySetting(org.hibernate.cfg.AvailableSettings.DELAY_CDI_ACCESS, true);
+
+    CompletableFuture<Registry> registry = new CompletableFuture<>();
+    ssrb.applySetting(org.hibernate.cfg.AvailableSettings.CDI_BEAN_MANAGER, GuiceBeanManager.beanManager(registry));
 
     StandardServiceRegistry serviceRegistry = ssrb.build();
 
@@ -787,9 +790,6 @@ public class Hbm implements Jooby.Module {
     SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
     this.sfb.accept(sfb, conf);
     sfb.applyName(name);
-
-    CompletableFuture<Registry> registry = new CompletableFuture<>();
-    sfb.applyBeanManager(GuiceBeanManager.beanManager(registry));
 
     SessionFactory sessionFactory = sfb.build();
     this.sf.accept(sessionFactory, conf);

--- a/modules/jooby-hbm/src/main/java/org/jooby/hbm/Hbm.java
+++ b/modules/jooby-hbm/src/main/java/org/jooby/hbm/Hbm.java
@@ -222,7 +222,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
-import org.hibernate.jpa.event.spi.JpaIntegrator;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.jooby.Env;
 import org.jooby.Env.ServiceKey;
@@ -752,7 +751,6 @@ public class Hbm implements Jooby.Module {
         .orElseThrow(() -> new NoSuchElementException("DataSource missing: " + dskey));
 
     BootstrapServiceRegistryBuilder bsrb = new BootstrapServiceRegistryBuilder();
-    bsrb.applyIntegrator(new JpaIntegrator());
 
     this.bsrb.accept(bsrb, conf);
 

--- a/modules/jooby-hbm/src/test/java/org/jooby/hbm/HbmTest.java
+++ b/modules/jooby-hbm/src/test/java/org/jooby/hbm/HbmTest.java
@@ -912,13 +912,18 @@ public class HbmTest {
     return unit -> {
       unit.mockStatic(GuiceBeanManager.class);
 
+      StandardServiceRegistryBuilder ssrb = unit.get(StandardServiceRegistryBuilder.class);
+
+      expect(ssrb.applySetting(org.hibernate.cfg.AvailableSettings.DELAY_CDI_ACCESS, true))
+                .andReturn(ssrb);
+
       BeanManager bm = unit.mock(BeanManager.class);
       unit.registerMock(BeanManager.class, bm);
 
       expect(GuiceBeanManager.beanManager(unit.capture(CompletableFuture.class))).andReturn(bm);
 
-      SessionFactoryBuilder sfb = unit.get(SessionFactoryBuilder.class);
-      expect(sfb.applyBeanManager(bm)).andReturn(sfb);
+      expect(ssrb.applySetting(org.hibernate.cfg.AvailableSettings.CDI_BEAN_MANAGER, bm))
+                .andReturn(ssrb);
     };
   }
 
@@ -1002,8 +1007,6 @@ public class HbmTest {
     return unit -> {
       StandardServiceRegistryBuilder ssrb = unit.get(StandardServiceRegistryBuilder.class);
       expect(ssrb.applySettings(settings)).andReturn(ssrb);
-      expect(ssrb.applySetting(org.hibernate.jpa.AvailableSettings.DELAY_CDI_ACCESS, true))
-          .andReturn(ssrb);
     };
   }
 

--- a/modules/jooby-hbm/src/test/java/org/jooby/hbm/HbmTest.java
+++ b/modules/jooby-hbm/src/test/java/org/jooby/hbm/HbmTest.java
@@ -32,7 +32,6 @@ import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.jpa.event.spi.JpaIntegrator;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.jooby.Env;
 import org.jooby.Env.ServiceKey;
@@ -67,7 +66,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Hbm.class, BootstrapServiceRegistryBuilder.class, JpaIntegrator.class,
+@PrepareForTest({Hbm.class, BootstrapServiceRegistryBuilder.class,
     MetadataSources.class, CompletableFuture.class, GuiceBeanManager.class, SessionProvider.class,
     OpenSessionInView.class})
 public class HbmTest {
@@ -76,11 +75,6 @@ public class HbmTest {
     BootstrapServiceRegistryBuilder bsrb = unit.constructor(BootstrapServiceRegistryBuilder.class)
         .build();
     unit.registerMock(BootstrapServiceRegistryBuilder.class, bsrb);
-
-    JpaIntegrator jpa = unit.constructor(JpaIntegrator.class)
-        .build();
-
-    expect(bsrb.applyIntegrator(jpa)).andReturn(bsrb);
 
     BootstrapServiceRegistry bsr = unit.mock(BootstrapServiceRegistry.class);
     unit.registerMock(BootstrapServiceRegistry.class, bsr);

--- a/pom.xml
+++ b/pom.xml
@@ -1118,10 +1118,17 @@
         <version>${elasticsearch}</version>
       </dependency>
 
+      <!-- CDI Api; https://hibernate.atlassian.net/browse/HHH-11370 -->
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>${cdi-api.version}</version>
+      </dependency>
+
       <!-- Hibernate -->
       <dependency>
         <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-entitymanager</artifactId>
+        <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
       </dependency>
 
@@ -3150,6 +3157,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <boringssl.version>2.0.20.Final</boringssl.version>
     <bson4jackson.version>2.9.2</bson4jackson.version>
     <caffeine.version>2.6.2</caffeine.version>
+    <cdi-api.version>1.1</cdi-api.version>
     <camel.version>2.18.3</camel.version>
     <cglib.version>3.2.6</cglib.version>
     <closure-compiler.version>v20180610</closure-compiler.version>
@@ -3182,7 +3190,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <handlebars.version>4.1.0</handlebars.version>
     <hazelcast.version>3.11</hazelcast.version>
     <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
-    <hibernate.version>5.2.1.Final</hibernate.version>
+    <hibernate.version>5.3.9.Final</hibernate.version>
     <hikariCP.version>3.2.0</hikariCP.version>
     <http-client.version>4.5.5</http-client.version>
     <j2v8.version>4.6.0</j2v8.version>


### PR DESCRIPTION
This pull request upgrades `jooby-hbm` to use the latest stable version of Hibernate in the 5.3 series.

Beside simply bumping the version number, two additional changes were necessary:

- they marked the CDI-API is provided dependency, therefore `jooby-hbm` needs to depend on it explicitly: https://hibernate.atlassian.net/browse/HHH-11370
- the usage of `JpaIntegrator` is not necessary anymore, so it can be removed from the initialization code and tests: https://hibernate.atlassian.net/browse/HHH-11264
