### PR TITLE
Fix build issue with JDK9 due to outdated dokka-maven-plugin

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -156,7 +156,7 @@
   <coveralls-maven-plugin.version>3.1.0</coveralls-maven-plugin.version>
   <depencency-check-maven.version>2.1.1</depencency-check-maven.version>
   <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
-  <dokka-maven-plugin.version>0.9.13</dokka-maven-plugin.version>
+  <dokka-maven-plugin.version>0.9.18</dokka-maven-plugin.version>
   <duplicate-finder-maven-plugin.version>1.2.1</duplicate-finder-maven-plugin.version>
   <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
   <jacoco-maven-plugin.version>${jacoco.version}</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3309,7 +3309,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <coveralls-maven-plugin.version>3.1.0</coveralls-maven-plugin.version>
     <depencency-check-maven.version>2.1.1</depencency-check-maven.version>
     <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
-    <dokka-maven-plugin.version>0.9.13</dokka-maven-plugin.version>
+    <dokka-maven-plugin.version>0.9.18</dokka-maven-plugin.version>
     <duplicate-finder-maven-plugin.version>1.2.1</duplicate-finder-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>${jacoco.version}</jacoco-maven-plugin.version>


### PR DESCRIPTION
mvn install fails on latest jdk1.8 with dokka-maven-plugin unable to find jdk tools.jar.
this is fixed in newer doka-maven-plugin version. check this out:

https://github.com/Kotlin/dokka/issues/272
https://github.com/Kotlin/dokka/issues/303