### PR TITLE
Added explicit dependency on crsh-cli to fix maven compilation problem

### DIFF
--- a/modules/jooby-crash/pom.xml
+++ b/modules/jooby-crash/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>crash.shell</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.crashub</groupId>
+      <artifactId>crash.cli</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.jooby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -911,7 +911,7 @@
         <version>${gson.version}</version>
       </dependency>
 
-     <!-- yasson - Json-B -->
+      <!-- yasson - Json-B -->
       <dependency>
         <groupId>org.eclipse</groupId>
         <artifactId>yasson</artifactId>
@@ -1642,6 +1642,12 @@
             <artifactId>groovy-all</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.crashub</groupId>
+        <artifactId>crash.cli</artifactId>
+        <version>${crash.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
master `mvn install` fails to build due to missing classes in jooby-crash module. seems that some of the dependencies should be more explicit.

```
modules/jooby-crash/src/main/java/org/jooby/crash/WebShellHandler.java:[207,25] package org.crsh.cli.impl does not exist
```

full log:
https://gist.github.com/altmind/e8429c3e9cbfb1df86e58c52ef5572e9