### PR TITLE
gradle syntax is without colon for compile

### DIFF
--- a/docs/src/main/java/io/jooby/adoc/DependencyProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/DependencyProcessor.java
@@ -100,7 +100,7 @@ public class DependencyProcessor extends BlockProcessor {
       }
       comment(artifactId[i], "//", "").ifPresent(lines::accept);
       lines.accept(
-          "compile: '" + (groupId == null ? groupId(artifactId(artifactId[i])) : groupId) + ":" + artifactId(artifactId[i])
+          "compile '" + (groupId == null ? groupId(artifactId(artifactId[i])) : groupId) + ":" + artifactId(artifactId[i])
               + ":" + (version == null ? version(artifactId(artifactId[i])) : version)
               + "'");
     }


### PR DESCRIPTION
The getting started section for gradle mentions to add

`compile: 'io.jooby:jooby-netty:2.0.0.M3'`

but the correct syntax is

`compile 'io.jooby:jooby-netty:2.0.0.M3'`

Don't know but DependencyProcessor seems like the only place mentioning `compile:`