### PR TITLE
Upgrade to Elasticsearch 7.2.0 REST client

### DIFF
--- a/modules/coverage-report/src/test/java/org/jooby/elasticsearch/ElasticsearchClientAPIFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/elasticsearch/ElasticsearchClientAPIFeature.java
@@ -1,6 +1,7 @@
 package org.jooby.elasticsearch;
 
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.jooby.test.ServerFeature;
 import org.junit.Test;
 
@@ -11,6 +12,7 @@ public class ElasticsearchClientAPIFeature extends ServerFeature {
     use(new Elasticsearch());
 
     get("/", req -> req.require(RestClient.class).getClass().getName());
+    get("/hlrc", req -> req.require(RestHighLevelClient.class).getClass().getName());
 
   }
 
@@ -19,6 +21,9 @@ public class ElasticsearchClientAPIFeature extends ServerFeature {
     request()
         .get("/")
         .expect("org.elasticsearch.client.RestClient");
+    request()
+        .get("/hlrc")
+        .expect("org.elasticsearch.client.RestHighLevelClient");
   }
 
 }

--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -40,7 +40,7 @@
   <ebean-maven-plugin.version>11.11.2</ebean-maven-plugin.version>
   <ebean.version>11.18.2</ebean.version>
   <ehcache.version>2.10.5</ehcache.version>
-  <elasticsearch>5.5.3</elasticsearch>
+  <elasticsearch.version>7.2.0</elasticsearch.version>
   <flyway.version>5.1.3</flyway.version>
   <freemarker.version>2.3.28</freemarker.version>
   <frontend-plugin-core.version>1.6</frontend-plugin-core.version>

--- a/modules/jooby-elasticsearch/pom.xml
+++ b/modules/jooby-elasticsearch/pom.xml
@@ -42,7 +42,7 @@
     <!-- Elasticsearch -->
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
-      <artifactId>rest</artifactId>
+      <artifactId>elasticsearch-rest-high-level-client</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/modules/jooby-elasticsearch/src/test/java/org/jooby/elasticsearch/ElasticsearchTest.java
+++ b/modules/jooby-elasticsearch/src/test/java/org/jooby/elasticsearch/ElasticsearchTest.java
@@ -7,6 +7,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import static org.easymock.EasyMock.expect;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.jooby.Env;
 import org.jooby.test.MockUnit;
 import org.jooby.funzy.Throwing;
@@ -32,16 +33,21 @@ public class ElasticsearchTest {
   private MockUnit.Block nb = unit -> {
     RestClient client = unit.mock(RestClient.class);
     unit.registerMock(RestClient.class, client);
+    RestHighLevelClient restHighLevelClient = unit.mock(RestHighLevelClient.class);
+    unit.registerMock(RestHighLevelClient.class, restHighLevelClient);
   };
 
   @SuppressWarnings("unchecked")
   private MockUnit.Block bindings = unit -> {
     AnnotatedBindingBuilder<RestClient> abbclient = unit.mock(AnnotatedBindingBuilder.class);
     abbclient.toInstance(unit.capture(RestClient.class));
-    //abbclient.toInstance(anyObject(RestClient.class));
+
+    AnnotatedBindingBuilder<RestHighLevelClient> defclient = unit.mock(AnnotatedBindingBuilder.class);
+    defclient.toInstance(unit.capture(RestHighLevelClient.class));
 
     Binder binder = unit.get(Binder.class);
     expect(binder.bind(RestClient.class)).andReturn(abbclient);
+    expect(binder.bind(RestHighLevelClient.class)).andReturn(defclient);
   };
 
   @Test
@@ -56,6 +62,9 @@ public class ElasticsearchTest {
         }, unit -> {
           List<RestClient> captured = unit.captured(RestClient.class);
           assert captured.size() == 1;
+
+          List<RestHighLevelClient> capturedHighLevelRestClient = unit.captured(RestHighLevelClient.class);
+          assert capturedHighLevelRestClient.size() == 1;
 
           List<Throwing.Runnable> callbacks = unit.captured(Throwing.Runnable.class);
           callbacks.get(0).run();

--- a/pom.xml
+++ b/pom.xml
@@ -1114,8 +1114,8 @@
       <!-- Elasticsearch -->
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
-        <artifactId>rest</artifactId>
-        <version>${elasticsearch}</version>
+        <artifactId>elasticsearch-rest-high-level-client</artifactId>
+        <version>${elasticsearch.version}</version>
       </dependency>
 
       <!-- CDI Api; https://hibernate.atlassian.net/browse/HHH-11370 -->
@@ -3181,7 +3181,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <ebean-maven-plugin.version>11.11.2</ebean-maven-plugin.version>
     <ebean.version>11.18.2</ebean.version>
     <ehcache.version>2.10.5</ehcache.version>
-    <elasticsearch>5.5.3</elasticsearch>
+    <elasticsearch.version>7.2.0</elasticsearch.version>
     <flyway.version>5.1.3</flyway.version>
     <freemarker.version>2.3.28</freemarker.version>
     <frontend-plugin-core.version>1.6</frontend-plugin-core.version>


### PR DESCRIPTION
This allows to use the fully fledged high level REST client from
Elasticsearch. This also keeps the low level rest client available, so
that it can be accessed as well in jooby apps.