### PR TITLE
Fixed missing Flyway property name prefix

### DIFF
--- a/modules/jooby-flyway/src/main/java/io/jooby/flyway/FlywayModule.java
+++ b/modules/jooby-flyway/src/main/java/io/jooby/flyway/FlywayModule.java
@@ -86,7 +86,7 @@ public class FlywayModule implements Extension {
     properties.putAll(defaults);
     properties.putAll(overrides);
 
-    String[] commandString = Optional.ofNullable(properties.remove("run")).orElse("migrate")
+    String[] commandString = Optional.ofNullable(properties.remove("flyway.run")).orElse("migrate")
         .split("\\s*,\\s*");
 
     configuration.configuration(properties);


### PR DESCRIPTION
The Flyway module was trying to remove a non-existent property for the `flyway.run` setting, which was causing things to fail on startup with `org.flywaydb.core.api.FlywayException: Unknown configuration property: flyway.run`.

The properties come through to that point with the `flyway.` prefix, so I corrected the property name to include it.