### PR TITLE
Update jooby-maven-plugin configuration

### DIFF
--- a/docs/asciidoc/dev-tools.adoc
+++ b/docs/asciidoc/dev-tools.adoc
@@ -107,7 +107,7 @@ The next example shows all the available options with their default values:
     <configuration>
       <mainClass>${application.class}</mainClass>                  <1>
       <restartExtensions>conf,properties,class</restartExtensions> <2>
-      <sourceExtensions>java,kt</sourceExtension>                  <3>
+      <compileExtensions>java,kt</compileExtensions>                  <3>
       <port>8080</port>                                            <4>
     </configuration>
   </plugin>
@@ -135,7 +135,7 @@ apply plugin: "jooby"
 joobyRun {
   mainClass = "${mainClassName}"                                   <1>
   restartExtensions = ["conf", "properties", "class"]              <2>
-  sourceExtensions =  ["java", "kt"]                               <3>
+  compileExtensions =  ["java", "kt"]                               <3>
   port = 8080                                                      <4>
 }
 ----


### PR DESCRIPTION
The 2.0.2 documentation for the jooby-maven-plugin specifies a configuration tag
```
<sourceExtensions>java,kt</sourceExtension>
```
which is incorrect and is now called
```
<compileExtensions>
```