### PR TITLE
Avoiding possible XSS attack through the default error handler

### DIFF
--- a/jooby/src/main/java/org/jooby/Err.java
+++ b/jooby/src/main/java/org/jooby/Err.java
@@ -203,10 +203,7 @@
  */
 package org.jooby;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -298,17 +295,14 @@ public class Err extends RuntimeException {
       Function<Object, String> xssFilter = env.xss("html").compose(Objects::toString);
       BiFunction<String, Object, String> escaper = (k, v) -> xssFilter.apply(v);
 
-      Supplier<Map<String, Object>> detailsProvider = () -> {
-        Map<String, Object> map = ex.toMap(stackstrace);
-        map.compute("message", escaper);
-        map.compute("reason", escaper);
-        return map;
-      };
+      Map<String, Object> details = ex.toMap(stackstrace);
+      details.compute("message", escaper);
+      details.compute("reason", escaper);
 
       rsp.send(
           Results
-              .when(MediaType.html, () -> Results.html(VIEW).put("err", detailsProvider.get()))
-              .when(MediaType.all, detailsProvider::get));
+              .when(MediaType.html, () -> Results.html(VIEW).put("err", details))
+              .when(MediaType.all, () -> details));
     }
 
   }

--- a/jooby/src/main/java/org/jooby/internal/HttpHandlerImpl.java
+++ b/jooby/src/main/java/org/jooby/internal/HttpHandlerImpl.java
@@ -627,7 +627,7 @@ public class HttpHandlerImpl implements HttpHandler {
           // default /favicon.ico handler:
           rsp.status(Status.NOT_FOUND).end();
         } else {
-          throw new Err(Status.NOT_FOUND, req.path(true));
+          throw new Err(Status.NOT_FOUND, req.path());
         }
       }
     }, method, path, "err", accept));

--- a/jooby/src/main/java/org/jooby/internal/RouteImpl.java
+++ b/jooby/src/main/java/org/jooby/internal/RouteImpl.java
@@ -233,7 +233,7 @@ public class RouteImpl implements RouteWithFilter {
   public static RouteWithFilter notFound(final String method, final String path) {
     return new FallbackRoute("404", method, path, MediaType.ALL, (req, rsp, chain) -> {
       if (!rsp.status().isPresent()) {
-        throw new Err(Status.NOT_FOUND, req.path(true));
+        throw new Err(Status.NOT_FOUND, req.path());
       }
     });
   }

--- a/jooby/src/test/java/org/jooby/DefaultErrHandlerTest.java
+++ b/jooby/src/test/java/org/jooby/DefaultErrHandlerTest.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
@@ -148,11 +149,12 @@ public class DefaultErrHandlerTest {
 
   private void checkErr(final String[] stacktrace, final String message,
       final Map<String, Object> err) {
-    assertEquals(message, err.remove("message"));
-    assertEquals("Server Error", err.remove("reason"));
-    assertEquals(500, err.remove("status"));
-    assertArrayEquals(stacktrace, (String[]) err.remove("stacktrace"));
-    assertEquals(err.toString(), 0, err.size());
+    final Map<String, Object> copy = new LinkedHashMap<>(err);
+    assertEquals(message, copy.remove("message"));
+    assertEquals("Server Error", copy.remove("reason"));
+    assertEquals(500, copy.remove("status"));
+    assertArrayEquals(stacktrace, (String[]) copy.remove("stacktrace"));
+    assertEquals(copy.toString(), 0, copy.size());
   }
 
 }


### PR DESCRIPTION
@jknack  Please review, especially the test case. I'm not familiar with it, i'm not sure if this line is correct:

`expect(env.xss("html")).andReturn(HtmlEscapers.htmlEscaper()::escape);`