### PR TITLE
Feature/more value types 1377

### DIFF
--- a/jooby/src/main/java/io/jooby/Value.java
+++ b/jooby/src/main/java/io/jooby/Value.java
@@ -10,6 +10,7 @@ import io.jooby.internal.HashValue;
 import io.jooby.internal.MissingValue;
 import io.jooby.internal.SingleValue;
 import io.jooby.internal.ValueInjector;
+import io.jooby.spi.ValueContainer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -52,7 +53,7 @@ import java.util.function.Function;
  * @since 2.0.0
  * @author edgar
  */
-public interface Value extends Iterable<Value> {
+public interface Value extends Iterable<Value>, ValueContainer {
 
   /**
    * Convert this value to long (if possible).

--- a/jooby/src/main/java/io/jooby/internal/ValueInjector.java
+++ b/jooby/src/main/java/io/jooby/internal/ValueInjector.java
@@ -14,6 +14,7 @@ import io.jooby.StatusCode;
 import io.jooby.TypeMismatchException;
 import io.jooby.Value;
 import io.jooby.internal.reflect.$Types;
+import io.jooby.spi.ValueConverters;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -147,6 +148,10 @@ public final class ValueInjector {
       throws IllegalAccessException, InvocationTargetException, InstantiationException,
       NoSuchMethodException {
     if (scope.isObject() || scope.isSingle()) {
+      Object o = ValueConverters.getInstance().convert(scope, type);
+      if (o != null) {
+        return o;
+      }
       return newInstance(type, scope);
     } else if (scope.isMissing()) {
       if (type.isPrimitive()) {

--- a/jooby/src/main/java/io/jooby/internal/ValueInjector.java
+++ b/jooby/src/main/java/io/jooby/internal/ValueInjector.java
@@ -345,9 +345,6 @@ public final class ValueInjector {
       }
       throw new TypeMismatchException(value.name(), FileUpload.class);
     }
-    if (rawType.isEnum()) {
-      return Enum.valueOf(rawType, value.get(0).value());
-    }
     /**********************************************************************************************
      * Static method: valueOf
      * ********************************************************************************************

--- a/jooby/src/main/java/io/jooby/internal/ValueInjector.java
+++ b/jooby/src/main/java/io/jooby/internal/ValueInjector.java
@@ -250,6 +250,9 @@ public final class ValueInjector {
     if (FileUpload.class == rawType) {
       return true;
     }
+    if (rawType.isEnum()) {
+      return true;
+    }
     /**********************************************************************************************
      * Static method: valueOf
      * ********************************************************************************************
@@ -336,6 +339,9 @@ public final class ValueInjector {
         return value.get(0);
       }
       throw new TypeMismatchException(value.name(), FileUpload.class);
+    }
+    if (rawType.isEnum()) {
+      return Enum.valueOf(rawType, value.get(0).value());
     }
     /**********************************************************************************************
      * Static method: valueOf

--- a/jooby/src/main/java/io/jooby/spi/ValueContainer.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueContainer.java
@@ -1,0 +1,63 @@
+package io.jooby.spi;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public interface ValueContainer {
+  
+  /**
+   * Get a value at the given position.
+   *
+   * @param index Position.
+   * @return A value at the given position.
+   */
+  @Nonnull ValueContainer get(@Nonnull int index);
+
+  /**
+   * Get a value that matches the given name.
+   *
+   * @param name Field name.
+   * @return Field value.
+   */
+  @Nonnull ValueContainer get(@Nonnull String name);
+  
+  @Nonnull String value();
+  
+  @Nullable String valueOrNull();
+  
+  /**
+   * True for missing values.
+   *
+   * @return True for missing values.
+   */
+  boolean isMissing();
+
+  /**
+   * The number of values this one has. For single values size is <code>0</code>.
+   *
+   * @return Number of values. Mainly for array and hash values.
+   */
+  int size();
+  
+  /**
+   * True if this value is an array/sequence (not single or hash).
+   *
+   * @return True if this value is an array/sequence.
+   */
+  boolean isArray();
+
+  /**
+   * True if this is a single value (not a hash or array).
+   *
+   * @return True if this is a single value (not a hash or array).
+   */
+  boolean isSingle();
+
+  /**
+   * True if this is a hash/object value (not single or array).
+   *
+   * @return True if this is a hash/object value (not single or array).
+   */
+  boolean isObject();
+
+}

--- a/jooby/src/main/java/io/jooby/spi/ValueContainer.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueContainer.java
@@ -3,8 +3,15 @@ package io.jooby.spi;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.jooby.Value;
+
+/**
+ *  A restricted base type of {@link Value} for the {@link ValueConverter} SPI.
+ * @author agentgt
+ *
+ */
 public interface ValueContainer {
-  
+
   /**
    * Get a value at the given position.
    *
@@ -20,11 +27,21 @@ public interface ValueContainer {
    * @return Field value.
    */
   @Nonnull ValueContainer get(@Nonnull String name);
-  
+
+  /**
+   * Get string value.
+   *
+   * @return String value.
+   */
   @Nonnull String value();
-  
+
+  /**
+   * Convert this value to String (if possible) or <code>null</code> when missing.
+   *
+   * @return Convert this value to String (if possible) or <code>null</code> when missing.
+   */
   @Nullable String valueOrNull();
-  
+
   /**
    * True for missing values.
    *
@@ -38,7 +55,7 @@ public interface ValueContainer {
    * @return Number of values. Mainly for array and hash values.
    */
   int size();
-  
+
   /**
    * True if this value is an array/sequence (not single or hash).
    *

--- a/jooby/src/main/java/io/jooby/spi/ValueConverter.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverter.java
@@ -1,6 +1,27 @@
 package io.jooby.spi;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.jooby.TypeMismatchException;
+import io.jooby.Value;
 
 public interface ValueConverter {
-
+  /**
+   * This defaults to true to allow a functional interface.
+   * @param type
+   * @return
+   */
+  default boolean supportsType(@Nonnull Class<?> type) {
+    return true;
+  }
+  /**
+   * Converts values for {@link Value#to} and friends. Returning null indicates the type is not supported
+   * or the converter chose not to do the conversion.
+   * @param value
+   * @param type
+   * @return <code>null</code> indicates that the converter chose to delegate to other converters down the chain.
+   * @throws TypeMismatchException if the converter cannot convert the type and does not want to delegate.
+   */
+  @Nullable Object convert(@Nonnull ValueContainer value, @Nonnull Class<?> type) throws TypeMismatchException;
 }

--- a/jooby/src/main/java/io/jooby/spi/ValueConverter.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverter.java
@@ -6,11 +6,19 @@ import javax.annotation.Nullable;
 import io.jooby.TypeMismatchException;
 import io.jooby.Value;
 
+/**
+ * An SPI for value conversion.
+ * @author agentgt
+ */
 public interface ValueConverter {
   /**
-   * This defaults to true to allow a functional interface.
-   * @param type
-   * @return
+   * A short circuit to see if the converter supports the given type.
+   *
+   * This defaults to true to allow a functional interface since convert can return null
+   * to indicate it does not support the type.
+   *
+   * @param type class or interface
+   * @return true if the converter can convert for the type
    */
   default boolean supportsType(@Nonnull Class<?> type) {
     return true;
@@ -18,8 +26,8 @@ public interface ValueConverter {
   /**
    * Converts values for {@link Value#to} and friends. Returning null indicates the type is not supported
    * or the converter chose not to do the conversion.
-   * @param value
-   * @param type
+   * @param value the value to be converted
+   * @param type the desired type. The type should be the equal or a super of the resulting instance returned.
    * @return <code>null</code> indicates that the converter chose to delegate to other converters down the chain.
    * @throws TypeMismatchException if the converter cannot convert the type and does not want to delegate.
    */

--- a/jooby/src/main/java/io/jooby/spi/ValueConverter.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverter.java
@@ -1,0 +1,6 @@
+package io.jooby.spi;
+
+
+public interface ValueConverter {
+
+}

--- a/jooby/src/main/java/io/jooby/spi/ValueConverters.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverters.java
@@ -1,0 +1,6 @@
+package io.jooby.spi;
+
+
+public class ValueConverters {
+
+}

--- a/jooby/src/main/java/io/jooby/spi/ValueConverters.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverters.java
@@ -7,24 +7,45 @@ import javax.annotation.Nullable;
 
 import io.jooby.TypeMismatchException;
 
+/**
+ * Contains the {@link ValueConverter}s loaded via the ServiceLoader. It is is a
+ * singleton and an instance can be retrieved with {@link #getInstance()}. The
+ * ValueConverters are stored in an ordered collection and thus resolution of
+ * type to be converted is based on the order of the converters.
+ *
+ * @author agentgt
+ *
+ */
 public final class ValueConverters {
+
   // Allow thread safe adding of ValueConverters.
   private final CopyOnWriteArrayList<ValueConverter> valueConverters;
-  
+
   // Initialization on demand
   private static final class Hidden {
+
     private static final ValueConverters INSTANCE = ValueConverters.create().fromServiceLoader();
   }
-  
+
   private ValueConverters(CopyOnWriteArrayList<ValueConverter> valueConverters) {
     super();
     this.valueConverters = valueConverters;
   }
-  
+
   static ValueConverters create() {
     return new ValueConverters(new CopyOnWriteArrayList<>());
   }
-  
+
+  /**
+   * Attempts to convert values to an object based on the provided type.
+   *
+   * @param v
+   *          value
+   * @param c
+   *          desired type
+   * @return the type if converted or null if conversion was not possible.
+   * @throws TypeMismatchException failure in a converter
+   */
   public @Nullable Object convert(ValueContainer v, Class<?> c) throws TypeMismatchException {
     Object result = null;
     for (ValueConverter vc : valueConverters) {
@@ -37,33 +58,37 @@ public final class ValueConverters {
     }
     return result;
   }
-  
-  final ValueConverters fromServiceLoader() {
+
+  ValueConverters fromServiceLoader() {
     ServiceLoader<ValueConverter> sl = ServiceLoader.load(ValueConverter.class);
-    //If any failes to load we will fail entirely.
-    //The value converters found earlier in the classpath take precedence.
+    // If any failes to load we will fail entirely.
+    // The value converters found earlier in the classpath take precedence.
     sl.forEach(this::add);
     return this;
   }
+
   /**
-   * You can add value converters programmatic. For now its protected.
-   * Its also to aid unit testing since serviceloader is inherently static singleton.
+   * You can add value converters programmatic. For now its protected. Its also
+   * to aid unit testing since serviceloader is inherently static singleton.
+   *
    * @param vc
    * @return
    */
-  /* private */ final ValueConverters add(ValueConverter vc) {
+  /* private */ ValueConverters add(ValueConverter vc) {
     valueConverters.add(vc);
     return this;
   }
-  
-  final ValueConverters clear() {
+
+  ValueConverters clear() {
     valueConverters.clear();
     return this;
   }
-  
-  
-  
-  public static final ValueConverters getInstance() {
+
+  /**
+   * The ValueConverters singleton usually preloaded by the ServiceLoader.
+   * @return the shared singleton used by Jooby
+   */
+  public static ValueConverters getInstance() {
     return ValueConverters.Hidden.INSTANCE;
   }
 

--- a/jooby/src/main/java/io/jooby/spi/ValueConverters.java
+++ b/jooby/src/main/java/io/jooby/spi/ValueConverters.java
@@ -1,6 +1,70 @@
 package io.jooby.spi;
 
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-public class ValueConverters {
+import javax.annotation.Nullable;
+
+import io.jooby.TypeMismatchException;
+
+public final class ValueConverters {
+  // Allow thread safe adding of ValueConverters.
+  private final CopyOnWriteArrayList<ValueConverter> valueConverters;
+  
+  // Initialization on demand
+  private static final class Hidden {
+    private static final ValueConverters INSTANCE = ValueConverters.create().fromServiceLoader();
+  }
+  
+  private ValueConverters(CopyOnWriteArrayList<ValueConverter> valueConverters) {
+    super();
+    this.valueConverters = valueConverters;
+  }
+  
+  static ValueConverters create() {
+    return new ValueConverters(new CopyOnWriteArrayList<>());
+  }
+  
+  public @Nullable Object convert(ValueContainer v, Class<?> c) throws TypeMismatchException {
+    Object result = null;
+    for (ValueConverter vc : valueConverters) {
+      if (vc.supportsType(c)) {
+        result = vc.convert(v, c);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+    return result;
+  }
+  
+  final ValueConverters fromServiceLoader() {
+    ServiceLoader<ValueConverter> sl = ServiceLoader.load(ValueConverter.class);
+    //If any failes to load we will fail entirely.
+    //The value converters found earlier in the classpath take precedence.
+    sl.forEach(this::add);
+    return this;
+  }
+  /**
+   * You can add value converters programmatic. For now its protected.
+   * Its also to aid unit testing since serviceloader is inherently static singleton.
+   * @param vc
+   * @return
+   */
+  /* private */ final ValueConverters add(ValueConverter vc) {
+    valueConverters.add(vc);
+    return this;
+  }
+  
+  final ValueConverters clear() {
+    valueConverters.clear();
+    return this;
+  }
+  
+  
+  
+  public static final ValueConverters getInstance() {
+    return ValueConverters.Hidden.INSTANCE;
+  }
 
 }

--- a/jooby/src/test/java/io/jooby/spi/ValueConvertersTest.java
+++ b/jooby/src/test/java/io/jooby/spi/ValueConvertersTest.java
@@ -1,0 +1,66 @@
+package io.jooby.spi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.jooby.MissingValueException;
+import io.jooby.QueryString;
+import io.jooby.internal.UrlParser;
+
+
+class ValueConvertersTest {
+
+  @AfterAll
+  static void restoreFromServiceLoader() {
+    //Restore ValueConvert list for other unit tests.
+    ValueConverters.getInstance().clear().fromServiceLoader();
+  }
+  
+  @Test
+  void testConvert() {
+    ValueConverters.getInstance()
+      .clear()
+      .add((value, type) -> { 
+      if (type == MyValue.class) {
+        MyValue mv = new MyValue();
+        // we have chosen simple parameters names to make sure we don't get a false positve 
+        // from the reflection converter.
+        mv.name = value.get("n").value();
+        //TODO: ValueContainer probably should have primitive convert methods.
+        mv.order = Integer.parseInt(value.get("o").value());
+        return mv;
+      }
+      return null;
+    });
+    queryString("n=stuff&o=1", queryString -> {
+      MyValue mv = queryString.to(MyValue.class);
+      assertEquals("stuff", mv.name);
+      assertEquals(1, mv.order);
+    });
+    queryString("n=stuff&missingOrder=1", queryString -> {
+      try {
+        queryString.to(MyValue.class);
+        fail();
+      }
+      catch (MissingValueException mve) {
+        assertEquals("Missing value: 'o'", mve.getMessage());
+      }
+    });
+  }
+  
+  static class MyValue {
+    public String name;
+    public int order;
+  }
+  
+  
+  
+  private void queryString(String queryString, Consumer<QueryString> consumer) {
+    consumer.accept(UrlParser.queryString(queryString));
+  }
+
+}

--- a/jooby/src/test/java/io/jooby/spi/ValueConvertersTest.java
+++ b/jooby/src/test/java/io/jooby/spi/ValueConvertersTest.java
@@ -11,31 +11,29 @@ import io.jooby.MissingValueException;
 import io.jooby.QueryString;
 import io.jooby.internal.UrlParser;
 
-
 class ValueConvertersTest {
 
   @AfterAll
   static void restoreFromServiceLoader() {
-    //Restore ValueConvert list for other unit tests.
-    ValueConverters.getInstance().clear().fromServiceLoader();
+    // Restore ValueConvert list for other unit tests.
+    ValueConverters.builder().fromServiceLoader().set();
   }
-  
+
   @Test
   void testConvert() {
-    ValueConverters.getInstance()
-      .clear()
-      .add((value, type) -> { 
+    ValueConverters.builder().add((value, type) -> {
       if (type == MyValue.class) {
         MyValue mv = new MyValue();
-        // we have chosen simple parameters names to make sure we don't get a false positve 
+        // we have chosen simple parameters names to make sure we don't get a
+        // false positve
         // from the reflection converter.
         mv.name = value.get("n").value();
-        //TODO: ValueContainer probably should have primitive convert methods.
+        // TODO: ValueContainer probably should have primitive convert methods.
         mv.order = Integer.parseInt(value.get("o").value());
         return mv;
       }
       return null;
-    });
+    }).set();
     queryString("n=stuff&o=1", queryString -> {
       MyValue mv = queryString.to(MyValue.class);
       assertEquals("stuff", mv.name);
@@ -45,20 +43,18 @@ class ValueConvertersTest {
       try {
         queryString.to(MyValue.class);
         fail();
-      }
-      catch (MissingValueException mve) {
+      } catch (MissingValueException mve) {
         assertEquals("Missing value: 'o'", mve.getMessage());
       }
     });
   }
-  
+
   static class MyValue {
+
     public String name;
     public int order;
   }
-  
-  
-  
+
   private void queryString(String queryString, Consumer<QueryString> consumer) {
     consumer.accept(UrlParser.queryString(queryString));
   }


### PR DESCRIPTION
Work to make a Value extension point for data conversion. The extension uses the ServiceLoader as discussed. It is mainly focused for object conversion and thus might fit nicely with the simple string conversion you @jknack are working on.

This PR is for discussion. Its not complete but I wanted to get it in before the end of the weekend as promised.

The big thing I think I want to add is more conversion methods to ValueContainer. Also I might make it so this extension loader only run for `Value#isObject()` given your work but unsure right now.