### PR TITLE
[v1] Test fixes for windows path separators, line endings

### DIFF
--- a/jooby/src/main/resources/org/jooby/jooby.conf
+++ b/jooby/src/main/resources/org/jooby/jooby.conf
@@ -16,7 +16,7 @@ application {
   # class = App.class.getName() 
 
   # tmpdir
-  tmpdir = ${java.io.tmpdir}/${application.name}
+  tmpdir = ${java.io.tmpdir}${file.separator}${application.name}
 
   # path (a.k.a. as contextPath)
   path = /

--- a/jooby/src/test/java/org/jooby/test/JoobyRunner.java
+++ b/jooby/src/test/java/org/jooby/test/JoobyRunner.java
@@ -105,6 +105,7 @@ public class JoobyRunner extends BlockJUnit4ClassRunner {
       }
 
       app = (Jooby) appClass.newInstance();
+      app.throwBootstrapException();
       if (app instanceof ServerFeature) {
         int appport = ((ServerFeature) app).port;
         if (appport > 0) {

--- a/modules/coverage-report/src/test/java/org/jooby/jackson/JsonCustomMapperFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/jackson/JsonCustomMapperFeature.java
@@ -1,5 +1,6 @@
 package org.jooby.jackson;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import java.net.URISyntaxException;
@@ -31,12 +32,12 @@ public class JsonCustomMapperFeature extends ServerFeature {
 
   @Test
   public void get() throws URISyntaxException, Exception {
-    request()
-        .get("/members")
-        .expect("[ {\n" +
-            "  \"id\" : 1,\n" +
-            "  \"name\" : \"pablo\"\n" +
-            "} ]");
+      request().get("/members").expect(value ->
+              assertEquals("[ {\n" +
+                      "  \"id\" : 1,\n" +
+                      "  \"name\" : \"pablo\"\n" +
+                      "} ]", value.replaceAll("\r\n", "\n"))
+      );
   }
 
 }

--- a/modules/coverage-report/src/test/java/org/jooby/jackson/JsonDoWithFeature.java
+++ b/modules/coverage-report/src/test/java/org/jooby/jackson/JsonDoWithFeature.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import static org.junit.Assert.assertEquals;
+
 @SuppressWarnings("unchecked")
 public class JsonDoWithFeature extends ServerFeature {
 
@@ -26,12 +28,12 @@ public class JsonDoWithFeature extends ServerFeature {
 
   @Test
   public void get() throws URISyntaxException, Exception {
-    request()
-        .get("/members")
-        .expect("[ {\n" +
-            "  \"id\" : 1,\n" +
-            "  \"name\" : \"pablo\"\n" +
-            "} ]");
+    request().get("/members").expect(value ->
+            assertEquals("[ {\n" +
+                    "  \"id\" : 1,\n" +
+                    "  \"name\" : \"pablo\"\n" +
+                    "} ]", value.replaceAll("\r\n", "\n"))
+    );
   }
 
 }

--- a/modules/coverage-report/src/test/java/org/jooby/whoops/WhoopsTest.java
+++ b/modules/coverage-report/src/test/java/org/jooby/whoops/WhoopsTest.java
@@ -47,7 +47,7 @@ public class WhoopsTest {
 
   @Test
   public void locationOf() {
-    assertTrue(new File(Whoops.locationOf(Whoops.class)).exists());
+    assertTrue(Whoops.locationOf(Whoops.class) + " file does not exist", new File(Whoops.locationOf(Whoops.class)).exists());
 
     assertEquals("rt.jar", Whoops.locationOf(Object.class));
   }

--- a/modules/jooby-assets-sass/src/test/java/org/jooby/assets/SassTest.java
+++ b/modules/jooby-assets-sass/src/test/java/org/jooby/assets/SassTest.java
@@ -1,8 +1,11 @@
 package org.jooby.assets;
 
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.hamcrest.core.StringStartsWith;
 import org.junit.Test;
 
 import com.typesafe.config.ConfigFactory;
@@ -204,14 +207,14 @@ public class SassTest {
                 "  color: $primary-color;\n" +
                 "}\n",
             ConfigFactory.empty());
-    assertTrue(output.startsWith(".foo {\n" +
-        "  color: #fff; }\n" +
-        "\n" +
-        "body {\n" +
-        "  font: 100% Helvetica, sans-serif;\n" +
-        "  color: #333; }\n" +
-        "\n" +
-        "/*# sourceMappingURL=data:application/json;base64,ewoJInZlcnNpb24iOiAzLAoJImZpbGUiOiAiLi4vLi4v"));
+    assertThat(output, startsWith(".foo {\n" +
+            "  color: #fff; }\n" +
+            "\n" +
+            "body {\n" +
+            "  font: 100% Helvetica, sans-serif;\n" +
+            "  color: #333; }\n" +
+            "\n" +
+            "/*# sourceMappingURL=data:application/json;base64,ewoJInZlcnNpb24iOiAzLAoJImZpbGUiOiAiL")); // include up to "file": "
   }
 
   @Test

--- a/modules/jooby-assets-svg-sprites/src/test/java/org/jooby/assets/SvgSpritesFileSetTest.java
+++ b/modules/jooby-assets-svg-sprites/src/test/java/org/jooby/assets/SvgSpritesFileSetTest.java
@@ -17,7 +17,7 @@ public class SvgSpritesFileSetTest {
 
   @Test
   public void cssPath() throws Exception {
-    assertEquals(Paths.get("target", "css", "sprite.css").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/sprite.css",
         new SvgSprites()
             .set("spritePath", Paths.get("target", "css").toString())
             .cssPath());
@@ -30,7 +30,7 @@ public class SvgSpritesFileSetTest {
 
   @Test
   public void spritePath() throws Exception {
-    assertEquals(Paths.get("target", "css", "sprite.svg").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/sprite.svg",
         new SvgSprites()
             .set("spritePath", Paths.get("target", "css").toString())
             .spritePath());
@@ -43,7 +43,7 @@ public class SvgSpritesFileSetTest {
 
   @Test
   public void spritePrefix() throws Exception {
-    assertEquals(Paths.get("target", "css", "p-sprite.svg").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/p-sprite.svg",
         new SvgSprites()
             .set("prefix", "p")
             .set("spritePath", Paths.get("target", "css").toString())
@@ -58,14 +58,14 @@ public class SvgSpritesFileSetTest {
 
   @Test
   public void spriteName() throws Exception {
-    assertEquals(Paths.get("target", "css", "p-n-sprite.svg").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/p-n-sprite.svg",
         new SvgSprites()
             .set("prefix", "p")
             .set("name", "n")
             .set("spritePath", Paths.get("target", "css").toString())
             .spritePath());
 
-    assertEquals(Paths.get("target", "css", "n-sprite.svg").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/n-sprite.svg",
         new SvgSprites()
             .set("name", "n")
             .set("spritePath", Paths.get("target", "css").toString())
@@ -74,7 +74,7 @@ public class SvgSpritesFileSetTest {
 
   @Test
   public void cssPrefix() throws Exception {
-    assertEquals(Paths.get("target", "css", "p-sprite.css").toString(),
+    assertEquals(Paths.get("target", "css").toString() + "/p-sprite.css",
         new SvgSprites()
             .set("prefix", "p")
             .set("spritePath", Paths.get("target", "css").toString())

--- a/modules/jooby-assets/src/test/java/org/jooby/assets/AssetCompilerTest.java
+++ b/modules/jooby-assets/src/test/java/org/jooby/assets/AssetCompilerTest.java
@@ -81,7 +81,7 @@ public class AssetCompilerTest {
 
     File dir = Paths.get("target", "summary").toFile();
     Map<String, List<File>> files = compiler.build("dev", dir);
-
+    String summary = compiler.summary(files, dir.toPath(), "dev", 1000, "Foo: bar").replaceAll("\\\\","/");
     assertEquals("Summary:\n"
             + "Pipeline: []\n"
             + "Time: 1s\n"
@@ -92,7 +92,7 @@ public class AssetCompilerTest {
             + "          assets/home.css         8b\n"
             + "           assets/base.js        19b\n"
             + "           assets/home.js        19b\n",
-        compiler.summary(files, dir.toPath(), "dev", 1000, "Foo: bar"));
+        summary);
   }
 
   @Test


### PR DESCRIPTION
This fixes:

1. Failure to start Jooby in JoobyRunner should fail the suite early - otherwise the tests will fail later with cryptic exception `org.apache.http.conn.HttpHostConnectException: Connect to localhost:9999 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused: connect`

2. Assets pipeline tests fail if there is no `assets.conf` in test path. Empty assets.conf seems to fix this.

3. Relax json tests to accept both "\r\n" and "\n" in output for windows(jackson seems to return platform-dependent line endings)

4. In some places(css sprites) we should not use system path separator - the css sprites results are URLS, the path separator there is always /.
In some places (tmpdir), we should use system path separator so our tests dont fail

Before the change: 9 errors, 19 failures https://altio.us/files/Test%20Results%20-%20TestAllorg_jooby.html

After the change:  https://altio.us/files/Test%20Results%20-%20TestAllorg_jooby2.html

(I dont know how to fix whoops, sorry)