### PR TITLE
fix java example for static file-system example

### DIFF
--- a/docs/asciidoc/static-files.adoc
+++ b/docs/asciidoc/static-files.adoc
@@ -29,7 +29,7 @@ supports classpath and file-system resources.
 [source, java, role="primary"]
 ----
 {
-  assets("/static/*", Paths.get("static")); <1>
+  assets("/static/*", Paths.get("www")); <1>
 }
 ----
 


### PR DESCRIPTION
Updated the Java static file-system route example to match the correct Kotlin example. Java example used `Paths.get("static")` instead of the correct `Paths.get("www")` as in the Kotlin code example.

From:
```
.File system resources:
[source, java, role="primary"]
----
{
  assets("/static/*", Paths.get("static")); <1>
}
----

.Kotlin
[source, kotlin, role="secondary"]
----
{
  assets("/static/*", Paths.get("www"))  <1>
}
----
```

To:
```
.File system resources:
[source, java, role="primary"]
----
{
  assets("/static/*", Paths.get("www")); <1>
}
----

.Kotlin
[source, kotlin, role="secondary"]
----
{
  assets("/static/*", Paths.get("www"))  <1>
}
----
```