### PR TITLE
fix broken link in usage

### DIFF
--- a/jooby/src/main/java/io/jooby/Usage.java
+++ b/jooby/src/main/java/io/jooby/Usage.java
@@ -20,7 +20,7 @@ public class Usage extends RuntimeException {
    * @param id Link to detailed section.
    */
   public Usage(@Nonnull String message, @Nonnull String id) {
-    super((message + "\nFor more details, please visit: https://io.jooby/usage#" + id));
+    super((message + "\nFor more details, please visit: https://jooby.io/usage#" + id));
   }
 
   /**


### PR DESCRIPTION
Changed http link from `io.jooby` to `jooby.io`.