### PR TITLE
Remove unused dependency

### DIFF
--- a/jooby/pom.xml
+++ b/jooby/pom.xml
@@ -183,13 +183,6 @@
       <artifactId>config</artifactId>
     </dependency>
 
-    <!-- JAXRS -->
-    <dependency>
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-
     <!-- kotlin -->
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Hello. I noticed that dependency `jakarta.ws.rs-api` is declared but not used in module `jooby`. Therefore, it makes sense to remove this dependency. 
