### PR TITLE
update undertow version to 2.0.29.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <asm.version>7.3.1</asm.version>
 
     <!-- Server -->
-    <undertow.version>2.0.28.Final</undertow.version>
+    <undertow.version>2.0.29.Final</undertow.version>
     <jetty.version>9.4.27.v20200227</jetty.version>
     <netty.version>4.1.48.Final</netty.version>
     <boringssl.version>2.0.27.Final</boringssl.version>


### PR DESCRIPTION
Version 2.0.28.Final has a vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2019-14888