### PR TITLE
Fixed invalid module name being used for MVC reflection fallback

### DIFF
--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -1122,7 +1122,7 @@ public class Jooby implements Router, Registry {
    */
   private Optional<MvcFactory> mvcReflectionFallback(Class source, ClassLoader classLoader) {
     try {
-      String moduleName = source.getName() + "$Factory";
+      String moduleName = source.getName() + "$Module";
       Class<?> moduleType = classLoader.loadClass(moduleName);
       Constructor<?> constructor = moduleType.getDeclaredConstructor();
       getLog().debug("Loading mvc using reflection: " + source);


### PR DESCRIPTION
This corrects the module name being used for the MVC reflection fallback being used when the module can't be found in the `ServiceLoader`.

I was running into #1390 even after the fix, and ended up finding the wrong class name suffix being used was the issue - now partial builds in IntelliJ work again :)