### PR TITLE
make message encoder return type nullable to prevent kotlin's compila…

### DIFF
--- a/jooby/src/main/java/io/jooby/MessageEncoder.java
+++ b/jooby/src/main/java/io/jooby/MessageEncoder.java
@@ -8,6 +8,7 @@ package io.jooby;
 import io.jooby.exception.NotAcceptableException;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -34,7 +35,7 @@ public interface MessageEncoder {
    * @return Value as byte array or <code>null</code> if given object isn't supported it.
    * @throws Exception If something goes wrong.
    */
-  @Nonnull byte[] encode(@Nonnull Context ctx, @Nonnull Object value) throws Exception;
+  @Nullable byte[] encode(@Nonnull Context ctx, @Nonnull Object value) throws Exception;
 
   /**
    * Execute this renderer only if the <code>Accept</code> header matches the content-type


### PR DESCRIPTION
fix issue #1766 , the message encoder now annotates its return type with `@Nullable`

This could be a breaking change although kotlin allows overriding with return type set to a non-nullable result so no code will break and java compiler doesn't care about those annotations  but....