### PR TITLE
Fix usage of javax.annotation.Nonnull on String args in MVC routes

### DIFF
--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ParamDefinition.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ParamDefinition.java
@@ -110,7 +110,7 @@ public class ParamDefinition {
 
   private boolean hasAnnotation(String type) {
     for (AnnotationMirror annotation : parameter.getAnnotationMirrors()) {
-      if (annotation.getAnnotationType().equals(type)) {
+      if (annotation.getAnnotationType().toString().equals(type)) {
         return true;
       }
     }

--- a/modules/jooby-apt/src/test/java/source/Controller1786.java
+++ b/modules/jooby-apt/src/test/java/source/Controller1786.java
@@ -1,0 +1,14 @@
+package source;
+
+import io.jooby.annotations.GET;
+import io.jooby.annotations.QueryParam;
+
+import javax.annotation.Nonnull;
+
+public class Controller1786 {
+
+  @GET("/required-string-param")
+  public String requiredStringParam(@QueryParam @Nonnull String value) {
+    return value;
+  }
+}

--- a/modules/jooby-apt/src/test/java/tests/Issue1786.java
+++ b/modules/jooby-apt/src/test/java/tests/Issue1786.java
@@ -1,0 +1,41 @@
+package tests;
+
+import io.jooby.MockContext;
+import io.jooby.MockRouter;
+import io.jooby.StatusCode;
+import io.jooby.apt.MvcModuleCompilerRunner;
+import io.jooby.exception.MissingValueException;
+import org.junit.jupiter.api.Test;
+import source.Controller1786;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Issue1786 {
+
+  @Test
+  public void shouldThrowMissingValueExceptionIfRequiredStringParamNotSpecified() throws Exception {
+    new MvcModuleCompilerRunner(new Controller1786())
+        .module(app -> {
+          MockRouter router = new MockRouter(app);
+          assertThrows(MissingValueException.class, () -> router.get("/required-string-param"));
+        });
+  }
+
+  @Test
+  public void shouldReturnValueIfRequiredStringParamSpecified() throws Exception {
+    new MvcModuleCompilerRunner(new Controller1786())
+        .module(app -> {
+          final String expectedValue = "non-null string";
+
+          MockContext ctx = new MockContext();
+          ctx.setQueryString("value=" + expectedValue);
+
+          MockRouter router = new MockRouter(app);
+          router.get("/required-string-param", ctx, rsp -> {
+            assertEquals(StatusCode.OK, rsp.getStatusCode());
+            assertEquals(expectedValue, rsp.value());
+          });
+        });
+  }
+}


### PR DESCRIPTION
Partially fixes issue #1786

The rest of the issue is related to non-String arguments and requires more time to think because it cannot be fixed by using the correct `ValueNode`'s method 