### PR TITLE
Extension: commons-email from Jooby 1.x

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -26,6 +26,7 @@
   <bucket4j-core.version>4.10.0</bucket4j-core.version>
   <caffeine.version>2.8.5</caffeine.version>
   <checkstyle.version>8.33</checkstyle.version>
+  <commons-email.version>1.5</commons-email.version>
   <commons-io.version>2.7</commons-io.version>
   <compile-testing.version>0.18</compile-testing.version>
   <config.version>1.4.0</config.version>
@@ -798,6 +799,12 @@
       <groupId>com.github.lalyos</groupId>
       <artifactId>jfiglet</artifactId>
       <version>${jfiglet.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-email</artifactId>
+      <version>${commons-email.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/modules/jooby-commons-email/pom.xml
+++ b/modules/jooby-commons-email/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4.0.0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-commons-email</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <!-- commons email -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-email</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-commons-email/src/main/java/io/jooby/email/CommonsEmailModule.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/email/CommonsEmailModule.java
@@ -1,0 +1,119 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.email;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.jooby.Extension;
+import io.jooby.Jooby;
+import io.jooby.ServiceKey;
+import io.jooby.ServiceRegistry;
+import io.jooby.internal.email.HtmlEmailProvider;
+import io.jooby.internal.email.ImageHtmlEmailProvider;
+import io.jooby.internal.email.MultiPartEmailProvider;
+import io.jooby.internal.email.SimpleEmailProvider;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.HtmlEmail;
+import org.apache.commons.mail.ImageHtmlEmail;
+import org.apache.commons.mail.MultiPartEmail;
+import org.apache.commons.mail.SimpleEmail;
+
+import javax.annotation.Nonnull;
+import javax.inject.Provider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * <h1>commons email</h1>
+ * <p>
+ * Small but helpful module that provides access to {@link Email} instances via
+ * the service registry and {@link Config}.
+ * </p>
+ *
+ * <h1>usage</h1>
+ *
+ * application.conf:
+ *
+ * <pre>
+ *  mail.hostName = smtp.googlemail.com
+ *  mail.ssl.onConnect = true
+ *  mail.username = username
+ *  mail.password = password
+ *  mail.from = user&#64;gmail.com
+ *  mail.subject = TestMail
+ * </pre>
+ *
+ * <pre>
+ * {
+ *   install(new CommonsEmailModule());
+ *
+ *   get("/send", ctx {@literal ->} {
+ *     require(SimpleEmail.class)
+ *        .setMsg("you got an email!")
+ *        .setTo("foo&#64;bar.com")
+ *        .send();
+ *   });
+ * }
+ * </pre>
+ *
+ * <p>
+ * That's all it does! Every time you require an email, it creates one and setup properties from
+ * <code>mail.*</code>.
+ * </p>
+ *
+ * @author edgar
+ * @since 2.8.9
+ */
+public class CommonsEmailModule implements Extension {
+
+  private final String name;
+
+  /**
+   * Creates a {@link CommonsEmailModule}.
+   *
+   * @param name Name of the property who has the mail information. Default is: <code>mail.*</code>.
+   */
+  public CommonsEmailModule(String name) {
+    this.name = requireNonNull(name, "Mail name is required.");
+  }
+
+  /**
+   * Creates a {@link CommonsEmailModule}.
+   */
+  public CommonsEmailModule() {
+    this("mail");
+  }
+
+  @Override
+  public void install(@Nonnull Jooby application) throws Exception {
+    Config appConfig = application.getConfig();
+
+    Config mail = appConfig.getConfig(name)
+        .withFallback(appConfig.getConfig("mail"))
+        .withFallback(defaults(appConfig));
+
+    ServiceRegistry services = application.getServices();
+
+    register(services, SimpleEmail.class, new SimpleEmailProvider(mail));
+    register(services, HtmlEmail.class, new HtmlEmailProvider(mail));
+    register(services, MultiPartEmail.class, new MultiPartEmailProvider(mail));
+    register(services, ImageHtmlEmail.class, new ImageHtmlEmailProvider(mail));
+  }
+
+  private <T> void register(ServiceRegistry services, Class<T> clazz, Provider<T> provider) {
+    services.putIfAbsent(clazz, provider);
+    services.put(ServiceKey.key(clazz, name), provider);
+  }
+
+  private Config defaults(Config appConfig) {
+    final Map<String, Object> defaults = new HashMap<>();
+    defaults.put("charset", appConfig.getString("application.charset"));
+    return ConfigFactory.parseMap(defaults, CommonsEmailModule.class.getSimpleName() + "#defaults(...)");
+  }
+}

--- a/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/EmailFactory.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/EmailFactory.java
@@ -1,0 +1,93 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.email;
+
+import com.typesafe.config.Config;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.HtmlEmail;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+public class EmailFactory {
+
+  private interface EmailSetter {
+    void apply(String p) throws Exception;
+  }
+
+  private final Config mail;
+
+  public EmailFactory(final Config mail) {
+    this.mail = requireNonNull(mail, "Mail config is required.");
+  }
+
+  public <T extends Email> T newEmail(final T email) {
+    try {
+      ifset("username", p -> email.setAuthentication(mail.getString(p), mail.getString("password")));
+
+      ifset("bcc", p -> email.setBcc(address(strList(p))));
+      ifset("bounceAddress", p -> email.setBounceAddress(mail.getString(p)));
+      ifset("cc", p -> email.setCc(address(strList(p))));
+      email.setCharset(mail.getString("charset"));
+      ifset("debug", p -> email.setDebug(mail.getBoolean(p)));
+      ifset("from", p -> email.setFrom(mail.getString(p)));
+      ifset("hostName", p -> email.setHostName(mail.getString(p)));
+      ifset("msg", p -> {
+        if (email instanceof HtmlEmail) {
+          ((HtmlEmail) email).setHtmlMsg(mail.getString(p));
+        } else {
+          email.setMsg(mail.getString(p));
+        }
+      });
+      ifset("replyTo", p -> email.setReplyTo(address(mail.getStringList(p))));
+      ifset("sendPartial", p -> email.setSendPartial(mail.getBoolean(p)));
+      ifset("smtpPort", p -> email.setSmtpPort(mail.getInt(p)));
+      ifset("socketConnectionTimeout",
+          p -> email.setSocketConnectionTimeout((int) mail.getDuration(p, TimeUnit.MILLISECONDS)));
+      ifset("socketTimeout",
+          p -> email.setSocketTimeout((int) mail.getDuration(p, TimeUnit.MILLISECONDS)));
+      ifset("ssl.checkServerIdentity", p -> email.setSSLCheckServerIdentity(mail.getBoolean(p)));
+      ifset("ssl.onConnect", p -> email.setSSLOnConnect(mail.getBoolean(p)));
+      ifset("ssl.smtpPort", p -> email.setSslSmtpPort(mail.getString(p)));
+      ifset("startTLSEnabled", p -> email.setStartTLSEnabled(mail.getBoolean(p)));
+      ifset("startTLSRequired", p -> email.setStartTLSRequired(mail.getBoolean(p)));
+      ifset("subject", p -> email.setSubject(mail.getString(p)));
+      ifset("to", p -> email.setTo(address(strList(p))));
+
+      return email;
+    } catch (Exception ex) {
+      throw new IllegalArgumentException(ex);
+    }
+  }
+
+  private List<String> strList(final String p) {
+    Object list = mail.getAnyRef(p);
+    if (list instanceof String) {
+      return singletonList(list.toString());
+    }
+    return mail.getStringList(p);
+  }
+
+  private List<InternetAddress> address(final List<String> list) throws AddressException {
+    List<InternetAddress> addresses = new ArrayList<>(list.size());
+    for (String addr : list) {
+      addresses.add(new InternetAddress(addr));
+    }
+    return addresses;
+  }
+
+  private void ifset(final String key, final EmailSetter setter) throws Exception {
+    if (mail.hasPath(key)) {
+      setter.apply(key);
+    }
+  }
+}

--- a/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/HtmlEmailProvider.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/HtmlEmailProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.email;
+
+import javax.inject.Provider;
+
+import org.apache.commons.mail.HtmlEmail;
+
+import com.typesafe.config.Config;
+
+public class HtmlEmailProvider implements Provider<HtmlEmail> {
+
+  private final EmailFactory factory;
+
+  public HtmlEmailProvider(final Config mail) {
+    factory = new EmailFactory(mail);
+  }
+
+  @Override
+  public HtmlEmail get() {
+    return factory.newEmail(new HtmlEmail());
+  }
+}

--- a/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/ImageHtmlEmailProvider.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/ImageHtmlEmailProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.email;
+
+import javax.inject.Provider;
+
+import org.apache.commons.mail.ImageHtmlEmail;
+
+import com.typesafe.config.Config;
+
+public class ImageHtmlEmailProvider implements Provider<ImageHtmlEmail> {
+
+  private final EmailFactory factory;
+
+  public ImageHtmlEmailProvider(final Config mail) {
+    factory = new EmailFactory(mail);
+  }
+
+  @Override
+  public ImageHtmlEmail get() {
+    return factory.newEmail(new ImageHtmlEmail());
+  }
+}

--- a/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/MultiPartEmailProvider.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/MultiPartEmailProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.email;
+
+import javax.inject.Provider;
+
+import org.apache.commons.mail.MultiPartEmail;
+
+import com.typesafe.config.Config;
+
+public class MultiPartEmailProvider implements Provider<MultiPartEmail> {
+
+  private final EmailFactory factory;
+
+  public MultiPartEmailProvider(final Config mail) {
+    factory = new EmailFactory(mail);
+  }
+
+  @Override
+  public MultiPartEmail get() {
+    return factory.newEmail(new MultiPartEmail());
+  }
+}

--- a/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/SimpleEmailProvider.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/internal/email/SimpleEmailProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.email;
+
+import javax.inject.Provider;
+
+import org.apache.commons.mail.SimpleEmail;
+
+import com.typesafe.config.Config;
+
+public class SimpleEmailProvider implements Provider<SimpleEmail> {
+
+  private final EmailFactory factory;
+
+  public SimpleEmailProvider(final Config mail) {
+    factory = new EmailFactory(mail);
+  }
+
+  @Override
+  public SimpleEmail get() {
+    return factory.newEmail(new SimpleEmail());
+  }
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -56,6 +56,8 @@
     <module>jooby-spring</module>
     <module>jooby-weld</module>
 
+    <module>jooby-commons-email</module>
+
     <module>jooby-archetype</module>
 
     <module>jooby-run</module>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,9 @@
     <log4j.version>2.13.3</log4j.version>
     <slf4j.version>1.7.30</slf4j.version>
 
+    <!-- communication -->
+    <commons-email.version>1.5</commons-email.version>
+
     <!-- util -->
     <jfiglet.version>0.0.8</jfiglet.version>
 
@@ -942,6 +945,13 @@
         <groupId>com.github.lalyos</groupId>
         <artifactId>jfiglet</artifactId>
         <version>${jfiglet.version}</version>
+      </dependency>
+
+      <!-- commons email -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-email</artifactId>
+        <version>${commons-email.version}</version>
       </dependency>
 
       <!-- jboss-modules -->


### PR DESCRIPTION
Almost a 1:1 port of `commons-email` module from Jooby 1.x

The only change is that only the `charset` is configured by default, and it is taken directly from `application.getConfig()`.

I created a `defaults(Config appConfig)` method to populate the default config for clarity. This method also sets an `originDescription` so the source of default configuration can be easily identified.