### PR TITLE
Asm support for java 11

### DIFF
--- a/jooby/src/main/java/org/jooby/internal/RouteMetadata.java
+++ b/jooby/src/main/java/org/jooby/internal/RouteMetadata.java
@@ -289,7 +289,7 @@ public class RouteMetadata implements ParameterNameProvider {
   }
 
   private static ClassVisitor visitor(final Map<String, Object> md) {
-    return new ClassVisitor(Opcodes.ASM5) {
+    return new ClassVisitor(Opcodes.ASM7) {
 
       @Override
       public MethodVisitor visitMethod(final int access, final String name,
@@ -308,7 +308,7 @@ public class RouteMetadata implements ParameterNameProvider {
         int minIdx = ((access & Opcodes.ACC_STATIC) > 0) ? 0 : 1;
         int maxIdx = Arrays.stream(args).mapToInt(Type::getSize).sum();
 
-        return new MethodVisitor(Opcodes.ASM5) {
+        return new MethodVisitor(Opcodes.ASM7) {
 
           private int i = 0;
 

--- a/modules/jooby-apitool/src/main/java/org/jooby/internal/apitool/TypeDescriptorParser.java
+++ b/modules/jooby-apitool/src/main/java/org/jooby/internal/apitool/TypeDescriptorParser.java
@@ -222,7 +222,7 @@ class TypeDescriptorParser extends SignatureVisitor {
   private int index;
 
   private TypeDescriptorParser(final ClassLoader loader) {
-    super(Opcodes.ASM5);
+    super(Opcodes.ASM7);
     this.loader = loader;
   }
 

--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -14,7 +14,7 @@
   <akka.version>2.5.13</akka.version>
   <antlr4-runtime.version>4.7</antlr4-runtime.version>
   <api-console.version>3.0.17</api-console.version>
-  <asm.version>7.2-beta</asm.version>
+  <asm.version>7.3.1</asm.version>
   <async-http-client.version>1.9.40</async-http-client.version>
   <avaje-agentloader.version>2.1.2</avaje-agentloader.version>
   <aws-java-sdk.version>1.11.358</aws-java-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3155,7 +3155,7 @@ org.eclipse.jdt.apt.processorOptions/defaultOverwrite=true
     <akka.version>2.5.13</akka.version>
     <antlr4-runtime.version>4.7</antlr4-runtime.version>
     <api-console.version>3.0.17</api-console.version>
-    <asm.version>7.2-beta</asm.version>
+    <asm.version>7.3.1</asm.version>
     <async-http-client.version>1.9.40</async-http-client.version>
     <avaje-agentloader.version>2.1.2</avaje-agentloader.version>
     <aws-java-sdk.version>1.11.358</aws-java-sdk.version>


### PR DESCRIPTION
This PR refers to issue https://github.com/jooby-project/jooby/issues/1345 , which I posted about a year ago.

We were hoping that the issue above was resolved with 1.6.4 and revisited migrating our software to JAVA 11. Unfortunately we still got an ASM error (see issue above) with Jooby Version 1.6.7.


After some debugging we figured out that including the latest ASM dependency would not solve our problem as the ClassVisitors defined by jooby would always use ASM5. JAVA 11 however requires ASM7.

We therefore suggest to create the ClassVisitors using ASMv7. We also bumped the ASM version to the latest 7.x version.

We would really appreciate seeing that change in the next Jooby 1.x maintenance release :)

Greetings
Tobi

