### PR TITLE
Print "forcibly closed by the remote host" message on debug level only

### DIFF
--- a/jooby/src/main/java/io/jooby/Server.java
+++ b/jooby/src/main/java/io/jooby/Server.java
@@ -134,7 +134,7 @@ public interface Server {
       String message = cause.getMessage();
       if (message != null) {
         String msg = message.toLowerCase();
-        return msg.contains("reset by peer") || msg.contains("broken pipe");
+        return msg.contains("reset by peer") || msg.contains("broken pipe") || msg.contains("forcibly closed");
       }
     }
     return (cause instanceof ClosedChannelException) || (cause instanceof EOFException);


### PR DESCRIPTION
Could close #1867 