### PR TITLE
fixed issue with pebble's allowUnsafeMethods option

### DIFF
--- a/modules/jooby-pebble/src/main/java/io/jooby/pebble/PebbleModule.java
+++ b/modules/jooby-pebble/src/main/java/io/jooby/pebble/PebbleModule.java
@@ -195,7 +195,7 @@ public class PebbleModule implements Extension {
         builder.strictVariables(conf.getBoolean("pebble.strictVariables"));
       }
       if (conf.hasPath("pebble.allowUnsafeMethods")) {
-        if (conf.getBoolean("")) {
+        if (conf.getBoolean("pebble.allowUnsafeMethods")) {
           builder.methodAccessValidator(new NoOpMethodAccessValidator());
         } else {
           builder.methodAccessValidator(new BlacklistMethodAccessValidator());


### PR DESCRIPTION
Fixes issue when config contains `allowUnsafeMethods` option for pebble module:
```
com.typesafe.config.ConfigException$BadPath: path parameter: Invalid path '': path has a leading, trailing, or two adjacent period '.' (use quoted "" empty string if you want an empty element)
```