### PR TITLE
Include 'jooby-commons-email' in dependency management.

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -299,6 +299,12 @@
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
+      <artifactId>jooby-commons-email</artifactId>
+      <version>${jooby.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>io.jooby</groupId>
       <artifactId>jooby-cli</artifactId>
       <version>${jooby.version}</version>
       <type>jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,12 @@
 
       <dependency>
         <groupId>io.jooby</groupId>
+        <artifactId>jooby-commons-email</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jooby</groupId>
         <artifactId>jooby-cli</artifactId>
         <version>${jooby.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes #1927.