### PR TITLE
Ignoring @ContextParam annotated parameters for OpenAPI

### DIFF
--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
@@ -175,6 +175,10 @@ public class AnnotationParser {
       "kotlin.coroutines.Continuation"
   ).stream().collect(Collectors.toSet());
 
+  static final Set<String> IGNORED_ANNOTATIONS = Arrays.asList(
+      ContextParam.class.getName()
+  ).stream().collect(Collectors.toSet());
+
   public static List<OperationExt> parse(ParserContext ctx, String prefix,
       Signature signature, MethodInsnNode node) {
     if (signature.matches(Class.class) ||
@@ -347,6 +351,13 @@ public class AnnotationParser {
         } else {
           annotations = Collections.emptyList();
         }
+
+        if (annotations != null && annotations.stream()
+            .anyMatch(n -> IGNORED_ANNOTATIONS.contains(ASMType.parse(n.desc)))) {
+
+          continue;
+        }
+
         ParamType paramType = ParamType.find(annotations);
 
         /** Required: */

--- a/modules/jooby-openapi/src/test/java/issues/i1934/App1934.java
+++ b/modules/jooby-openapi/src/test/java/issues/i1934/App1934.java
@@ -1,0 +1,9 @@
+package issues.i1934;
+
+import io.jooby.Jooby;
+
+public class App1934 extends Jooby {
+  {
+    mvc(new Controller1934());
+  }
+}

--- a/modules/jooby-openapi/src/test/java/issues/i1934/Controller1934.java
+++ b/modules/jooby-openapi/src/test/java/issues/i1934/Controller1934.java
@@ -1,0 +1,16 @@
+package issues.i1934;
+
+import examples.Person;
+import io.jooby.annotations.ContextParam;
+import io.jooby.annotations.GET;
+import io.jooby.annotations.Path;
+
+@Path("/openapi")
+public class Controller1934 {
+
+  @GET
+  @Path("me")
+  public Person getUserInformation(@ContextParam Person user) {
+    return user;
+  }
+}

--- a/modules/jooby-openapi/src/test/java/issues/i1934/Issue1934.java
+++ b/modules/jooby-openapi/src/test/java/issues/i1934/Issue1934.java
@@ -1,0 +1,22 @@
+package issues.i1934;
+
+import io.jooby.internal.openapi.ResponseExt;
+import io.jooby.openapi.OpenAPITest;
+import io.jooby.openapi.RouteIterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class Issue1934 {
+
+  @OpenAPITest(value = App1934.class, ignoreArguments = true)
+  public void shouldParseContextParamArg(RouteIterator iterator) {
+    iterator.next(route -> {
+          assertNull(route.getParameters());
+          ResponseExt response = route.getDefaultResponse();
+          assertEquals("200", response.getCode());
+          assertEquals("Success", response.getDescription());
+          assertEquals("examples.Person", response.getJavaType());
+        }).verify();
+  }
+}


### PR DESCRIPTION
The exception was thrown because `io.jooby.internal.openapi.AnnotationParser.ParamType#CONTEXT` doesn't override `setIn(...)`.

But I guess `@ContextParam` parameters should not be part of the generated API, so I created an ignore list based on annotations.

Another possibility would be to skip based on the determined `ParamType`. I also found that although the `FORM` `ParamType` overrides `setIn(...)`, it is never called.

Could close #1934 
