### PR TITLE
Ability to access the current context via the service registry

### DIFF
--- a/docs/asciidoc/context.adoc
+++ b/docs/asciidoc/context.adoc
@@ -1,6 +1,46 @@
 == Context
 
-A javadoc:Context[Context] allows you to interact with the HTTP Request and manipulate the HTTP Response
+A javadoc:Context[Context] allows you to interact with the HTTP Request and manipulate the HTTP Response.
+
+In most of the cases you can access the context object as a parameter of your route handler:
+
+.Java
+[source, java, role="primary"]
+----
+{
+  get("/", ctx -> { /* do important stuff with variable 'ctx'. */ });
+}
+----
+
+.Kotlin
+[source, kotlin, role="secondary"]
+----
+{
+  get("/") { /* variable 'it' holds the context now. */ }
+}
+----
+
+If you need to access the context via the service registry or dependency injection, you need to
+explicitly request the registration of it as a service with the following invocation:
+
+.Java
+[source, java, role="primary"]
+----
+{
+  setContextAsService(true);
+}
+----
+
+.Kotlin
+[source, kotlin, role="secondary"]
+----
+{
+  setContextAsService(true)
+}
+----
+
+Important to note that the context is a *request scoped* object, it's only available through the service
+registry while the request it belongs to is being processed.
 
 === Parameters
 
@@ -35,14 +75,14 @@ response.
 [source, kotlin, role="secondary"]
 ----
 {
-  get("/") {
+  get("/") { ctx ->
     val token = ctx.header("token").value() // <1>
 
     val headers = ctx.headers()             // <2>
 
-    val = ctx.headerMap();                  // <3>
+    val headerMap = ctx.headerMap();        // <3>
     ...
-  });
+  }
   
 }
 ----
@@ -74,12 +114,12 @@ Request cookies are send to the server using the `Cookie` header, but we do prov
 [source, kotlin, role="secondary"]
 ----
 {
-  get("/") {
+  get("/") { ctx ->
     val token = ctx.cookie("token").value() // <1>
 
-    val = ctx.cookieMap();                  // <2>
+    val cookieMap = ctx.cookieMap()         // <2>
     ...
-  });
+  }
   
 }
 ----
@@ -111,15 +151,15 @@ Path parameter are part of the `URI`. To define a path variable you need to use 
 [source,kotlin,role="secondary"]
 ----
 {
-  get("/{id}") { ctx.path("id").value() }                                 // <1>
+  get("/{id}") { ctx -> ctx.path("id").value() }                                 // <1>
   
-  get("/@{id}") { ctx.path("id").value() }                                // <2>
+  get("/@{id}") { ctx -> ctx.path("id").value() }                                // <2>
   
-  get("/file/{name}.{ext}") { cxt.path("name") + "." + ctx.path("ext") }  // <3>
+  get("/file/{name}.{ext}") { ctx -> cxt.path("name") + "." + ctx.path("ext") }  // <3>
   
-  get("/file/*") { ctx.path("*") }                                        // <4>
+  get("/file/*") { ctx -> ctx.path("*") }                                        // <4>
 
-  get("/{id:[0-9]+}") { ctx.path("id) }                                   // <5>
+  get("/{id:[0-9]+}") { ctx -> ctx.path("id) }                                   // <5>
 }
 ----
 
@@ -151,7 +191,7 @@ Path parameter are part of the `URI`. To define a path variable you need to use 
 [source, kotlin, role="secondary"]
 ----
 {
-  get("/{name}") {
+  get("/{name}") { ctx ->
     val pathString = ctx.getRequestPath()  // <1>
     
     val path = ctx.path()                 // <2>
@@ -161,7 +201,7 @@ Path parameter are part of the `URI`. To define a path variable you need to use 
     val name = ctx.path("name").value()   // <4>
 
     ...    
-  });
+  }
 }
 ----
 
@@ -226,7 +266,7 @@ class SearchQuery {
 [source, kotlin, role="secondary"]
 ----
 {
-  get("/search") {
+  get("/search") { ctx ->
     val queryString = ctx.queryString()         // <1>
 
     val query = ctx.query()                     // <2>
@@ -238,7 +278,7 @@ class SearchQuery {
     val searchQuery = ctx.query<SearchQuery>()  // <5>
 
     ...
-  });
+  }
 }
 
 data class SearchQuery (val q: String)
@@ -316,7 +356,7 @@ class User {
 [source, kotlin, role="secondary"]
 ----
 {
-  post("/user") {
+  post("/user") { ctx ->
     val form = ctx.form()               // <1>
 
     val formMap = ctx.formMultimap()    // <2>
@@ -328,7 +368,7 @@ class User {
     val user = ctx.form<User>()         // <5>
     
     ...
-  });
+  }
 }
 
 data class User (val id: String, val pass: String)
@@ -390,7 +430,7 @@ class User {
 [source, kotlin, role="secondary"]
 ----
 {
-  post("/user") {
+  post("/user") { ctx ->
     val multipart = ctx.multipart()              // <1>
 
     val multipartMap = ctx.multipartMultimap()   // <2>
@@ -404,7 +444,7 @@ class User {
     val user = ctx.multipart<User>()             // <6>
 
     ...
-  });
+  }
 }
 
 data class User (val id: String, val pass: String, val pic: FileUpload)
@@ -499,7 +539,7 @@ a javadoc:Session[] but the lifecycle is shorter: *data is kept for only one req
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
-  get("/") {
+  get("/") { ctx ->
     ctx.flash("success").value("Welcome!")         <3>
   }
   

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -629,6 +629,11 @@ public class Jooby implements Router, Registry {
     return this;
   }
 
+  @Nonnull @Override public Jooby setContextAsService(boolean contextAsService) {
+    router.setContextAsService(contextAsService);
+    return this;
+  }
+
   @Nonnull @Override public Jooby setHiddenMethod(@Nonnull String parameterName) {
     router.setHiddenMethod(parameterName);
     return this;

--- a/jooby/src/main/java/io/jooby/Router.java
+++ b/jooby/src/main/java/io/jooby/Router.java
@@ -242,6 +242,15 @@ public interface Router extends Registry {
    */
   @Nonnull Router setCurrentUser(@Nullable Function<Context, Object> provider);
 
+  /**
+   * If enabled, allows to retrieve the {@link Context} object associated with the current
+   * request via the service registry while the request is being processed.
+   *
+   * @param contextAsService whether to enable or disable this feature
+   * @return This router.
+   */
+  @Nonnull Router setContextAsService(boolean contextAsService);
+
   /* ***********************************************************************************************
    * use(Router)
    * ***********************************************************************************************

--- a/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
+++ b/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
@@ -1,0 +1,32 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal;
+
+import io.jooby.Context;
+import io.jooby.RequestScope;
+
+import javax.inject.Provider;
+
+import static io.jooby.RequestScope.bind;
+import static io.jooby.RequestScope.unbind;
+
+public class ContextAsServiceInitializer implements ContextInitializer, Provider<Context> {
+
+  public static final ContextAsServiceInitializer INSTANCE = new ContextAsServiceInitializer();
+
+  private ContextAsServiceInitializer() {}
+
+  @Override
+  public void apply(Context ctx) {
+    bind(this, ctx);
+    ctx.onComplete(context -> unbind(this));
+  }
+
+  @Override
+  public Context get() {
+    return RequestScope.get(this);
+  }
+}

--- a/jooby/src/main/java/io/jooby/internal/Pipeline.java
+++ b/jooby/src/main/java/io/jooby/internal/Pipeline.java
@@ -231,7 +231,7 @@ public class Pipeline {
   }
 
   private static Handler kotlinJob(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
-    return next(mode, executor, new DetachHandler(new KotlinJobHandler(next.getPipeline())),
+    return next(mode, executor, new DetachHandler(decorate(next, initializer, new KotlinJobHandler(next.getPipeline()))),
         false);
   }
 

--- a/jooby/src/main/java/io/jooby/internal/Pipeline.java
+++ b/jooby/src/main/java/io/jooby/internal/Pipeline.java
@@ -16,6 +16,7 @@ import io.jooby.internal.handler.CompletionStageHandler;
 import io.jooby.internal.handler.DefaultHandler;
 import io.jooby.internal.handler.DetachHandler;
 import io.jooby.internal.handler.DispatchHandler;
+import io.jooby.internal.handler.PostDispatchInitializerHandler;
 import io.jooby.internal.handler.KotlinJobHandler;
 import io.jooby.internal.handler.SendAttachment;
 import io.jooby.internal.handler.SendByteArray;
@@ -47,46 +48,46 @@ import java.util.concurrent.Executor;
 public class Pipeline {
 
   public static Handler compute(ClassLoader loader, Route route, ExecutionMode mode,
-      Executor executor, List<ResponseHandler> responseHandler) {
+      Executor executor, ContextInitializer initializer, List<ResponseHandler> responseHandler) {
     Type returnType = route.getReturnType();
     Class<?> type = Reified.rawType(returnType);
     if (CompletionStage.class.isAssignableFrom(type)) {
-      return completableFuture(mode, route, executor);
+      return completableFuture(mode, route, executor, initializer);
     }
     /** Rx 2: */
     // Single:
     Optional<Class> single = loadClass(loader, "io.reactivex.Single");
     if (single.isPresent()) {
       if (single.get().isAssignableFrom(type)) {
-        return single(mode, route, executor);
+        return single(mode, route, executor, initializer);
       }
     }
     // Maybe:
     Optional<Class> maybe = loadClass(loader, "io.reactivex.Maybe");
     if (maybe.isPresent()) {
       if (maybe.get().isAssignableFrom(type)) {
-        return rxMaybe(mode, route, executor);
+        return rxMaybe(mode, route, executor, initializer);
       }
     }
     // Flowable:
     Optional<Class> flowable = loadClass(loader, "io.reactivex.Flowable");
     if (flowable.isPresent()) {
       if (flowable.get().isAssignableFrom(type)) {
-        return rxFlowable(mode, route, executor);
+        return rxFlowable(mode, route, executor, initializer);
       }
     }
     // Observable:
     Optional<Class> observable = loadClass(loader, "io.reactivex.Observable");
     if (observable.isPresent()) {
       if (observable.get().isAssignableFrom(type)) {
-        return rxObservable(mode, route, executor);
+        return rxObservable(mode, route, executor, initializer);
       }
     }
     // Disposable
     Optional<Class> disposable = loadClass(loader, "io.reactivex.disposables.Disposable");
     if (disposable.isPresent()) {
       if (disposable.get().isAssignableFrom(type)) {
-        return rxDisposable(mode, route, executor);
+        return rxDisposable(mode, route, executor, initializer);
       }
     }
     /** Reactor: */
@@ -94,33 +95,33 @@ public class Pipeline {
     Optional<Class> flux = loadClass(loader, "reactor.core.publisher.Flux");
     if (flux.isPresent()) {
       if (flux.get().isAssignableFrom(type)) {
-        return reactorFlux(mode, route, executor);
+        return reactorFlux(mode, route, executor, initializer);
       }
     }
     // Mono:
     Optional<Class> mono = loadClass(loader, "reactor.core.publisher.Mono");
     if (mono.isPresent()) {
       if (mono.get().isAssignableFrom(type)) {
-        return reactorMono(mode, route, executor);
+        return reactorMono(mode, route, executor, initializer);
       }
     }
     /** Kotlin: */
     Optional<Class> deferred = loadClass(loader, "kotlinx.coroutines.Deferred");
     if (deferred.isPresent()) {
       if (deferred.get().isAssignableFrom(type)) {
-        return kotlinJob(mode, route, executor);
+        return kotlinJob(mode, route, executor, initializer);
       }
     }
     Optional<Class> job = loadClass(loader, "kotlinx.coroutines.Job");
     if (job.isPresent()) {
       if (job.get().isAssignableFrom(type)) {
-        return kotlinJob(mode, route, executor);
+        return kotlinJob(mode, route, executor, initializer);
       }
     }
     Optional<Class> continuation = loadClass(loader, "kotlin.coroutines.Continuation");
     if (continuation.isPresent()) {
       if (continuation.get().isAssignableFrom(type)) {
-        return kotlinContinuation(mode, route, executor);
+        return kotlinContinuation(mode, route, executor, initializer);
       }
     }
 
@@ -128,7 +129,7 @@ public class Pipeline {
     Optional<Class> publisher = loadClass(loader, "org.reactivestreams.Publisher");
     if (publisher.isPresent()) {
       if (publisher.get().isAssignableFrom(type)) {
-        return reactivePublisher(mode, route, executor);
+        return reactivePublisher(mode, route, executor, initializer);
       }
     }
     /** Context: */
@@ -136,114 +137,117 @@ public class Pipeline {
       if (executor == null && mode == ExecutionMode.EVENT_LOOP) {
         return next(mode, executor, new DetachHandler(route.getPipeline()), false);
       }
-      return next(mode, executor, decorate(route, new SendDirect(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendDirect(route.getPipeline())), true);
     }
     /** InputStream: */
     if (InputStream.class.isAssignableFrom(type)) {
-      return next(mode, executor, decorate(route, new SendStream(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendStream(route.getPipeline())), true);
     }
     /** FileChannel: */
     if (FileChannel.class.isAssignableFrom(type) || Path.class.isAssignableFrom(type) || File.class
         .isAssignableFrom(type)) {
-      return next(mode, executor, decorate(route, new SendFileChannel(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendFileChannel(route.getPipeline())), true);
     }
     /** FileDownload: */
     if (FileDownload.class.isAssignableFrom(type)) {
-      return next(mode, executor, decorate(route, new SendAttachment(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendAttachment(route.getPipeline())), true);
     }
     /** Strings: */
     if (CharSequence.class.isAssignableFrom(type)) {
-      return next(mode, executor, decorate(route, new SendCharSequence(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendCharSequence(route.getPipeline())), true);
     }
     /** RawByte: */
     if (byte[].class == type) {
-      return next(mode, executor, decorate(route, new SendByteArray(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendByteArray(route.getPipeline())), true);
     }
     if (ByteBuffer.class.isAssignableFrom(type)) {
-      return next(mode, executor, decorate(route, new SendByteBuffer(route.getPipeline())), true);
+      return next(mode, executor, decorate(route, initializer, new SendByteBuffer(route.getPipeline())), true);
     }
 
     if (responseHandler != null) {
       return responseHandler.stream().filter(it -> it.matches(returnType))
           .findFirst()
           .map(factory ->
-              next(mode, executor, decorate(route, factory.create(route.getPipeline())), true)
+              next(mode, executor, decorate(route, initializer, factory.create(route.getPipeline())), true)
           )
           .orElseGet(
-              () -> next(mode, executor, decorate(route, new DefaultHandler(route.getPipeline())),
+              () -> next(mode, executor, decorate(route, initializer, new DefaultHandler(route.getPipeline())),
                   true));
     }
-    return next(mode, executor, decorate(route, new DefaultHandler(route.getPipeline())), true);
+    return next(mode, executor, decorate(route, initializer, new DefaultHandler(route.getPipeline())), true);
   }
 
-  private static Handler decorate(Route route, Handler handler) {
+  private static Handler decorate(Route route, ContextInitializer initializer, Handler handler) {
     Handler pipeline = handler;
     if (route.isHttpHead()) {
       pipeline = new HeadResponseHandler(pipeline);
     }
-    return pipeline;
+    if (initializer == null) {
+      return pipeline;
+    }
+    return new PostDispatchInitializerHandler(initializer, pipeline);
   }
 
-  private static Handler completableFuture(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler completableFuture(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new CompletionStageHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new CompletionStageHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler rxFlowable(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler rxFlowable(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new RxFlowableHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new RxFlowableHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler reactivePublisher(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler reactivePublisher(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new ReactivePublisherHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new ReactivePublisherHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler rxDisposable(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler rxDisposable(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new SendDirect(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new SendDirect(next.getPipeline()))),
         false);
   }
 
-  private static Handler rxObservable(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler rxObservable(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new ObservableHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new ObservableHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler reactorFlux(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler reactorFlux(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new ReactorFluxHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new ReactorFluxHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler reactorMono(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler reactorMono(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new ReactorMonoHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new ReactorMonoHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler kotlinJob(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler kotlinJob(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor, new DetachHandler(new KotlinJobHandler(next.getPipeline())),
         false);
   }
 
-  private static Handler kotlinContinuation(ExecutionMode mode, Route next, Executor executor) {
-    return next(mode, executor, new DetachHandler(decorate(next, next.getPipeline())), false);
+  private static Handler kotlinContinuation(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
+    return next(mode, executor, new DetachHandler(decorate(next, initializer, next.getPipeline())), false);
   }
 
-  private static Handler single(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler single(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new RxSingleHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new RxSingleHandler(next.getPipeline()))),
         false);
   }
 
-  private static Handler rxMaybe(ExecutionMode mode, Route next, Executor executor) {
+  private static Handler rxMaybe(ExecutionMode mode, Route next, Executor executor, ContextInitializer initializer) {
     return next(mode, executor,
-        new DetachHandler(decorate(next, new RxMaybeHandler(next.getPipeline()))),
+        new DetachHandler(decorate(next, initializer, new RxMaybeHandler(next.getPipeline()))),
         false);
   }
 

--- a/jooby/src/main/java/io/jooby/internal/RouterImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/RouterImpl.java
@@ -857,6 +857,8 @@ public class RouterImpl implements Router {
   private void removePreDispatchInitializer(ContextInitializer initializer) {
     if (this.preDispatchInitializer instanceof ContextInitializerList) {
       ((ContextInitializerList) initializer).remove(initializer);
+    } else if (this.preDispatchInitializer == initializer) {
+      this.preDispatchInitializer = null;
     }
   }
 
@@ -873,6 +875,8 @@ public class RouterImpl implements Router {
   private void removePostDispatchInitializer(ContextInitializer initializer) {
     if (this.postDispatchInitializer instanceof ContextInitializerList) {
       ((ContextInitializerList) postDispatchInitializer).remove(initializer);
+    } else if (this.postDispatchInitializer == initializer) {
+      this.postDispatchInitializer = null;
     }
   }
 

--- a/jooby/src/main/java/io/jooby/internal/handler/PostDispatchInitializerHandler.java
+++ b/jooby/src/main/java/io/jooby/internal/handler/PostDispatchInitializerHandler.java
@@ -1,0 +1,37 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.handler;
+
+import io.jooby.Context;
+import io.jooby.Route;
+import io.jooby.internal.ContextInitializer;
+
+import javax.annotation.Nonnull;
+
+public class PostDispatchInitializerHandler implements LinkedHandler {
+
+  private final ContextInitializer initializer;
+  private final Route.Handler next;
+
+  public PostDispatchInitializerHandler(ContextInitializer initializer, Route.Handler next) {
+    this.initializer = initializer;
+    this.next = next;
+  }
+
+  @Nonnull @Override public Object apply(@Nonnull Context ctx) {
+    try {
+      initializer.apply(ctx);
+      return next.apply(ctx);
+    } catch (Throwable x) {
+      ctx.sendError(x);
+      return x;
+    }
+  }
+
+  @Override public Route.Handler next() {
+    return next;
+  }
+}

--- a/jooby/src/test/java/io/jooby/internal/PipelineTest.java
+++ b/jooby/src/test/java/io/jooby/internal/PipelineTest.java
@@ -219,7 +219,7 @@ public class PipelineTest {
   }
 
   private Route.Handler pipeline(Route route, ExecutionMode mode, Executor executor) {
-    return Pipeline.compute(getClass().getClassLoader(), route, mode, executor, null);
+    return Pipeline.compute(getClass().getClassLoader(), route, mode, executor, null, null);
   }
 
   private Route route(Type returnType, Route.Handler handler) {

--- a/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
+++ b/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
@@ -557,8 +557,8 @@ public class JettyContext implements DefaultContext {
   @Nonnull @Override public Context onComplete(@Nonnull Route.Complete task) {
     if (listeners == null) {
       listeners = new CompletionListeners();
-      listeners.addListener(task);
     }
+    listeners.addListener(task);
     return this;
   }
 

--- a/tests/src/test/java/io/jooby/i1937/Issue1937.java
+++ b/tests/src/test/java/io/jooby/i1937/Issue1937.java
@@ -1,0 +1,31 @@
+package io.jooby.i1937;
+
+import io.jooby.Context;
+import io.jooby.junit.ServerTest;
+import io.jooby.junit.ServerTestRunner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1937 {
+
+  @ServerTest
+  public void shouldFailIfContextAsServiceWasNotCalled(ServerTestRunner runner) {
+    runner.define(app -> app.get("/i1937", ctx -> {
+      app.require(Context.class);
+      return "OK";
+    })).ready(http -> http.get("/i1937", rsp -> assertEquals(500, rsp.code())));
+  }
+
+  @ServerTest
+  public void shouldWorkIfContextAsServiceWasCalled(ServerTestRunner runner) {
+    runner.define(app -> {
+      app.get("/i1937", ctx -> {
+        app.require(Context.class);
+        return "OK";
+      });
+
+      app.setContextAsService(true);
+
+    }).ready(http -> http.get("/i1937", rsp -> assertEquals(200, rsp.code())));
+  }
+}


### PR DESCRIPTION
Closes #1937

I wrote a simple test case and discovered a problem. With Jetty it works fine but fails with Netty and Undertow (strange because I did my initial tests with Netty, and it was working fine...).

The problem is that Netty and Undertow dispatches the execution to a worker thread. The thread local is initialized by the event loop thread, but then the service registry is queried by the worker thread -> not found.

Do you have an idea how to resolve this?