### PR TITLE
Allow to specify pac4j clients as classes and utilize DI

### DIFF
--- a/modules/jooby-pac4j/src/main/java/io/jooby/internal/pac4j/ClientReference.java
+++ b/modules/jooby-pac4j/src/main/java/io/jooby/internal/pac4j/ClientReference.java
@@ -1,0 +1,70 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.pac4j;
+
+import org.pac4j.core.client.Client;
+import org.pac4j.core.util.Pac4jConstants;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class ClientReference {
+
+  private Class<Client> clientClass;
+  private Client client;
+
+  public ClientReference(Class<Client> clientClass) {
+    this.clientClass = requireNonNull(clientClass);
+  }
+
+  public ClientReference(Client<?> client) {
+    this.client = requireNonNull(client);
+  }
+
+  public Client getClient() {
+    if (isResolved()) {
+      return client;
+    }
+    throw new IllegalStateException("Client of class " + clientClass + " has not been resolved yet.");
+  }
+
+  public boolean isResolved() {
+    return client != null;
+  }
+
+  public void resolve(Function<Class<Client>, Client> resolver) {
+    if (!isResolved()) {
+      client = resolver.apply(clientClass);
+    }
+  }
+
+  /* Thread-safe memoized supplier that computes the client list exactly once;
+   * all clients must be resolved at the time of invocation of the supplier. */
+  public static Supplier<String> lazyClientNameList(List<ClientReference> references) {
+    AtomicReference<String> value = new AtomicReference<>();
+    return () -> {
+      String val = value.get();
+      if (val == null) {
+        synchronized(value) {
+          val = value.get();
+          if (val == null) {
+            val = references.stream()
+                .map(ClientReference::getClient)
+                .map(Client::getName)
+                .collect(joining(Pac4jConstants.ELEMENT_SEPARATOR));
+            value.set(val);
+          }
+        }
+      }
+      return val;
+    };
+  }
+}


### PR DESCRIPTION
May close #1908 

I tried to solve it in a way that only minor modifications are necessary in the existing code and logic.

<details>
<summary>Click for test application.</summary>

```java
package demo;

import io.jooby.Context;
import io.jooby.Jooby;
import io.jooby.di.GuiceModule;
import io.jooby.pac4j.Pac4jModule;
import org.pac4j.core.exception.CredentialsException;
import org.pac4j.core.profile.CommonProfile;
import org.pac4j.http.client.direct.ParameterClient;

import javax.inject.Inject;
import javax.inject.Provider;

public class Pac4JTest extends Jooby {

  {
    install(new GuiceModule());

    setContextAsService(true);

    get("/unprotected", ctx -> "unprotected");

    install(new Pac4jModule().client(CustomClient.class));

    get("/protected", ctx -> "protected");
  }

  static class CustomClient extends ParameterClient {

    @Inject
    private Provider<Context> context;

    public CustomClient() {
      setSupportGetRequest(true);
      setParameterName("auth");
      setAuthenticator((credentials, ctx) -> {
        if (credentials == null || !context.get().query("password")
            .value("42").equals(credentials.getToken())) {
          throw new CredentialsException("Invalid credentials");
        }
        final String token = credentials.getToken();
        final CommonProfile profile = new CommonProfile();
        profile.setId(token);
        credentials.setUserProfile(profile);
      });
    }
  }

  public static void main(String[] args) {
    runApp(args, Pac4JTest::new);
  }
}
```
</details>

The above test app allows to access `/unprotected`, but only allows to access `/protected` like this:
```
/protected?auth=42
/protected?auth=foo&password=foo   <-- uses the injected context to match auth to password
```