### PR TITLE
Throw an exception on attempt to inject Context out of scope

### DIFF
--- a/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
+++ b/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
@@ -7,6 +7,7 @@ package io.jooby.internal;
 
 import io.jooby.Context;
 import io.jooby.RequestScope;
+import io.jooby.exception.RegistryException;
 
 import javax.inject.Provider;
 
@@ -27,6 +28,10 @@ public class ContextAsServiceInitializer implements ContextInitializer, Provider
 
   @Override
   public Context get() {
-    return RequestScope.get(this);
+    Context context = RequestScope.get(this);
+    if (context == null) {
+      throw new RegistryException("Context is not available. Are you getting it from request scope?");
+    }
+    return context;
   }
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
+      <artifactId>jooby-guice</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jooby</groupId>
       <artifactId>jooby-pac4j</artifactId>
       <version>${jooby.version}</version>
     </dependency>

--- a/tests/src/test/java/io/jooby/i1937/Issue1937.java
+++ b/tests/src/test/java/io/jooby/i1937/Issue1937.java
@@ -1,10 +1,13 @@
 package io.jooby.i1937;
 
 import io.jooby.Context;
+import io.jooby.di.GuiceModule;
+import io.jooby.exception.RegistryException;
 import io.jooby.junit.ServerTest;
 import io.jooby.junit.ServerTestRunner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Issue1937 {
 
@@ -27,5 +30,28 @@ public class Issue1937 {
       app.setContextAsService(true);
 
     }).ready(http -> http.get("/i1937", rsp -> assertEquals(200, rsp.code())));
+  }
+
+  @ServerTest
+  public void shouldThrowIfOutOfScope(ServerTestRunner runner) {
+    runner.define(app -> {
+      app.setContextAsService(true);
+      app.onStarted(() -> {
+        Throwable t = assertThrows(RegistryException.class, () -> app.require(Context.class));
+        assertEquals(t.getMessage(), "Context is not available. Are you getting it from request scope?");
+      });
+    }).ready(http -> {});
+  }
+
+  @ServerTest
+  public void shouldThrowIfOutOfScopeWithDI(ServerTestRunner runner) {
+    runner.define(app -> {
+      app.install(new GuiceModule());
+      app.setContextAsService(true);
+      app.onStarted(() -> {
+        Throwable t = assertThrows(RegistryException.class, () -> app.require(Context.class));
+        assertEquals(t.getMessage(), "Context is not available. Are you getting it from request scope?");
+      });
+    }).ready(http -> {});
   }
 }


### PR DESCRIPTION
I found out that when Guice the module is installed and someone tries to fetch the `Context` outside of a request (with `setContextAsService(true)`) `Jooby.require(Context.class)` returns with `null` instead of throwing an exception. This breaks the `@Nonnull` contract of this method.

**Without** Guice it works as expected:
- `require(...)` tries the Service Registry
- finds the provider, calls it, `null` is returned
- `require(...)` tries the DI registry, but there is none
- throws `RegistryException`

**With** Guice it breaks:
- `require(...)` tries the Service Registry
- finds the provider, calls it, `null` is returned
- `require(...)` tries the DI registry, finds Guice registry, calls it
- Guice registry finds the provider since it was taken over from the Service Registry at startup
- Guice calls the provider, `null` is returned
- `require(...)` does not check the return value from DI registry -> return `null`

A possible fix is in this PR, but another possibility is that `require(...)` could perform a `null` check on returned values from DI registry.