### PR TITLE
Advanced cache control for AssetHandler

### DIFF
--- a/docs/asciidoc/static-files.adoc
+++ b/docs/asciidoc/static-files.adoc
@@ -127,7 +127,7 @@ SPAs mode never generates a `NOT FOUND (404)` response, unresolved assets fallba
 
 === Options
 
-The javadoc:AssetHandler[] automatically handles `E-Tag` and `Last-Modified` headers. You can turn
+The javadoc:AssetHandler[] automatically handles `E-Tag` and `Last-Modified` headers. You can
 control these headers programmatically:
 
 .Asset handler options:
@@ -175,5 +175,49 @@ The `maxAge` option set a `Cache-Control` header:
   assets("/static/*", AssetHandler(www)
     .setMaxAge(Duration.ofDays(365))
   );
+}
+----
+
+There is also a javadoc:AssetHandler[setNoCache] method that explicitly forbids web browsers
+to cache assets.
+
+You can use different cache configurations for different assets based on asset name if you
+specify a function via javadoc:AssetHandler[cacheControl, java.util.Function]:
+
+.Per-asset cache control:
+[source, java, role="primary"]
+----
+{
+  AssetSource www = AssetSource.create(Paths.get("www"));
+  assets("/static/*", new AssetHandler(www)
+      .cacheControl(path -> {
+        if (path.endsWith("dont-cache-me.html")) {
+          return CacheControl.noCache(); // disable caching
+        } else if (path.equals("foo.js")) {
+          return CacheControl.defaults()
+              .setETag(false)
+              .setMaxAge(Duration.ofDays(365));
+        } else {
+          return CacheControl.defaults(); // AssetHandler defaults
+        }
+      }));
+}
+----
+
+.Kotlin
+[source, kotlin, role="secondary"]
+----
+{
+  val www = AssetSource.create(Paths.get("www"))
+  assets("/static/*", AssetHandler(www)
+      .cacheControl {
+        when {
+          it.endsWith("dont-cache-me.html") -> CacheControl.noCache() // disable caching
+          it == "foo.js" -> CacheControl.defaults()
+              .setETag(false)
+              .setMaxAge(Duration.ofDays(365))
+          else -> CacheControl.defaults() // AssetHandler defaults
+        }
+      })
 }
 ----

--- a/jooby/src/main/java/io/jooby/CacheControl.java
+++ b/jooby/src/main/java/io/jooby/CacheControl.java
@@ -1,0 +1,150 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * Class allowing the fine tune the browser cache behavior for assets.
+ *
+ * @see AssetHandler
+ * @see AssetHandler#cacheControl(Function)
+ */
+class CacheControl {
+
+  /**
+   * Constant for the max-age parameter, when set, no {@code Cache-Control} header is generated.
+   *
+   * @see #setMaxAge(long)
+   */
+  public static final int UNDEFINED = -1;
+
+  /**
+   * Constant for the max-age parameter, when set, the {@code Cache-Control} header is set to {@code no-store, must-revalidate}.
+   *
+   * @see #setMaxAge(long)
+   */
+  public static final int NO_CACHE = -2;
+
+  private boolean etag = true;
+  private boolean lastModified = true;
+  private long maxAge = -1;
+
+  /**
+   * Returns whether e-tag support is enabled.
+   *
+   * @return {@code true} if enabled.
+   */
+  public boolean isEtag() {
+    return etag;
+  }
+
+  /**
+   * Returns whether the handling of {@code If-Modified-Since} header is enabled.
+   *
+   * @return {@code true} if enabled.
+   */
+  public boolean isLastModified() {
+    return lastModified;
+  }
+
+  /**
+   * Returns the max-age header parameter value.
+   *
+   * @return the max-age header parameter value.
+   */
+  public long getMaxAge() {
+    return maxAge;
+  }
+
+  /**
+   * Turn on/off e-tag support.
+   *
+   * @param etag True for turning on.
+   * @return This instance.
+   */
+  public CacheControl setETag(boolean etag) {
+    this.etag = etag;
+    return this;
+  }
+
+  /**
+   * Turn on/off handling of {@code If-Modified-Since} header.
+   *
+   * @param lastModified True for turning on. Default is: true.
+   * @return This instance.
+   */
+  public CacheControl setLastModified(boolean lastModified) {
+    this.lastModified = lastModified;
+    return this;
+  }
+
+  /**
+   * Set cache-control header with the given max-age value. If max-age is greater than 0.
+   *
+   * @param maxAge Max-age value in seconds.
+   * @return This instance.
+   * @see #UNDEFINED
+   * @see #NO_CACHE
+   */
+  public CacheControl setMaxAge(long maxAge) {
+    this.maxAge = maxAge;
+    return this;
+  }
+
+  /**
+   * Set cache-control header with the given max-age value. If max-age is greater than 0.
+   *
+   * @param maxAge Max-age value in seconds.
+   * @return This instance.
+   */
+  public CacheControl setMaxAge(Duration maxAge) {
+    this.maxAge = maxAge.getSeconds();
+    return this;
+  }
+
+  /**
+   * Set cache-control header to {@code no-store, must-revalidate}, disables e-tag
+   * and {@code If-Modified-Since} header support.
+   *
+   * @return This instance.
+   */
+  public CacheControl setNoCache() {
+    this.etag = false;
+    this.lastModified = false;
+    this.maxAge = NO_CACHE;
+    return this;
+  }
+
+  /**
+   * Returns the default caching configuration for assets.
+   * <ul>
+   *   <li>e-tag support: enabled</li>
+   *   <li>{@code If-Modified-Since} support: enabled</li>
+   *   <li>max-age: {@link #UNDEFINED} (no {@code Cache-Control} header is generated)</li>
+   * </ul>
+   *
+   * @return the default cache configuration.
+   */
+  public static CacheControl defaults() {
+    return new CacheControl();
+  }
+
+  /**
+   * Returns a caching configuration for disabling cache completely.
+   * <ul>
+   *   <li>e-tag support: disabled</li>
+   *   <li>{@code If-Modified-Since} support: disabled</li>
+   *   <li>max-age: {@link #NO_CACHE} (the {@code Cache-Control} header is set to {@code no-store, must-revalidate})</li>
+   * </ul>
+   *
+   * @return the default cache configuration.
+   */
+  public static CacheControl noCache() {
+    return defaults().setNoCache();
+  }
+}

--- a/jooby/src/main/java/io/jooby/CacheControl.java
+++ b/jooby/src/main/java/io/jooby/CacheControl.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
  * @see AssetHandler
  * @see AssetHandler#cacheControl(Function)
  */
-class CacheControl {
+public class CacheControl {
 
   /**
    * Constant for the max-age parameter, when set, no {@code Cache-Control} header is generated.

--- a/jooby/src/main/java/io/jooby/CacheControl.java
+++ b/jooby/src/main/java/io/jooby/CacheControl.java
@@ -142,7 +142,7 @@ public class CacheControl {
    *   <li>max-age: {@link #NO_CACHE} (the {@code Cache-Control} header is set to {@code no-store, must-revalidate})</li>
    * </ul>
    *
-   * @return the default cache configuration.
+   * @return cache configuration that disables caching.
    */
   public static CacheControl noCache() {
     return defaults().setNoCache();

--- a/tests/src/test/java/io/jooby/FeaturedTest.java
+++ b/tests/src/test/java/io/jooby/FeaturedTest.java
@@ -1950,6 +1950,65 @@ public class FeaturedTest {
   }
 
   @ServerTest
+  public void staticAssetsCaching(ServerTestRunner runner) {
+    AssetSource source = AssetSource.create(Router.class.getClassLoader(), "/www");
+
+    // defaults
+    runner.define(app -> {
+      app.assets("/www/?*", new AssetHandler(source));
+    }).ready(client -> {
+      client.get("/www/index.html", rsp -> {
+        assertNotNull(rsp.header("ETag"));
+        assertNotNull(rsp.header("Last-Modified"));
+        assertNull(rsp.header("Cache-Control"));
+      });
+    });
+
+    // no cache for all
+    runner.define(app -> {
+      app.assets("/www/?*", new AssetHandler(source).setNoCache());
+    }).ready(client -> {
+      client.get("/www/index.html", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNull(rsp.header("Last-Modified"));
+        assertEquals("no-store, must-revalidate", rsp.header("Cache-Control"));
+      });
+    });
+
+    // per path config
+    runner.define(app -> {
+      app.assets("/www/?*", new AssetHandler(source)
+        .cacheControl(path -> {
+          if (path.endsWith("about.html")) {
+            return CacheControl.noCache();
+          } else if (path.equals("foo.js")) {
+            return CacheControl.defaults().setETag(false);
+          } else {
+            return CacheControl.defaults();
+          }
+        }));
+    }).ready(client -> {
+      client.get("/www/index.html", rsp -> {
+        assertNotNull(rsp.header("ETag"));
+        assertNotNull(rsp.header("Last-Modified"));
+        assertNull(rsp.header("Cache-Control"));
+      });
+
+      client.get("/www/about.html", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNull(rsp.header("Last-Modified"));
+        assertEquals("no-store, must-revalidate", rsp.header("Cache-Control"));
+      });
+
+      client.get("/www/foo.js", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNotNull(rsp.header("Last-Modified"));
+        assertNull(rsp.header("Cache-Control"));
+      });
+    });
+  }
+
+  @ServerTest
   public void staticSiteFromCpWithPrefixPathAndPrefixLocation(ServerTestRunner runner) {
     runner.define(app -> {
 

--- a/tests/src/test/java/io/jooby/FeaturedTest.java
+++ b/tests/src/test/java/io/jooby/FeaturedTest.java
@@ -2006,6 +2006,36 @@ public class FeaturedTest {
         assertNull(rsp.header("Cache-Control"));
       });
     });
+
+    // spa
+    runner.define(app -> {
+      app.assets("/www/?*", new AssetHandler("index.html", source)
+          .cacheControl(path -> {
+            if (path.endsWith("index.html")) {
+              return CacheControl.noCache();
+            } else {
+              return CacheControl.defaults();
+            }
+          }));
+    }).ready(client -> {
+      client.get("/www", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNull(rsp.header("Last-Modified"));
+        assertEquals("no-store, must-revalidate", rsp.header("Cache-Control"));
+      });
+
+      client.get("/www/index.html", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNull(rsp.header("Last-Modified"));
+        assertEquals("no-store, must-revalidate", rsp.header("Cache-Control"));
+      });
+
+      client.get("/www/some-fancy-spa-page", rsp -> {
+        assertNull(rsp.header("ETag"));
+        assertNull(rsp.header("Last-Modified"));
+        assertEquals("no-store, must-revalidate", rsp.header("Cache-Control"));
+      });
+    });
   }
 
   @ServerTest


### PR DESCRIPTION
We used `AssetHandler` to serve a single page app and it does it great. However we would like to specify alternative cache header config for specific assets. We also need to explicitly disable caching completely for some assets. Currently we use our own asset handler implementation for this.

I created this PR as a basis of discussion for a possible feature for the above functionality in Jooby.

The API could be something like this:

```java
new AssetHandler(source)
        .cacheControl(path -> path.endsWith("about.html"), cacheControl.setNoCache())
        .cacheControl("foo.js", cacheControl -> cacheControl.maxAge(3600).setETag(false))
```

The current changes are a proof of concept and are fully backwards compatible.