### PR TITLE
Cookie API now supports the SameSite parameter

### DIFF
--- a/docs/asciidoc/context.adoc
+++ b/docs/asciidoc/context.adoc
@@ -557,16 +557,16 @@ a javadoc:Session[] but the lifecycle is shorter: *data is kept for only one req
 <3> Display an existing flash attribute `success` or shows `Welcome!`
 
 Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie
-(its name defaults to `jooby.flash`) use the javadoc:Router[setFlashCookieTemplate, Cookie] method:
+(its name defaults to `jooby.flash`) use the javadoc:Router[setFlashCookie, Cookie] method:
 
 .Java
 [source,java,role="primary"]
 ----
 {
-  setFlashCookieTemplate(new Cookie("myflash").setHttpOnly(true));
+  setFlashCookie(new Cookie("myflash").setHttpOnly(true));
   
   // or if you're fine with the default name
-  getFlashCookieTemplate().setHttpOnly(true);
+  getFlashCookie().setHttpOnly(true);
 }
 ----
 
@@ -574,10 +574,10 @@ Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie
 [source,kotlin,role="secondary"]
 ----
 {
-  flashCookieTemplate = Cookie("myflash").setHttpOnly(true)
+  flashCookie = Cookie("myflash").setHttpOnly(true)
 
   // or if you're fine with the default name
-  flashCookieTemplate.isHttpOnly = true
+  flashCookie.isHttpOnly = true
 }
 ----
 

--- a/docs/asciidoc/context.adoc
+++ b/docs/asciidoc/context.adoc
@@ -556,19 +556,29 @@ a javadoc:Session[] but the lifecycle is shorter: *data is kept for only one req
 <2> Redirect to home page
 <3> Display an existing flash attribute `success` or shows `Welcome!`
 
-Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie name
-(defaults to `jooby.flash`) use the javadoc:FlashScope extension:
+Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie
+(its name defaults to `jooby.flash`) use the javadoc:Router[setFlashCookieTemplate, Cookie] method:
 
 .Java
 [source,java,role="primary"]
 ----
-  install(new FlashScope(new Cookie("myflash").setHttpOnly(true)));
+{
+  setFlashCookieTemplate(new Cookie("myflash").setHttpOnly(true));
+  
+  // or if you're fine with the default name
+  getFlashCookieTemplate().setHttpOnly(true);
+}
 ----
 
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
-  install(FlashScope(Cookie("myflash").setHttpOnly(true)))
+{
+  flashCookieTemplate = Cookie("myflash").setHttpOnly(true)
+
+  // or if you're fine with the default name
+  flashCookieTemplate.isHttpOnly = true
+}
 ----
 
 ==== Parameter Lookup

--- a/jooby/src/main/java/io/jooby/DefaultContext.java
+++ b/jooby/src/main/java/io/jooby/DefaultContext.java
@@ -92,7 +92,7 @@ public interface DefaultContext extends Context {
   @Override default @Nonnull FlashMap flash() {
     return (FlashMap) getAttributes()
         .computeIfAbsent(FlashMap.NAME, key -> FlashMap
-            .create(this, getRouter().getFlashCookieTemplate().clone()));
+            .create(this, getRouter().getFlashCookie().clone()));
   }
 
   /**

--- a/jooby/src/main/java/io/jooby/DefaultContext.java
+++ b/jooby/src/main/java/io/jooby/DefaultContext.java
@@ -92,7 +92,7 @@ public interface DefaultContext extends Context {
   @Override default @Nonnull FlashMap flash() {
     return (FlashMap) getAttributes()
         .computeIfAbsent(FlashMap.NAME, key -> FlashMap
-            .create(this, new Cookie(getRouter().getFlashCookie()).setHttpOnly(true)));
+            .create(this, getRouter().getFlashCookieTemplate().clone()));
   }
 
   /**

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -590,12 +590,21 @@ public class Jooby implements Router, Registry {
     return this;
   }
 
-  @Nonnull @Override public String getFlashCookie() {
+  @Deprecated @Nonnull @Override public String getFlashCookie() {
     return router.getFlashCookie();
   }
 
-  @Nonnull @Override public Jooby setFlashCookie(@Nonnull String name) {
+  @Deprecated @Nonnull @Override public Jooby setFlashCookie(@Nonnull String name) {
     router.setFlashCookie(name);
+    return this;
+  }
+
+  @Nonnull @Override public Cookie getFlashCookieTemplate() {
+    return router.getFlashCookieTemplate();
+  }
+
+  @Nonnull @Override public Jooby setFlashCookieTemplate(@Nonnull Cookie flashCookie) {
+    router.setFlashCookieTemplate(flashCookie);
     return this;
   }
 

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -590,21 +590,17 @@ public class Jooby implements Router, Registry {
     return this;
   }
 
-  @Deprecated @Nonnull @Override public String getFlashCookie() {
-    return router.getFlashCookie();
-  }
-
   @Deprecated @Nonnull @Override public Jooby setFlashCookie(@Nonnull String name) {
     router.setFlashCookie(name);
     return this;
   }
 
-  @Nonnull @Override public Cookie getFlashCookieTemplate() {
-    return router.getFlashCookieTemplate();
+  @Nonnull @Override public Cookie getFlashCookie() {
+    return router.getFlashCookie();
   }
 
-  @Nonnull @Override public Jooby setFlashCookieTemplate(@Nonnull Cookie flashCookie) {
-    router.setFlashCookieTemplate(flashCookie);
+  @Nonnull @Override public Jooby setFlashCookie(@Nonnull Cookie flashCookie) {
+    router.setFlashCookie(flashCookie);
     return this;
   }
 

--- a/jooby/src/main/java/io/jooby/Router.java
+++ b/jooby/src/main/java/io/jooby/Router.java
@@ -961,19 +961,11 @@ public interface Router extends Registry {
   @Nonnull Router executor(@Nonnull String name, @Nonnull Executor executor);
 
   /**
-   * Name of the flash cookie. Defaults is: <code>jooby.flash</code>.
-   *
-   * @return Name of the flash cookie. Defaults is: <code>jooby.flash</code>.
-   * @deprecated Use {@link #getFlashCookieTemplate()} instead.
-   */
-  @Deprecated @Nonnull String getFlashCookie();
-
-  /**
    * Set flash cookie name.
    *
    * @param name Flash cookie name.
    * @return This router.
-   * @deprecated Use {@link #setFlashCookieTemplate(Cookie)} instead.
+   * @deprecated Use {@link #setFlashCookie(Cookie)} instead.
    */
   @Deprecated @Nonnull Router setFlashCookie(@Nonnull String name);
 
@@ -982,7 +974,7 @@ public interface Router extends Registry {
    *
    * @return Template for the flash cookie.
    */
-  @Nonnull Cookie getFlashCookieTemplate();
+  @Nonnull Cookie getFlashCookie();
 
   /**
    * Sets a cookie used as a template to generate the flash cookie, allowing
@@ -991,7 +983,7 @@ public interface Router extends Registry {
    * @param flashCookie The cookie template.
    * @return This router.
    */
-  @Nonnull Router setFlashCookieTemplate(@Nonnull Cookie flashCookie);
+  @Nonnull Router setFlashCookie(@Nonnull Cookie flashCookie);
 
   /**
    * Add a custom string value converter.

--- a/jooby/src/main/java/io/jooby/Router.java
+++ b/jooby/src/main/java/io/jooby/Router.java
@@ -964,16 +964,34 @@ public interface Router extends Registry {
    * Name of the flash cookie. Defaults is: <code>jooby.flash</code>.
    *
    * @return Name of the flash cookie. Defaults is: <code>jooby.flash</code>.
+   * @deprecated Use {@link #getFlashCookieTemplate()} instead.
    */
-  @Nonnull String getFlashCookie();
+  @Deprecated @Nonnull String getFlashCookie();
 
   /**
    * Set flash cookie name.
    *
    * @param name Flash cookie name.
    * @return This router.
+   * @deprecated Use {@link #setFlashCookieTemplate(Cookie)} instead.
    */
-  @Nonnull Router setFlashCookie(@Nonnull String name);
+  @Deprecated @Nonnull Router setFlashCookie(@Nonnull String name);
+
+  /**
+   * Template for the flash cookie. Default name is: <code>jooby.flash</code>.
+   *
+   * @return Template for the flash cookie.
+   */
+  @Nonnull Cookie getFlashCookieTemplate();
+
+  /**
+   * Sets a cookie used as a template to generate the flash cookie, allowing
+   * to customize the cookie name and other cookie parameters.
+   *
+   * @param flashCookie The cookie template.
+   * @return This router.
+   */
+  @Nonnull Router setFlashCookieTemplate(@Nonnull Cookie flashCookie);
 
   /**
    * Add a custom string value converter.

--- a/jooby/src/main/java/io/jooby/SameSite.java
+++ b/jooby/src/main/java/io/jooby/SameSite.java
@@ -1,3 +1,8 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
 package io.jooby;
 
 import static java.util.Arrays.stream;

--- a/jooby/src/main/java/io/jooby/SameSite.java
+++ b/jooby/src/main/java/io/jooby/SameSite.java
@@ -1,0 +1,74 @@
+package io.jooby;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * The SameSite attribute of the Set-Cookie HTTP response header allows you to declare
+ * if your cookie should be restricted to a first-party or same-site context.
+ *
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">
+ *   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite</a>
+ */
+public enum SameSite {
+
+  /**
+   * Cookies are allowed to be sent with top-level navigations and will be sent along with
+   * GET request initiated by third party website. This is the default value in modern browsers.
+   */
+  LAX("Lax"),
+
+  /**
+   * Cookies will only be sent in a first-party context and not be sent along with
+   * requests initiated by third party websites.
+   */
+  STRICT("Strict"),
+
+  /**
+   * Cookies will be sent in all contexts, i.e sending cross-origin is allowed.
+   * Requires the {@code Secure} attribute in latest browser versions.
+   */
+  NONE("None");
+
+  SameSite(String value) {
+    this.value = value;
+  }
+
+  private final String value;
+
+  /**
+   * Returns the parameter value used in {@code Set-Cookie}.
+   *
+   * @return the parameter value.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Returns whether this value requires the cookie to be flagged as {@code Secure}.
+   *
+   * @return {@code true} if the cookie should be secure.
+   */
+  public boolean requiresSecure() {
+    return this == NONE;
+  }
+
+  /**
+   * Returns an instance of this class based on value it uses in {@code Set-Cookie}.
+   *
+   * @param value the value.
+   * @return an instance of this class.
+   * @see #getValue()
+   * @throws IllegalArgumentException if an invalid value is specified.
+   */
+  public static SameSite of(String value) {
+    return stream(values())
+        .filter(v -> v.getValue().equals(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Invalid SameSite value '"
+            + value + "'. Use one of: " + stream(values())
+            .map(SameSite::getValue)
+            .collect(joining(", "))));
+  }
+}

--- a/jooby/src/main/java/io/jooby/internal/RouterImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/RouterImpl.java
@@ -732,20 +732,16 @@ public class RouterImpl implements Router {
     return services.require(key);
   }
 
-  @Nonnull @Override public String getFlashCookie() {
-    return flashCookie.getName();
-  }
-
   @Nonnull @Override public Router setFlashCookie(@Nonnull String name) {
     this.flashCookie.setName(name);
     return this;
   }
 
-  @Nonnull @Override public Cookie getFlashCookieTemplate() {
+  @Nonnull @Override public Cookie getFlashCookie() {
     return flashCookie;
   }
 
-  @Nonnull @Override public Router setFlashCookieTemplate(@Nonnull Cookie flashCookie) {
+  @Nonnull @Override public Router setFlashCookie(@Nonnull Cookie flashCookie) {
     this.flashCookie = requireNonNull(flashCookie);
     return this;
   }

--- a/jooby/src/main/java/io/jooby/internal/RouterImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/RouterImpl.java
@@ -8,6 +8,7 @@ package io.jooby.internal;
 import com.typesafe.config.Config;
 import io.jooby.BeanConverter;
 import io.jooby.Context;
+import io.jooby.Cookie;
 import io.jooby.Environment;
 import io.jooby.ErrorHandler;
 import io.jooby.ExecutionMode;
@@ -60,6 +61,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
 
 public class RouterImpl implements Router {
 
@@ -171,7 +174,7 @@ public class RouterImpl implements Router {
 
   private SessionStore sessionStore = SessionStore.memory();
 
-  private String flashName = "jooby.flash";
+  private Cookie flashCookie = new Cookie("jooby.flash").setHttpOnly(true);
 
   private List<ValueConverter> converters;
 
@@ -730,11 +733,20 @@ public class RouterImpl implements Router {
   }
 
   @Nonnull @Override public String getFlashCookie() {
-    return flashName;
+    return flashCookie.getName();
   }
 
   @Nonnull @Override public Router setFlashCookie(@Nonnull String name) {
-    this.flashName = name;
+    this.flashCookie.setName(name);
+    return this;
+  }
+
+  @Nonnull @Override public Cookie getFlashCookieTemplate() {
+    return flashCookie;
+  }
+
+  @Nonnull @Override public Router setFlashCookieTemplate(@Nonnull Cookie flashCookie) {
+    this.flashCookie = requireNonNull(flashCookie);
     return this;
   }
 

--- a/jooby/src/test/java/io/jooby/CookieTest.java
+++ b/jooby/src/test/java/io/jooby/CookieTest.java
@@ -1,9 +1,12 @@
 package io.jooby;
 
 import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CookieTest {
 
@@ -37,5 +40,71 @@ public class CookieTest {
         Cookie.sign("foo=bar&x=u iq", "987654345!$009P"));
     assertEquals("foo=bar&x=u iq", Cookie
         .unsign("RcFzlzECN2Lv32Ie9jfSWVr13j6OjllJwDDZe4mVS4c|foo=bar&x=u iq", "987654345!$009P"));
+  }
+
+  @Test
+  public void testCreateSameSite() {
+    assertEquals(SameSite.LAX, Cookie.create("mycookie",
+        ConfigFactory.parseMap(ImmutableMap.of(
+            "mycookie.name", "foo",
+            "mycookie.value", "bar",
+            "mycookie.sameSite", "Lax")))
+        .map(Cookie::getSameSite)
+        .orElse(null));
+
+    assertEquals(SameSite.NONE, Cookie.create("mycookie",
+        ConfigFactory.parseMap(ImmutableMap.of(
+            "mycookie.name", "foo",
+            "mycookie.value", "bar",
+            "mycookie.sameSite", "None",
+            "mycookie.secure", true)))
+        .map(Cookie::getSameSite)
+        .orElse(null));
+
+    Throwable t1 = assertThrows(IllegalArgumentException.class, () -> Cookie.create("mycookie",
+        ConfigFactory.parseMap(ImmutableMap.of(
+            "mycookie.name", "foo",
+            "mycookie.value", "bar",
+            "mycookie.sameSite", "None"))));
+
+    assertEquals("Cookies with SameSite=None"
+        + " must be flagged as Secure. Call Cookie.setSecure(true)"
+        + " before calling Cookie.setSameSite(...).", t1.getMessage());
+
+    Throwable t2 = assertThrows(IllegalArgumentException.class, () -> Cookie.create("mycookie",
+        ConfigFactory.parseMap(ImmutableMap.of(
+            "mycookie.name", "foo",
+            "mycookie.value", "bar",
+            "mycookie.sameSite", "Cheese"))));
+
+    assertEquals("Invalid SameSite value 'Cheese'. Use one of: Lax, Strict, None", t2.getMessage());
+  }
+
+  @Test
+  public void testSameSiteVsSecure() {
+    Cookie cookie = new Cookie("foo", "bar");
+
+    Throwable t1 = assertThrows(IllegalArgumentException.class, () -> cookie.setSameSite(SameSite.NONE));
+
+    assertEquals("Cookies with SameSite=None"
+        + " must be flagged as Secure. Call Cookie.setSecure(true)"
+        + " before calling Cookie.setSameSite(...).", t1.getMessage());
+
+    cookie.setSecure(true);
+    cookie.setSameSite(SameSite.NONE);
+
+    assertEquals(SameSite.NONE, cookie.getSameSite());
+
+
+    Throwable t2 = assertThrows(IllegalArgumentException.class, () -> cookie.setSecure(false));
+
+    assertEquals("Cookies with SameSite=" + cookie.getSameSite().getValue()
+        + " must be flagged as Secure. Call Cookie.setSameSite(...) with an argument"
+        + " allowing non-secure cookies before calling Cookie.setSecure(false).", t2.getMessage());
+
+    cookie.setSameSite(null);
+    cookie.setSecure(false);
+
+    assertFalse(cookie.isSecure());
   }
 }

--- a/modules/jooby-pac4j/src/main/java/io/jooby/internal/pac4j/WebContextImpl.java
+++ b/modules/jooby-pac4j/src/main/java/io/jooby/internal/pac4j/WebContextImpl.java
@@ -6,8 +6,10 @@
 package io.jooby.internal.pac4j;
 
 import io.jooby.Context;
+import io.jooby.SameSite;
 import io.jooby.Value;
 import io.jooby.pac4j.Pac4jContext;
+import io.jooby.pac4j.Pac4jOptions;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.session.SessionStore;
 
@@ -119,6 +121,12 @@ public class WebContextImpl implements Pac4jContext {
     rsp.setHttpOnly(cookie.isHttpOnly());
     rsp.setMaxAge(cookie.getMaxAge());
     rsp.setSecure(cookie.isSecure());
+
+    SameSite sameSite = context.require(Pac4jOptions.class).getCookieSameSite();
+    if (sameSite != null) {
+      rsp.setSecure(rsp.isSecure() || sameSite.requiresSecure());
+      rsp.setSameSite(sameSite);
+    }
 
     context.setResponseCookie(rsp);
   }

--- a/modules/jooby-pac4j/src/main/java/io/jooby/pac4j/Pac4jModule.java
+++ b/modules/jooby-pac4j/src/main/java/io/jooby/pac4j/Pac4jModule.java
@@ -355,6 +355,8 @@ public class Pac4jModule implements Extension {
   }
 
   @Override public void install(@Nonnull Jooby application) throws Exception {
+    application.getServices().putIfAbsent(Pac4jOptions.class, options);
+
     Clients clients = ofNullable(pac4j.getClients())
         /** No client? set a default one: */
         .orElseGet(Clients::new);

--- a/modules/jooby-pac4j/src/main/java/io/jooby/pac4j/Pac4jOptions.java
+++ b/modules/jooby-pac4j/src/main/java/io/jooby/pac4j/Pac4jOptions.java
@@ -5,6 +5,8 @@
  */
 package io.jooby.pac4j;
 
+import io.jooby.SameSite;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -38,6 +40,8 @@ public class Pac4jOptions {
   private boolean destroySession = true;
 
   private boolean centralLogout;
+
+  private SameSite cookieSameSite;
 
   /**
    * Default url to redirect to after successful login.
@@ -246,6 +250,30 @@ public class Pac4jOptions {
    */
   public @Nonnull Pac4jOptions setDestroySession(boolean destroySession) {
     this.destroySession = destroySession;
+    return this;
+  }
+
+  /**
+   * Returns the 'SameSite' parameter value used for cookies generated
+   * by the pac4j security engine.
+   *
+   * @return An instance of {@link SameSite} or {@code null} if the
+   * 'SameSite' parameter should be omitted.
+   */
+  @Nullable public SameSite getCookieSameSite() {
+    return cookieSameSite;
+  }
+
+  /**
+   * Sets the 'SameSite' parameter value used for cookies generated
+   * by the pac4j security engine, pass {@code null} to omit the
+   * parameter.
+   *
+   * @param sameSite Value for the 'SameSite' parameter or {@code null} to omit it.
+   * @return This options.
+   */
+  public @Nonnull Pac4jOptions setCookieSameSite(@Nullable SameSite sameSite) {
+    cookieSameSite = sameSite;
     return this;
   }
 }

--- a/tests/src/test/java/io/jooby/FeaturedTest.java
+++ b/tests/src/test/java/io/jooby/FeaturedTest.java
@@ -2348,6 +2348,38 @@ public class FeaturedTest {
         assertEquals("f=success=Thank+you%21;Path=/custom;HttpOnly", setCookie);
       });
     });
+
+    runner.define(app -> {
+      app.setContextPath("/custom");
+      app.getFlashCookieTemplate().setName("f").setSameSite(SameSite.LAX);
+
+      app.get("/flash", ctx -> {
+        ctx.flash().put("success", "Thank you!");
+        return ctx.flash();
+      });
+    }).ready(client -> {
+      client.get("/custom/flash", rsp -> {
+        assertEquals(200, rsp.code());
+        String setCookie = rsp.header("Set-Cookie");
+        assertEquals("f=success=Thank+you%21;Path=/custom;SameSite=Lax;HttpOnly", setCookie);
+      });
+    });
+
+    runner.define(app -> {
+      app.setContextPath("/custom");
+      app.setFlashCookieTemplate(new Cookie("f").setSecure(true));
+
+      app.get("/flash", ctx -> {
+        ctx.flash().put("success", "Thank you!");
+        return ctx.flash();
+      });
+    }).ready(client -> {
+      client.get("/custom/flash", rsp -> {
+        assertEquals(200, rsp.code());
+        String setCookie = rsp.header("Set-Cookie");
+        assertEquals("f=success=Thank+you%21;Path=/custom;Secure", setCookie);
+      });
+    });
   }
 
   @ServerTest

--- a/tests/src/test/java/io/jooby/FeaturedTest.java
+++ b/tests/src/test/java/io/jooby/FeaturedTest.java
@@ -2351,7 +2351,7 @@ public class FeaturedTest {
 
     runner.define(app -> {
       app.setContextPath("/custom");
-      app.getFlashCookieTemplate().setName("f").setSameSite(SameSite.LAX);
+      app.getFlashCookie().setName("f").setSameSite(SameSite.LAX);
 
       app.get("/flash", ctx -> {
         ctx.flash().put("success", "Thank you!");
@@ -2367,7 +2367,7 @@ public class FeaturedTest {
 
     runner.define(app -> {
       app.setContextPath("/custom");
-      app.setFlashCookieTemplate(new Cookie("f").setSecure(true));
+      app.setFlashCookie(new Cookie("f").setSecure(true));
 
       app.get("/flash", ctx -> {
         ctx.flash().put("success", "Thank you!");


### PR DESCRIPTION
May close #1998

This PR contains the possible API changes. This should not change anything on the current behavior unless someone sets the parameter explicitly.

We should now decide whether to apply this on any of jooby's cookies (session, flash, pac4j maybe)?
- [DefaultContext](https://github.com/jooby-project/jooby/blob/d6fbe9b552501240719c5ee9c9fe698a059c8ad7/jooby/src/main/java/io/jooby/DefaultContext.java#L95)
- [SessionToken](https://github.com/jooby-project/jooby/blob/d6fbe9b552501240719c5ee9c9fe698a059c8ad7/jooby/src/main/java/io/jooby/SessionToken.java#L131)
- [WebContextImpl](https://github.com/jooby-project/jooby/blob/d6fbe9b552501240719c5ee9c9fe698a059c8ad7/modules/jooby-pac4j/src/main/java/io/jooby/internal/pac4j/WebContextImpl.java#L115)

In Play Framework they use `Lax` by default but it can be overridden from the config: https://github.com/playframework/playframework/pull/7103

pac4j's cookie API does not support it yet, so we should probably not add it by default, maybe allow to set it via configuration.