### PR TITLE
MVC: wrong method signature

### DIFF
--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ModuleCompiler.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ModuleCompiler.java
@@ -152,7 +152,7 @@ public class ModuleCompiler {
   private void install(ClassWriter writer, List<HandlerCompiler> handlers) throws Exception {
     MethodVisitor visitor = writer.visitMethod(ACC_PRIVATE | ACC_STATIC, "install",
         "(Lio/jooby/Jooby;Ljavax/inject/Provider;)V",
-        "(Lio/jooby/Jooby;Ljavax/inject/Provider<" + controllerClass + ">;)V",
+        "(Lio/jooby/Jooby;Ljavax/inject/Provider<" + Type.getObjectType(controllerClass.replace(".", "/")) + ">;)V",
         new String[]{"java/lang/Exception"});
     visitor.visitParameter("app", 0);
     visitor.visitParameter("provider", 0);

--- a/modules/jooby-apt/src/test/java/tests/i1859/Issue1859.java
+++ b/modules/jooby-apt/src/test/java/tests/i1859/Issue1859.java
@@ -13,7 +13,7 @@ public class Issue1859 {
   public void shouldGetNullOnMissingBody() throws Exception {
     new MvcModuleCompilerRunner(new C1859())
         .example(Expected1859.class)
-        .debugModule(app -> {
+        .module(app -> {
           MockRouter router = new MockRouter(app);
           MockContext ctx = new MockContext();
           ctx.setBody(new byte[0]);

--- a/modules/jooby-apt/src/test/java/tests/i2026/C2026.java
+++ b/modules/jooby-apt/src/test/java/tests/i2026/C2026.java
@@ -1,0 +1,13 @@
+package tests.i2026;
+
+import io.jooby.annotations.GET;
+import io.jooby.annotations.Path;
+
+@Path("/api/todo")
+public class C2026 {
+
+  @GET
+  public String handle() {
+    return "TODO...";
+  }
+}

--- a/modules/jooby-apt/src/test/java/tests/i2026/Expected2026.java
+++ b/modules/jooby-apt/src/test/java/tests/i2026/Expected2026.java
@@ -1,0 +1,26 @@
+package tests.i2026;
+
+import javax.inject.Provider;
+
+import io.jooby.Extension;
+import io.jooby.Jooby;
+import io.jooby.MvcFactory;
+import output.MyController;
+
+public class Expected2026 implements MvcFactory {
+
+  private static void install(Jooby application, Provider<C2026> provider) throws Exception {
+    application.get("/api/todo", ctx -> {
+      C2026 myController = provider.get();
+      return myController.handle();
+    });
+  }
+
+  @Override public boolean supports(Class type) {
+    return type == MyController.class;
+  }
+
+  @Override public Extension create(Provider provider) {
+    return app -> install(app, provider);
+  }
+}

--- a/modules/jooby-apt/src/test/java/tests/i2026/Issue2026.java
+++ b/modules/jooby-apt/src/test/java/tests/i2026/Issue2026.java
@@ -1,0 +1,24 @@
+package tests.i2026;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.jooby.MockContext;
+import io.jooby.MockRouter;
+import io.jooby.apt.MvcModuleCompilerRunner;
+
+public class Issue2026 {
+
+  @Test
+  public void shouldGenerateWriteMethodSignature() throws Exception {
+    new MvcModuleCompilerRunner(new C2026())
+        .example(Expected2026.class)
+        .module(app -> {
+          MockRouter router = new MockRouter(app);
+          MockContext ctx = new MockContext();
+          assertEquals("TODO...", router.get("/api/todo", ctx).value().toString());
+        });
+  }
+
+}


### PR DESCRIPTION
Before: `"(Lio/jooby/Jooby;Ljavax/inject/Provider<tests.i2026.C2026>;)V"`
After: `"(Lio/jooby/Jooby;Ljavax/inject/Provider<Ltests/i2026/C2026;>;)V"`
Fix #2026