### PR TITLE
SSL: configure protocol

### DIFF
--- a/docs/asciidoc/servers.adoc
+++ b/docs/asciidoc/servers.adoc
@@ -4,9 +4,9 @@ Jooby comes with three server implementations:
 
 - javadoc:Jetty[]
 - javadoc:Netty[]
-- javadoc:Undertow[]
+- javadoc:Utow[]
 
-Server are automatically registered based on their presence on the project classpath.
+Servers are automatically registered based on their presence on the project classpath.
 
 To use Jetty, add the dependency:
 
@@ -291,3 +291,41 @@ server {
   }
 }
 ----
+
+==== TLS protocol
+
+Default protocol is `TLSv1.3, TLSv1.2`. To override, just do:
+
+.TLS example
+[source,java,role="primary"]
+----
+{
+  setServerOptions(new ServerOptions()
+      .setSsl(new SslOptions().setProtocol("TLSv1.3", "TLSv1.2"))
+  ); 
+}
+----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+{
+  serverOptions {
+    ssl = SslOptions().apply {
+      protocol = listOf("TLSv1.3", "TLSv1.2")
+    }
+  }
+}
+----
+
+If a listed protocol is not supported, it is ignored; however, if you specify a list of protocols,
+none of which are supported, an exception will be thrown.
+
+[NOTE]
+====
+*TLSv1.3 protocol is available in*
+
+- 8u261-b12 from Oracle JDK
+- TLS 1.3 support in OpenJDK is (beside Azul's OpenJSSE) expected to come into 8u272.
+- Java 11.0.3 or higher.
+====

--- a/jooby/src/test/java/io/jooby/SslOptionsTest.java
+++ b/jooby/src/test/java/io/jooby/SslOptionsTest.java
@@ -1,12 +1,16 @@
 package io.jooby;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import org.junit.jupiter.api.Test;
-
 import static com.typesafe.config.ConfigValueFactory.fromAnyRef;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 public class SslOptionsTest {
 
@@ -84,5 +88,31 @@ public class SslOptionsTest {
     assertEquals("ssl/test.crt", options.getCert());
     assertEquals("ssl/test.key", options.getPrivateKey());
     assertEquals("changeit", options.getPassword());
+  }
+
+  @Test
+  public void shouldParseSingleProtocol() {
+    Config config = ConfigFactory.empty()
+        .withValue("ssl.protocol", fromAnyRef("TLSv1.2"))
+        .withValue("ssl.cert", fromAnyRef("ssl/test.crt"))
+        .withValue("ssl.key", fromAnyRef("ssl/test.key"))
+        .withValue("ssl.password", fromAnyRef("changeit"))
+        .resolve();
+
+    SslOptions options = SslOptions.from(config).get();
+    assertEquals(Collections.singletonList("TLSv1.2"), options.getProtocol());
+  }
+
+  @Test
+  public void shouldParseProtocols() {
+    Config config = ConfigFactory.empty()
+        .withValue("ssl.protocol", fromAnyRef(Arrays.asList("TLSv1.2", "TLSv1.3")))
+        .withValue("ssl.cert", fromAnyRef("ssl/test.crt"))
+        .withValue("ssl.key", fromAnyRef("ssl/test.key"))
+        .withValue("ssl.password", fromAnyRef("changeit"))
+        .resolve();
+
+    SslOptions options = SslOptions.from(config).get();
+    assertEquals(Arrays.asList("TLSv1.2", "TLSv1.3"), options.getProtocol());
   }
 }

--- a/modules/jooby-freemarker/src/test/java/io/jooby/freemarker/FreemarkerModuleTest.java
+++ b/modules/jooby-freemarker/src/test/java/io/jooby/freemarker/FreemarkerModuleTest.java
@@ -1,5 +1,18 @@
 package io.jooby.freemarker;
 
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import freemarker.template.Configuration;
@@ -7,18 +20,6 @@ import io.jooby.Environment;
 import io.jooby.Jooby;
 import io.jooby.MockContext;
 import io.jooby.ModelAndView;
-import org.junit.jupiter.api.Test;
-
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.TemporalAdjusters;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Locale;
-
-import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FreemarkerModuleTest {
 
@@ -58,7 +59,8 @@ public class FreemarkerModuleTest {
         .build(new Environment(getClass().getClassLoader(), ConfigFactory.empty(), "test"));
     FreemarkerTemplateEngine engine = new FreemarkerTemplateEngine(freemarker,
         Arrays.asList(".ftl"));
-    MockContext ctx = new MockContext().setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
+    MockContext ctx = new MockContext()
+        .setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
     ctx.getAttributes().put("local", "var");
     String output = engine
         .render(ctx, new ModelAndView("index.ftl")
@@ -73,10 +75,14 @@ public class FreemarkerModuleTest {
         .build(new Environment(getClass().getClassLoader(), ConfigFactory.empty(), "test"));
     FreemarkerTemplateEngine engine = new FreemarkerTemplateEngine(freemarker,
         Arrays.asList(".ftl"));
-    MockContext ctx = new MockContext().setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
+    MockContext ctx = new MockContext()
+        .setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
 
-    Date nextFriday = Date.from(LocalDateTime.now()
-        .with(TemporalAdjusters.next(DayOfWeek.FRIDAY)).toInstant(ZoneOffset.UTC));
+    Date nextFriday = java.util.Date
+        .from(LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.FRIDAY)).atStartOfDay()
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+        );
 
     assertEquals("friday", engine.render(ctx, new ModelAndView("locales.ftl")
         .put("someDate", nextFriday)).trim().toLowerCase());
@@ -96,7 +102,8 @@ public class FreemarkerModuleTest {
         .build(new Environment(getClass().getClassLoader(), ConfigFactory.empty(), "test"));
     FreemarkerTemplateEngine engine = new FreemarkerTemplateEngine(freemarker,
         Arrays.asList(".ftl"));
-    MockContext ctx = new MockContext().setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
+    MockContext ctx = new MockContext()
+        .setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
     ctx.getAttributes().put("local", "var");
     String output = engine
         .render(ctx, new ModelAndView("index.ftl")
@@ -113,7 +120,8 @@ public class FreemarkerModuleTest {
                 ConfigValueFactory.fromAnyRef("foo"))));
     FreemarkerTemplateEngine engine = new FreemarkerTemplateEngine(freemarker,
         Arrays.asList(".ftl"));
-    MockContext ctx = new MockContext().setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
+    MockContext ctx = new MockContext()
+        .setRouter(new Jooby().setLocales(singletonList(Locale.ENGLISH)));
     ctx.getAttributes().put("local", "var");
     String output = engine
         .render(ctx, new ModelAndView("index.ftl"));

--- a/modules/jooby-utow/src/main/java/io/jooby/utow/Utow.java
+++ b/modules/jooby-utow/src/main/java/io/jooby/utow/Utow.java
@@ -5,6 +5,19 @@
  */
 package io.jooby.utow;
 
+import java.net.BindException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.net.ssl.SSLContext;
+
+import org.xnio.Options;
+import org.xnio.Sequence;
+import org.xnio.SslClientAuthMode;
+
 import io.jooby.Jooby;
 import io.jooby.Server;
 import io.jooby.ServerOptions;
@@ -18,16 +31,6 @@ import io.undertow.server.handlers.encoding.ContentEncodingRepository;
 import io.undertow.server.handlers.encoding.DeflateEncodingProvider;
 import io.undertow.server.handlers.encoding.EncodingHandler;
 import io.undertow.server.handlers.encoding.GzipEncodingProvider;
-import org.xnio.Options;
-import org.xnio.SslClientAuthMode;
-
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLContext;
-import java.net.BindException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Web server implementation using <a href="http://undertow.io/">Undertow</a>.
@@ -99,6 +102,8 @@ public class Utow extends Server.Base {
       SSLContext sslContext = options.getSSLContext(application.getEnvironment().getClassLoader());
       if (sslContext != null) {
         builder.addHttpsListener(options.getSecurePort(), options.getHost(), sslContext);
+        SslOptions ssl = options.getSsl();
+        builder.setSocketOption(Options.SSL_ENABLED_PROTOCOLS, Sequence.of(ssl.getProtocol()));
         Optional.ofNullable(options.getSsl())
             .map(SslOptions::getClientAuth)
             .map(this::toSslClientAuthMode)


### PR DESCRIPTION
- Set default protocol to `TLSv1.2, TLSv1.3`
- If a listed protocol is not supported, it is ignored; however, if you specify a list of protocols, none of which are supported, an exception will be thrown.
- Turn off TLSv1 and TLSv1.1 in Jetty
- Fix date tests failure