### PR TITLE
Rocker: move from string builder to byte array

### DIFF
--- a/docs/asciidoc/modules/rocker.adoc
+++ b/docs/asciidoc/modules/rocker.adoc
@@ -94,3 +94,53 @@ import io.jooby.rocker.RockerModule
 
 <1> Install Rocker
 <2> Returns a rocker view
+
+=== Options
+
+Rocker uses a byte buffer to render a view. Default byte buffer size is `4k`. To change the buffer size:
+
+.Java
+[source, java, role="primary"]
+----
+import io.jooby.rocker.RockerModule;
+
+{
+  install(new RockerModule().bufferSize(1024));
+}
+----
+
+.Kotlin
+[source, kt, role="secondary"]
+----
+import io.jooby.rocker.RockerModule
+
+{
+  install(RockerModule().bufferSize(1024)
+}
+----
+
+You can reuse/recycle the buffer using a thread-local approach by setting `reuseBuffer(true)`:
+
+.Java
+[source, java, role="primary"]
+----
+import io.jooby.rocker.RockerModule;
+
+{
+  install(new RockerModule().reuseBuffer(true));
+}
+----
+
+.Kotlin
+[source, kt, role="secondary"]
+----
+import io.jooby.rocker.RockerModule
+
+{
+  install(RockerModule().reuseBuffer(true)
+}
+----
+
+CAUTION: Use with caution due it creates a buffer per thread memory consumption might be high.
+This technique works when the number of available threads is low enough
+(like the number of available processors).

--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -21,7 +21,7 @@
   <archetype-packaging.version>3.2.0</archetype-packaging.version>
   <asm.version>9.0</asm.version>
   <auto-service.version>1.0-rc7</auto-service.version>
-  <aws-java-sdk.version>1.11.885</aws-java-sdk.version>
+  <aws-java-sdk.version>1.11.893</aws-java-sdk.version>
   <boringssl.version>2.0.27.Final</boringssl.version>
   <bucket4j-core.version>4.10.0</bucket4j-core.version>
   <caffeine.version>2.8.5</caffeine.version>
@@ -56,7 +56,7 @@
   <jdbi.version>3.17.0</jdbi.version>
   <jetty.version>9.4.34.v20201102</jetty.version>
   <jfiglet.version>0.0.8</jfiglet.version>
-  <jmespath-java.version>1.11.896</jmespath-java.version>
+  <jmespath-java.version>1.11.893</jmespath-java.version>
   <jooby-maven-plugin.version>2.9.3-SNAPSHOT</jooby-maven-plugin.version>
   <jooby.version>2.9.3-SNAPSHOT</jooby.version>
   <json.version>20200518</json.version>

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyContext.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyContext.java
@@ -146,6 +146,11 @@ public class NettyContext implements DefaultContext, ChannelFutureListener {
     this.method = req.method().name().toUpperCase();
   }
 
+  boolean isHttpGet() {
+    return this.method.length() == 3 && this.method.charAt(0) == 'G' && this.method.charAt(1) == 'E'
+        && this.method.charAt(2) == 'T';
+  }
+
   @Nonnull @Override public Router getRouter() {
     return router;
   }

--- a/modules/jooby-rocker/src/main/java/io/jooby/rocker/ByteBufferOutput.java
+++ b/modules/jooby-rocker/src/main/java/io/jooby/rocker/ByteBufferOutput.java
@@ -1,0 +1,155 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.rocker;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import com.fizzed.rocker.ContentType;
+import com.fizzed.rocker.RockerOutput;
+import com.fizzed.rocker.RockerOutputFactory;
+
+/**
+ * Rocker output that uses a byte array to render the output.
+ *
+ * @author edgar
+ */
+public class ByteBufferOutput implements RockerOutput<ByteBufferOutput> {
+
+  /** Default buffer size: <code>4k</code>. */
+  public static final int BUFFER_SIZE = 4096;
+
+  /**
+   * The maximum size of array to allocate.
+   * Some VMs reserve some header words in an array.
+   * Attempts to allocate larger arrays may result in
+   * OutOfMemoryError: Requested array size exceeds VM limit
+   */
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+  private final ContentType contentType;
+
+  /**
+   * The buffer where data is stored.
+   */
+  protected byte[] buf;
+
+  /**
+   * The number of valid bytes in the buffer.
+   */
+  protected int count;
+
+  ByteBufferOutput(ContentType contentType, int bufferSize) {
+    this.buf = new byte[bufferSize];
+    this.contentType = contentType;
+  }
+
+  void reset() {
+    count = 0;
+  }
+
+  @Override public ContentType getContentType() {
+    return contentType;
+  }
+
+  @Override public Charset getCharset() {
+    return StandardCharsets.UTF_8;
+  }
+
+  @Override public ByteBufferOutput w(String string) {
+    return w(string.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override public ByteBufferOutput w(byte[] bytes) {
+    int len = bytes.length;
+    ensureCapacity(count + len);
+    System.arraycopy(bytes, 0, buf, count, len);
+    count += len;
+    return this;
+  }
+
+  @Override public int getByteLength() {
+    return count;
+  }
+
+  /**
+   * Get a view of the byte buffer.
+   *
+   * @return Byte buffer.
+   */
+  public ByteBuffer toBuffer() {
+    return ByteBuffer.wrap(buf, 0, count);
+  }
+
+  /**
+   * Copy internal byte array into a new array.
+   *
+   * @return Byte array.
+   */
+  public byte[] toByteArray() {
+    byte[] array = new byte[count];
+    System.arraycopy(buf, 0, array, 0, count);
+    return array;
+  }
+
+  private void ensureCapacity(int minCapacity) {
+    // overflow-conscious code
+    if (minCapacity - buf.length > 0) {
+      grow(minCapacity);
+    }
+  }
+
+  /**
+   * Increases the capacity to ensure that it can hold at least the
+   * number of elements specified by the minimum capacity argument.
+   *
+   * @param minCapacity the desired minimum capacity
+   */
+  private void grow(int minCapacity) {
+    // overflow-conscious code
+    int oldCapacity = buf.length;
+    int newCapacity = oldCapacity << 1;
+    if (newCapacity - minCapacity < 0) {
+      newCapacity = minCapacity;
+    }
+    if (newCapacity - MAX_ARRAY_SIZE > 0) {
+      newCapacity = hugeCapacity(minCapacity);
+    }
+    buf = Arrays.copyOf(buf, newCapacity);
+  }
+
+  private static int hugeCapacity(int minCapacity) {
+    if (minCapacity < 0) {
+      throw new OutOfMemoryError();
+    }
+    return (minCapacity > MAX_ARRAY_SIZE)
+        ? Integer.MAX_VALUE
+        : MAX_ARRAY_SIZE;
+  }
+
+  static RockerOutputFactory<ByteBufferOutput> factory(int bufferSize) {
+    return (contentType, charsetName) -> new ByteBufferOutput(contentType, bufferSize);
+  }
+
+  static RockerOutputFactory<ByteBufferOutput> reuse(
+      RockerOutputFactory<ByteBufferOutput> factory) {
+    return new RockerOutputFactory<ByteBufferOutput>() {
+      private final ThreadLocal<ByteBufferOutput> thread = new ThreadLocal<>();
+
+      @Override public ByteBufferOutput create(ContentType contentType, String charsetName) {
+        ByteBufferOutput output = thread.get();
+        if (output == null) {
+          output = factory.create(contentType, charsetName);
+          thread.set(output);
+        }
+        output.reset();
+        return output;
+      }
+    };
+  }
+}

--- a/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerHandler.java
+++ b/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerHandler.java
@@ -5,27 +5,29 @@
  */
 package io.jooby.rocker;
 
+import javax.annotation.Nonnull;
+
 import com.fizzed.rocker.RockerModel;
-import com.fizzed.rocker.runtime.StringBuilderOutput;
+import com.fizzed.rocker.RockerOutputFactory;
 import io.jooby.Context;
 import io.jooby.MediaType;
 import io.jooby.Route;
 
-import javax.annotation.Nonnull;
-
 class RockerHandler implements Route.Handler {
   private final Route.Handler next;
 
-  RockerHandler(Route.Handler next) {
+  private final RockerOutputFactory<ByteBufferOutput> factory;
+
+  RockerHandler(Route.Handler next, RockerOutputFactory<ByteBufferOutput> factory) {
     this.next = next;
+    this.factory = factory;
   }
 
-  @Nonnull @Override public Object apply(@Nonnull Context ctx) throws Exception {
+  @Nonnull @Override public Object apply(@Nonnull Context ctx) {
     try {
       RockerModel template = (RockerModel) next.apply(ctx);
       ctx.setResponseType(MediaType.html);
-      ctx.send(template.render(StringBuilderOutput.FACTORY).toString());
-      return ctx;
+      return ctx.send(template.render(factory).toBuffer());
     } catch (Throwable x) {
       ctx.sendError(x);
       return x;

--- a/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerMessageEncoder.java
+++ b/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerMessageEncoder.java
@@ -5,19 +5,25 @@
  */
 package io.jooby.rocker;
 
+import javax.annotation.Nonnull;
+
 import com.fizzed.rocker.RockerModel;
-import com.fizzed.rocker.runtime.ArrayOfByteArraysOutput;
+import com.fizzed.rocker.RockerOutputFactory;
 import io.jooby.Context;
 import io.jooby.MediaType;
 import io.jooby.MessageEncoder;
 
-import javax.annotation.Nonnull;
-
 class RockerMessageEncoder implements MessageEncoder {
-  @Override public byte[] encode(@Nonnull Context ctx, @Nonnull Object value) throws Exception {
+  private final RockerOutputFactory<ByteBufferOutput> factory;
+
+  RockerMessageEncoder(RockerOutputFactory<ByteBufferOutput> factory) {
+    this.factory = factory;
+  }
+
+  @Override public byte[] encode(@Nonnull Context ctx, @Nonnull Object value) {
     if (value instanceof RockerModel) {
       RockerModel template = (RockerModel) value;
-      ArrayOfByteArraysOutput output = template.render(ArrayOfByteArraysOutput.FACTORY);
+      ByteBufferOutput output = template.render(factory);
       ctx.setResponseLength(output.getByteLength());
       ctx.setDefaultResponseType(MediaType.html);
       return output.toByteArray();

--- a/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerModule.java
+++ b/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerModule.java
@@ -5,12 +5,14 @@
  */
 package io.jooby.rocker;
 
+import javax.annotation.Nonnull;
+
+import com.fizzed.rocker.RockerOutputFactory;
 import com.fizzed.rocker.runtime.RockerRuntime;
 import io.jooby.Environment;
 import io.jooby.Extension;
 import io.jooby.Jooby;
-
-import javax.annotation.Nonnull;
+import io.jooby.ServiceRegistry;
 
 /**
  * Rocker module. It requires some build configuration setup which are documented in the web site.
@@ -23,6 +25,10 @@ public class RockerModule implements Extension {
 
   private Boolean reloading;
 
+  private int bufferSize = ByteBufferOutput.BUFFER_SIZE;
+
+  private boolean reuseBuffer;
+
   /**
    * Turn on/off autoreloading of template for development.
    *
@@ -34,16 +40,47 @@ public class RockerModule implements Extension {
     return this;
   }
 
-  @Override public void install(@Nonnull Jooby application) throws Exception {
+  /**
+   * Configure buffer size to use while rendering. The buffer can grow ups when need it, so this
+   * option works as a hint to allocate initial memory.
+   *
+   * @param bufferSize Buffer size.
+   * @return This module.
+   */
+  public @Nonnull RockerModule useBuffer(int bufferSize) {
+    this.bufferSize = bufferSize;
+    return this;
+  }
+
+  /**
+   * Allow simple reuse of raw byte buffers. It is usually used through <code>ThreadLocal</code>
+   * variable pointing to instance of {@link ByteBufferOutput}.
+   *
+   * @param reuseBuffer True for reuse the buffer. Default is: <code>false</code>
+   * @return This module.
+   */
+  public RockerModule reuseBuffer(boolean reuseBuffer) {
+    this.reuseBuffer = reuseBuffer;
+    return this;
+  }
+
+  @Override public void install(@Nonnull Jooby application) {
     Environment env = application.getEnvironment();
     RockerRuntime runtime = RockerRuntime.getInstance();
     boolean reloading = this.reloading == null
         ? (env.isActive("dev") && runtime.isReloadingPossible())
         : this.reloading.booleanValue();
+    RockerOutputFactory<ByteBufferOutput> factory = ByteBufferOutput.factory(bufferSize);
+    if (reuseBuffer) {
+      factory = ByteBufferOutput.reuse(factory);
+    }
     runtime.setReloading(reloading);
     // response handler
-    application.responseHandler(new RockerResponseHandler());
+    application.responseHandler(new RockerResponseHandler(factory));
     // renderer
-    application.encoder(new RockerMessageEncoder());
+    application.encoder(new RockerMessageEncoder(factory));
+    // factory
+    ServiceRegistry services = application.getServices();
+    services.put(RockerOutputFactory.class, factory);
   }
 }

--- a/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerResponseHandler.java
+++ b/modules/jooby-rocker/src/main/java/io/jooby/rocker/RockerResponseHandler.java
@@ -5,19 +5,26 @@
  */
 package io.jooby.rocker;
 
+import java.lang.reflect.Type;
+
 import com.fizzed.rocker.RockerModel;
+import com.fizzed.rocker.RockerOutputFactory;
 import io.jooby.Reified;
 import io.jooby.ResponseHandler;
 import io.jooby.Route;
 
-import java.lang.reflect.Type;
-
 class RockerResponseHandler implements ResponseHandler {
+  private final RockerOutputFactory<ByteBufferOutput> factory;
+
+  RockerResponseHandler(final RockerOutputFactory<ByteBufferOutput> factory) {
+    this.factory = factory;
+  }
+
   @Override public boolean matches(Type type) {
     return RockerModel.class.isAssignableFrom(Reified.rawType(type));
   }
 
   @Override public Route.Handler create(Route.Handler next) {
-    return new RockerHandler(next);
+    return new RockerHandler(next, factory);
   }
 }


### PR DESCRIPTION
- Replace the StringBuilder output with a byte buffer array
- Byte buffer need to be sized properly to reduce re-allocation and copy
- Default buffer size is 4k
- There is an option to reuse/recycle a byte buffer using a thread local mechanism
- Extra: micro optimization around incoming requests: Ignore HTTP body on GET requests