### PR TITLE
openapi/swagger: Conflicting setter definitions for property

### DIFF
--- a/modules/jooby-openapi/pom.xml
+++ b/modules/jooby-openapi/pom.xml
@@ -57,6 +57,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-models</artifactId>
     </dependency>

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ConflictiveSetter.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ConflictiveSetter.java
@@ -1,0 +1,47 @@
+package io.jooby.internal.openapi;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+
+/**
+ * Fix for:
+ *
+ * Caused by: java.lang.IllegalArgumentException: Conflicting setter definitions for property
+ * 	at com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder.getSetter(POJOPropertyBuilder.java:504)
+ * 	at io.swagger.v3.core.jackson.ModelResolver.ignore(ModelResolver.java:995)
+ * 	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:572)
+ */
+class ConflictiveSetter extends AnnotationIntrospector {
+  @Override public Version version() {
+    return Version.unknownVersion();
+  }
+
+  @Override
+  public AnnotatedMethod resolveSetterConflict(MapperConfig<?> config, AnnotatedMethod setter1,
+      AnnotatedMethod setter2) {
+    Class<?> cls1 = setter1.getRawParameterType(0);
+    Class<?> cls2 = setter2.getRawParameterType(0);
+    if (isArrayLike(cls1, cls2)) {
+      return setter1;
+    }
+    if (isArrayLike(cls2, cls1)) {
+      return setter2;
+    }
+    return null;
+  }
+
+  /**
+   * Returns true if type1 is a list and type2 an array.
+   *
+   * @param type1 Type 1.
+   * @param type2 Type 2.
+   * @return True if type1 is a list and type2 an array.
+   */
+  private boolean isArrayLike(Class type1, Class type2) {
+    return List.class.isAssignableFrom(type1) && type2.isArray();
+  }
+}


### PR DESCRIPTION
- Add a rule to favor List over Array([]) on setters
- Affects SslOptions.setProtocol, Jooby.setLocales
- Not sure why previous version ignore Jooby classes and this one doesn't (2.0.23)
- Get back build

fix #2137