### PR TITLE
HTTP/2 Support

### DIFF
--- a/docs/asciidoc/servers.adoc
+++ b/docs/asciidoc/servers.adoc
@@ -47,6 +47,7 @@ Server options are available via javadoc:ServerOptions[] class:
       .setMaxRequestSize(10485760)
       .setSecurePort(8433)
       .setSsl(SslOptions.selfSigned())
+      .setHttp2(true)
   ); 
 }
 ----
@@ -67,6 +68,7 @@ Server options are available via javadoc:ServerOptions[] class:
     maxRequestSize = 10485760
     securePort = 8443
     ssl = SslOptions.selfSigned()
+    http2 = true
   }
 }
 ----
@@ -80,8 +82,9 @@ Server options are available via javadoc:ServerOptions[] class:
 - singleLoop: Indicates if the web server should use a single loop/group for doing IO or not. **Netty only**.
 - defaultHeaders: Configure server to set the following headers: `Date`, `Content-Type` and `Server` headers.
 - maxRequestSize: Maximum request size in bytes. Request exceeding this value results in 413(REQUEST_ENTITY_TOO_LARGE) response. Default is `10mb`.
-- securePort: Configure Jooby to do HTTPs. This option is fully convered in next section.
-- ssl: SSL options with certificate details.  This option is fully convered in next section.
+- securePort: Enable HTTPS. This option is fully covered in next section.
+- ssl: SSL options with certificate details. This option is fully covered in next section.
+- http2: Enable HTTP 2.0.
 
 Server options are available as application configuration properties too:
 
@@ -98,9 +101,10 @@ server.defaultHeaders = true
 server.maxRequestSize = 10485760
 server.securePort = 8443
 server.ssl.type = self-signed
+server.http2 = true
 ----
 
-=== SSL
+=== HTTPS Support
 
 Jooby supports HTTPS out of the box. By default HTTPS is disabled and all requests are served using 
 HTTP. Jooby supports two certificate formats:
@@ -157,13 +161,13 @@ A better option for development is the https://mkcert.dev[mkcert] tool:
 .Generates a PKCS12 certificate
 [source,bash,role="primary]
 ----
-mkcrt -pkcs12 localhost
+mkcert -pkcs12 localhost
 ----
 
 .Generates a X.509 certificate
 [source,bash,role="secondary"]
 ----
-mkcrt localhost
+mkcert localhost
 ----
 
 ==== Using X.509
@@ -328,4 +332,59 @@ none of which are supported, an exception will be thrown.
 - 8u261-b12 from Oracle JDK
 - TLS 1.3 support in OpenJDK is (beside Azul's OpenJSSE) expected to come into 8u272.
 - Java 11.0.3 or higher.
+====
+
+=== HTTP/2 Support
+
+HTTP2 support is provided across web server implementation. To enable it, you must add one of the
+following dependencies:
+
+HTTP/2 with Jetty:
+[dependency, artifactId="jooby-http2-jetty"]
+.
+
+HTTP/2 with Netty:
+[dependency, artifactId="jooby-http2-netty"]
+.
+
+HTTP/2 with Undertow:
+[dependency, artifactId="jooby-http2-undertow"]
+.
+
+Once the required dependencies are added, Jooby automatically configures HTTP/2.
+
+To use HTTP/2 from browsers you need TLS (the h2 protocol) please refer to
+<<server-https-support, HTTPS support>> to configure TLS.
+
+.HTTP/2
+[source,java,role="primary"]
+----
+{
+  setServerOptions(new ServerOptions()
+      .setSecurePort(8433)
+  );
+  
+  get("/", ctx -> {
+    ctx.getProtocol()
+  })
+}
+----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+{
+  serverOptions {
+    securePort = 8433
+  }
+  
+  get("/") {
+    ctx.protocol
+  } 
+}
+----
+
+[NOTE]
+====
+There is no support for HTTP/2 Push.
 ====

--- a/jooby/src/main/java/io/jooby/Http2Configurer.java
+++ b/jooby/src/main/java/io/jooby/Http2Configurer.java
@@ -1,0 +1,31 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby;
+
+/**
+ * HTTP/2 extension.
+ *
+ * @param <ServerInput> Server input.
+ * @param <ServerOutput> Server output.
+ */
+public interface Http2Configurer<ServerInput, ServerOutput> {
+
+  /**
+   * True whenever the extension supports the current server.
+   *
+   * @param type Server implementation.
+   * @return True whenever the extension supports the current server.
+   */
+  boolean support(Class type);
+
+  /**
+   * Configure server to support HTTP/2.
+   *
+   * @param input Server input.
+   * @return Output or <code>null</code> for side-effect configurer.
+   */
+  ServerOutput configure(ServerInput input);
+}

--- a/jooby/src/main/java/io/jooby/SslOptions.java
+++ b/jooby/src/main/java/io/jooby/SslOptions.java
@@ -295,7 +295,7 @@ public final class SslOptions {
    * @param protocol TLS protocols.
    * @return This options.
    */
-  public SslOptions setProtocol(@Nonnull String... protocol) {
+  public @Nonnull SslOptions setProtocol(@Nonnull String... protocol) {
     return setProtocol(Arrays.asList(protocol));
   }
 
@@ -307,7 +307,7 @@ public final class SslOptions {
    * @param protocol TLS protocols.
    * @return This options.
    */
-  public SslOptions setProtocol(@Nonnull List<String> protocol) {
+  public @Nonnull SslOptions setProtocol(@Nonnull List<String> protocol) {
     this.protocol = protocol;
     return this;
   }

--- a/jooby/src/main/java/io/jooby/internal/SslContextProvider.java
+++ b/jooby/src/main/java/io/jooby/internal/SslContextProvider.java
@@ -13,7 +13,7 @@ public interface SslContextProvider {
 
   boolean supports(String type);
 
-  SSLContext create(ClassLoader loader, SslOptions options);
+  SSLContext create(ClassLoader loader, String provider, SslOptions options);
 
   static SslContextProvider[] providers() {
     return new SslContextProvider[] {new SslPkcs12Provider(), new SslX509Provider()};

--- a/jooby/src/main/java/io/jooby/internal/SslPkcs12Provider.java
+++ b/jooby/src/main/java/io/jooby/internal/SslPkcs12Provider.java
@@ -5,16 +5,17 @@
  */
 package io.jooby.internal;
 
-import io.jooby.SneakyThrows;
-import io.jooby.SslOptions;
+import java.io.InputStream;
+import java.security.KeyStore;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import java.io.InputStream;
-import java.security.KeyStore;
+
+import io.jooby.SneakyThrows;
+import io.jooby.SslOptions;
 
 public class SslPkcs12Provider implements SslContextProvider {
 
@@ -22,14 +23,16 @@ public class SslPkcs12Provider implements SslContextProvider {
     return SslOptions.PKCS12.equalsIgnoreCase(type);
   }
 
-  @Override public SSLContext create(ClassLoader loader, SslOptions options) {
+  @Override public SSLContext create(ClassLoader loader, String provider, SslOptions options) {
     try {
       KeyStore store = keystore(options, loader, options.getCert(), options.getPassword());
       KeyManagerFactory kmf = KeyManagerFactory
           .getInstance(KeyManagerFactory.getDefaultAlgorithm());
       kmf.init(store, toCharArray(options.getPassword()));
       KeyManager[] kms = kmf.getKeyManagers();
-      SSLContext context = SSLContext.getInstance("TLS");
+      SSLContext context = provider == null
+          ? SSLContext.getInstance("TLS")
+          : SSLContext.getInstance("TLS", provider);
 
       TrustManager[] tms;
       if (options.getTrustCert() != null) {

--- a/jooby/src/main/java/io/jooby/internal/SslX509Provider.java
+++ b/jooby/src/main/java/io/jooby/internal/SslX509Provider.java
@@ -5,19 +5,20 @@
  */
 package io.jooby.internal;
 
+import java.io.InputStream;
+
+import javax.net.ssl.SSLContext;
+
 import io.jooby.SneakyThrows;
 import io.jooby.SslOptions;
 import io.jooby.internal.x509.SslContext;
-
-import javax.net.ssl.SSLContext;
-import java.io.InputStream;
 
 public class SslX509Provider implements SslContextProvider {
   @Override public boolean supports(String type) {
     return SslOptions.X509.equalsIgnoreCase(type);
   }
 
-  @Override public SSLContext create(ClassLoader loader, SslOptions options) {
+  @Override public SSLContext create(ClassLoader loader, String provider, SslOptions options) {
     try {
       InputStream trustCert;
       if (options.getTrustCert() == null) {
@@ -30,7 +31,8 @@ public class SslX509Provider implements SslContextProvider {
       String keyStorePass = null;
 
       SSLContext context = SslContext
-          .newServerContextInternal(trustCert, keyStoreCert, keyStoreKey, keyStorePass, 0, 0)
+          .newServerContextInternal(provider, trustCert, keyStoreCert, keyStoreKey,
+              keyStorePass, 0, 0)
           .context();
 
       return context;

--- a/jooby/src/main/java/io/jooby/internal/x509/JdkSslServerContext.java
+++ b/jooby/src/main/java/io/jooby/internal/x509/JdkSslServerContext.java
@@ -62,7 +62,7 @@ public final class JdkSslServerContext extends JdkSslContext {
    * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
    *        {@code 0} to use the default value.
    */
-  public JdkSslServerContext(final InputStream trustCertChainFile,
+  public JdkSslServerContext(final String provider, final InputStream trustCertChainFile,
       final InputStream keyCertChainFile, final InputStream keyFile, final String keyPassword,
       final long sessionCacheSize, final long sessionTimeout) throws SSLException {
 
@@ -75,7 +75,10 @@ public final class JdkSslServerContext extends JdkSslContext {
           keyPassword);
 
       // Initialize the SSLContext to work with our key managers.
-      ctx = SSLContext.getInstance(PROTOCOL);
+      ctx = provider == null
+          ? SSLContext.getInstance(PROTOCOL)
+          : SSLContext.getInstance(PROTOCOL, provider);
+
       ctx.init(keyManagerFactory.getKeyManagers(),
           trustManagerFactory == null ? null : trustManagerFactory.getTrustManagers(),
           null);

--- a/jooby/src/main/java/io/jooby/internal/x509/SslContext.java
+++ b/jooby/src/main/java/io/jooby/internal/x509/SslContext.java
@@ -86,11 +86,11 @@ public abstract class SslContext {
     }
   }
 
-  public static SslContext newServerContextInternal(
+  public static SslContext newServerContextInternal(final String provider,
       final InputStream trustCertChainFile,
       final InputStream keyCertChainFile, final InputStream keyFile, final String keyPassword,
       final long sessionCacheSize, final long sessionTimeout) throws SSLException {
-    return new JdkSslServerContext(trustCertChainFile, keyCertChainFile,
+    return new JdkSslServerContext(provider, trustCertChainFile, keyCertChainFile,
         keyFile, keyPassword, sessionCacheSize, sessionTimeout);
   }
 

--- a/modules/jooby-http2-jetty/pom.xml
+++ b/modules/jooby-http2-jetty/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.9.5-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-http2-jetty</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-jetty</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-alpn-conscrypt-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-http2-jetty/src/main/java/io/jooby/internal/jetty/JettyHttp2Configurer.java
+++ b/modules/jooby-http2-jetty/src/main/java/io/jooby/internal/jetty/JettyHttp2Configurer.java
@@ -1,0 +1,52 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.jetty;
+
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.conscrypt.OpenSSLProvider;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+
+import io.jooby.Http2Configurer;
+
+public class JettyHttp2Configurer
+    implements Http2Configurer<HttpConfiguration, List<ConnectionFactory>> {
+
+  static {
+    if (Security.getProvider("Conscrypt") == null) {
+      Security.addProvider(new OpenSSLProvider());
+    }
+  }
+
+  private static final String H2 = "h2";
+  private static final String H2_17 = "h2-17";
+  private static final String HTTP_1_1 = "http/1.1";
+
+  @Override public boolean support(Class type) {
+    return HttpConfiguration.class == type;
+  }
+
+  @Override public List<ConnectionFactory> configure(HttpConfiguration input) {
+    if (input.getCustomizer(SecureRequestCustomizer.class) != null) {
+      ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory(H2, H2_17, HTTP_1_1);
+      alpn.setDefaultProtocol(HTTP_1_1);
+
+      HTTP2ServerConnectionFactory https2 = new HTTP2ServerConnectionFactory(input);
+
+      return Arrays.asList(alpn, https2);
+    } else {
+      return Collections.singletonList(new HTTP2CServerConnectionFactory(input));
+    }
+  }
+}

--- a/modules/jooby-http2-jetty/src/main/resources/META-INF/services/io.jooby.Http2Configurer
+++ b/modules/jooby-http2-jetty/src/main/resources/META-INF/services/io.jooby.Http2Configurer
@@ -1,0 +1,1 @@
+io.jooby.internal.jetty.JettyHttp2Configurer

--- a/modules/jooby-http2-netty/pom.xml
+++ b/modules/jooby-http2-netty/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.9.5-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-http2-netty</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-netty</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/Http2OrHttp11Handler.java
+++ b/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/Http2OrHttp11Handler.java
@@ -1,0 +1,37 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+import java.util.function.Consumer;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+
+class Http2OrHttp11Handler extends ApplicationProtocolNegotiationHandler {
+
+  private final Consumer<ChannelPipeline> http2;
+  private final Consumer<ChannelPipeline> http1;
+
+  public Http2OrHttp11Handler(Consumer<ChannelPipeline> http1, Consumer<ChannelPipeline> http2) {
+    super(ApplicationProtocolNames.HTTP_1_1);
+    this.http2 = http2;
+    this.http1 = http1;
+  }
+
+  @Override
+  public void configurePipeline(final ChannelHandlerContext ctx, final String protocol) {
+    if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
+      http1.accept(ctx.pipeline());
+    } else if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
+      http2.accept(ctx.pipeline());
+    } else {
+      throw new IllegalStateException("Unknown protocol: " + protocol);
+    }
+  }
+
+}

--- a/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/Http2PrefaceOrHttpHandler.java
+++ b/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/Http2PrefaceOrHttpHandler.java
@@ -1,0 +1,44 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+class Http2PrefaceOrHttpHandler extends ByteToMessageDecoder {
+
+  private static final int PRI = 0x50524920;
+
+  private Consumer<ChannelPipeline> http1;
+
+  private Consumer<ChannelPipeline> http2;
+
+  public Http2PrefaceOrHttpHandler(Consumer<ChannelPipeline> http1,
+      Consumer<ChannelPipeline> http2) {
+    this.http1 = http1;
+    this.http2 = http2;
+  }
+
+  @Override
+  protected void decode(final ChannelHandlerContext ctx, final ByteBuf in, final List<Object> out) {
+    if (in.readableBytes() < 4) {
+      return;
+    }
+
+    if (in.getInt(in.readerIndex()) == PRI) {
+      http2.accept(ctx.pipeline());
+    } else {
+      http1.accept(ctx.pipeline());
+    }
+
+    ctx.pipeline().remove(this);
+  }
+}

--- a/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/NettyHttp2Configurer.java
+++ b/modules/jooby-http2-netty/src/main/java/io/jooby/internal/netty/NettyHttp2Configurer.java
@@ -1,0 +1,64 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+import static io.netty.handler.codec.http.HttpScheme.HTTP;
+
+import io.jooby.Http2Configurer;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http2.DefaultHttp2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
+import io.netty.handler.logging.LogLevel;
+
+public class NettyHttp2Configurer
+    implements Http2Configurer<Http2Extension, ChannelInboundHandler> {
+
+  @Override public boolean support(Class type) {
+    return type == Http2Extension.class;
+  }
+
+  @Override public ChannelInboundHandler configure(Http2Extension extension) {
+    if (extension.isSecure()) {
+      return new Http2OrHttp11Handler(extension::http11,
+          pipeline ->
+              extension.http2(pipeline,
+                  settings -> newHttp2Handler(settings.getMaxRequestSize(), HttpScheme.HTTPS))
+      );
+    } else {
+      return new Http2PrefaceOrHttpHandler(
+          pipeline ->
+              extension.http11Upgrade(pipeline, settings ->
+                  new Http2ServerUpgradeCodec(newHttp2Handler(settings.getMaxRequestSize(), HTTP))),
+
+          pipeline ->
+              extension.http2c(pipeline, settings ->
+                  newHttp2Handler(settings.getMaxRequestSize(), HTTP))
+      );
+    }
+  }
+
+  private Http2ConnectionHandler newHttp2Handler(int maxRequestSize, HttpScheme scheme) {
+    DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
+    InboundHttp2ToHttpAdapter listener = new InboundHttp2ToHttpAdapterBuilder(connection)
+        .propagateSettings(false)
+        .validateHttpHeaders(true)
+        .maxContentLength(maxRequestSize)
+        .build();
+
+    return new HttpToHttp2ConnectionHandlerBuilder()
+        .frameListener(listener)
+        .frameLogger(new Http2FrameLogger(LogLevel.DEBUG))
+        .connection(connection)
+        .httpScheme(scheme)
+        .build();
+  }
+}

--- a/modules/jooby-http2-netty/src/main/resources/META-INF/services/io.jooby.Http2Configurer
+++ b/modules/jooby-http2-netty/src/main/resources/META-INF/services/io.jooby.Http2Configurer
@@ -1,0 +1,1 @@
+io.jooby.internal.netty.NettyHttp2Configurer

--- a/modules/jooby-http2-undertow/pom.xml
+++ b/modules/jooby-http2-undertow/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.9.5-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-http2-undertow</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-utow</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-http2-undertow/src/main/java/io/jooby/internal/undertow/UndertowHttp2Configurer.java
+++ b/modules/jooby-http2-undertow/src/main/java/io/jooby/internal/undertow/UndertowHttp2Configurer.java
@@ -1,0 +1,28 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.undertow;
+
+import static io.undertow.UndertowOptions.ENABLE_HTTP2;
+
+import io.jooby.Http2Configurer;
+import io.undertow.Undertow;
+
+/**
+ * This class is useless, due Undertow comes with built-in support for HTTP/2.
+ *
+ * We need it to normalize usage across web server implementation.
+ */
+public class UndertowHttp2Configurer implements Http2Configurer<Undertow.Builder, Void> {
+
+  @Override public boolean support(Class type) {
+    return Undertow.Builder.class == type;
+  }
+
+  @Override public Void configure(Undertow.Builder input) {
+    input.setServerOption(ENABLE_HTTP2, true);
+    return null;
+  }
+}

--- a/modules/jooby-http2-undertow/src/main/resources/META-INF/services/io.jooby.Http2Configurer
+++ b/modules/jooby-http2-undertow/src/main/resources/META-INF/services/io.jooby.Http2Configurer
@@ -1,0 +1,1 @@
+io.jooby.internal.undertow.UndertowHttp2Configurer

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/Http2Extension.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/Http2Extension.java
@@ -1,0 +1,63 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+
+public class Http2Extension {
+
+  private Http2Settings settings;
+
+  private Consumer<ChannelPipeline> http11;
+
+  private BiConsumer<ChannelPipeline, Supplier<HttpServerUpgradeHandler.UpgradeCodec>> http11Upgrade;
+
+  private BiConsumer<ChannelPipeline, Supplier<ChannelOutboundHandler>> http2;
+
+  private BiConsumer<ChannelPipeline, Supplier<ChannelOutboundHandler>> http2c;
+
+  public Http2Extension(Http2Settings settings,
+      Consumer<ChannelPipeline> http11,
+      BiConsumer<ChannelPipeline, Supplier<HttpServerUpgradeHandler.UpgradeCodec>> http11Upgrade,
+      BiConsumer<ChannelPipeline, Supplier<ChannelOutboundHandler>> http2,
+      BiConsumer<ChannelPipeline, Supplier<ChannelOutboundHandler>> http2c) {
+    this.settings = settings;
+    this.http11 = http11;
+    this.http11Upgrade = http11Upgrade;
+    this.http2 = http2;
+    this.http2c = http2c;
+  }
+
+  public boolean isSecure() {
+    return settings.isSecure();
+  }
+
+  public void http11(ChannelPipeline pipeline) {
+    this.http11.accept(pipeline);
+  }
+
+  public void http2(ChannelPipeline pipeline,
+      Function<Http2Settings, ChannelOutboundHandler> factory) {
+    this.http2.accept(pipeline, () -> factory.apply(settings));
+  }
+
+  public void http2c(ChannelPipeline pipeline,
+      Function<Http2Settings, ChannelOutboundHandler> factory) {
+    this.http2c.accept(pipeline, () -> factory.apply(settings));
+  }
+
+  public void http11Upgrade(ChannelPipeline pipeline,
+      Function<Http2Settings, HttpServerUpgradeHandler.UpgradeCodec> factory) {
+    this.http11Upgrade.accept(pipeline, () -> factory.apply(settings));
+  }
+}

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/Http2Settings.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/Http2Settings.java
@@ -1,0 +1,24 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+public class Http2Settings {
+  private final int maxRequestSize;
+  private final boolean secure;
+
+  public Http2Settings(long maxRequestSize, boolean secure) {
+    this.maxRequestSize = (int) maxRequestSize;
+    this.secure = secure;
+  }
+
+  public boolean isSecure() {
+    return secure;
+  }
+
+  public int getMaxRequestSize() {
+    return maxRequestSize;
+  }
+}

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyPipeline.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyPipeline.java
@@ -5,21 +5,26 @@
  */
 package io.jooby.internal.netty;
 
-import io.jooby.Router;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
-import io.netty.handler.codec.http.multipart.HttpDataFactory;
-import io.netty.handler.ssl.SslContext;
-
-import java.util.concurrent.ScheduledExecutorService;
-
 import static io.jooby.ServerOptions._4KB;
 import static io.jooby.ServerOptions._8KB;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import io.jooby.Http2Configurer;
+import io.jooby.Router;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.handler.ssl.SslContext;
+
 public class NettyPipeline extends ChannelInitializer<SocketChannel> {
+  private static final String H2_HANDSHAKE = "h2-handshake";
 
   private final Router router;
   private final HttpDataFactory factory;
@@ -29,14 +34,17 @@ public class NettyPipeline extends ChannelInitializer<SocketChannel> {
   private final boolean defaultHeaders;
   private final ScheduledExecutorService service;
   private final SslContext sslContext;
+  private final Http2Configurer<Http2Extension, ChannelInboundHandler> http2;
 
   public NettyPipeline(ScheduledExecutorService service, Router router, HttpDataFactory factory,
-      SslContext sslContext,
-      boolean defaultHeaders, Integer compressionLevel, int bufferSize, long maxRequestSize) {
+      SslContext sslContext, Http2Configurer<Http2Extension, ChannelInboundHandler> http2,
+      boolean defaultHeaders,
+      Integer compressionLevel, int bufferSize, long maxRequestSize) {
     this.service = service;
     this.router = router;
     this.factory = factory;
     this.sslContext = sslContext;
+    this.http2 = http2;
     this.defaultHeaders = defaultHeaders;
     this.compressionLevel = compressionLevel;
     this.bufferSize = bufferSize;
@@ -49,12 +57,59 @@ public class NettyPipeline extends ChannelInitializer<SocketChannel> {
     if (sslContext != null) {
       p.addLast("ssl", sslContext.newHandler(ch.alloc()));
     }
-    p.addLast("decoder", new HttpRequestDecoder(_4KB, _8KB, bufferSize, false));
-    p.addLast("encoder", new HttpResponseEncoder());
+    if (http2 == null) {
+      http11(p);
+    } else {
+      Http2Settings settings = new Http2Settings(maxRequestSize, sslContext != null);
+      Http2Extension extension = new Http2Extension(settings,
+          this::http11, this::http11Upgrade, this::http2, this::http2c);
+
+      ChannelInboundHandler handshake = http2.configure(extension);
+
+      p.addLast(H2_HANDSHAKE, handshake);
+
+      if (compressionLevel != null) {
+        p.addLast("compressor", new HttpChunkContentCompressor(compressionLevel));
+      }
+
+      p.addLast("handler", createHandler());
+    }
+  }
+
+  private void http2(ChannelPipeline pipeline, Supplier<ChannelOutboundHandler> factory) {
+    pipeline.addAfter(H2_HANDSHAKE, "http2", factory.get());
+  }
+
+  private void http2c(ChannelPipeline pipeline, Supplier<ChannelOutboundHandler> factory) {
+    pipeline.addAfter(H2_HANDSHAKE, "http2", factory.get());
+  }
+
+  private void http11Upgrade(ChannelPipeline pipeline,
+      Supplier<HttpServerUpgradeHandler.UpgradeCodec> factory) {
+    // direct http1 to h2c
+    HttpServerCodec serverCodec = createServerCodec();
+    pipeline.addAfter(H2_HANDSHAKE, "codec", serverCodec);
+    pipeline.addAfter("codec", "h2upgrade",
+        new HttpServerUpgradeHandler(serverCodec,
+            protocol -> protocol.toString().equals("h2c") ? factory.get() : null,
+            (int) maxRequestSize)
+    );
+  }
+
+  private void http11(ChannelPipeline p) {
+    HttpServerCodec codec = createServerCodec();
+    p.addLast("codec", codec);
     if (compressionLevel != null) {
       p.addLast("compressor", new HttpChunkContentCompressor(compressionLevel));
     }
-    p.addLast("handler", new NettyHandler(service, router, maxRequestSize, bufferSize, factory,
-        defaultHeaders));
+    p.addLast("handler", createHandler());
+  }
+
+  HttpServerCodec createServerCodec() {
+    return new HttpServerCodec(_4KB, _8KB, bufferSize, false);
+  }
+
+  private NettyHandler createHandler() {
+    return new NettyHandler(service, router, maxRequestSize, bufferSize, factory, defaultHeaders);
   }
 }

--- a/modules/jooby-netty/src/main/java/io/jooby/netty/Netty.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/netty/Netty.java
@@ -5,9 +5,15 @@
  */
 package io.jooby.netty;
 
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.StreamSupport.stream;
+
 import java.net.BindException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -15,14 +21,17 @@ import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
 
+import io.jooby.Http2Configurer;
 import io.jooby.Jooby;
 import io.jooby.Server;
 import io.jooby.ServerOptions;
 import io.jooby.SneakyThrows;
 import io.jooby.SslOptions;
+import io.jooby.internal.netty.Http2Extension;
 import io.jooby.internal.netty.NettyPipeline;
 import io.jooby.internal.netty.NettyTransport;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
@@ -30,6 +39,7 @@ import io.netty.handler.codec.http.multipart.DiskAttribute;
 import io.netty.handler.codec.http.multipart.DiskFileUpload;
 import io.netty.handler.codec.http.multipart.HttpDataFactory;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JdkSslContext;
@@ -102,9 +112,23 @@ public class Netty extends Server.Base {
       /** File data factory: */
       HttpDataFactory factory = new DefaultHttpDataFactory(options.getBufferSize());
 
+      Http2Configurer<Http2Extension, ChannelInboundHandler> http2;
+      if (options.isHttp2() == null || options.isHttp2() == Boolean.TRUE) {
+        http2 = stream(
+            spliteratorUnknownSize(
+                ServiceLoader.load(Http2Configurer.class).iterator(),
+                Spliterator.ORDERED),
+            false)
+            .filter(it -> it.support(Http2Extension.class))
+            .findFirst()
+            .orElse(null);
+      } else {
+        http2 = null;
+      }
+
       /** Bootstrap: */
       ServerBootstrap http = transport.configure(acceptorloop, eventloop)
-          .childHandler(newPipeline(factory, null))
+          .childHandler(newPipeline(factory, null, http2))
           .childOption(ChannelOption.SO_REUSEADDR, true)
           .childOption(ChannelOption.TCP_NODELAY, true);
 
@@ -121,7 +145,9 @@ public class Netty extends Server.Base {
         SslOptions.ClientAuth clientAuth = sslOptions.getClientAuth();
         ServerBootstrap https = transport.configure(acceptorloop, eventloop)
             .childHandler(
-                newPipeline(factory, wrap(javaSslContext, toClientAuth(clientAuth), protocol)))
+                newPipeline(factory,
+                    wrap(javaSslContext, toClientAuth(clientAuth), protocol, http2 != null),
+                    http2))
             .childOption(ChannelOption.SO_REUSEADDR, true)
             .childOption(ChannelOption.TCP_NODELAY, true);
 
@@ -152,12 +178,14 @@ public class Netty extends Server.Base {
     }
   }
 
-  private NettyPipeline newPipeline(HttpDataFactory factory, SslContext sslContext) {
+  private NettyPipeline newPipeline(HttpDataFactory factory, SslContext sslContext,
+      Http2Configurer http2) {
     return new NettyPipeline(
         acceptorloop.next(),
         applications.get(0),
         factory,
         sslContext,
+        http2,
         options.getDefaultHeaders(),
         options.getCompressionLevel(),
         options.getBufferSize(),
@@ -182,8 +210,21 @@ public class Netty extends Server.Base {
     return this;
   }
 
-  private SslContext wrap(SSLContext sslContext, ClientAuth clientAuth, String[] protocol) {
-    return new JdkSslContext(sslContext, false, null, IdentityCipherSuiteFilter.INSTANCE,
-        ApplicationProtocolConfig.DISABLED, clientAuth, protocol, false);
+  private SslContext wrap(SSLContext sslContext, ClientAuth clientAuth, String[] protocol,
+      boolean http2) {
+    ApplicationProtocolConfig protocolConfig;
+    if (http2) {
+      protocolConfig = new ApplicationProtocolConfig(ApplicationProtocolConfig.Protocol.ALPN,
+          ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+          ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+          Arrays.asList(ApplicationProtocolNames.HTTP_2, ApplicationProtocolNames.HTTP_1_1));
+    } else {
+      protocolConfig = ApplicationProtocolConfig.DISABLED;
+    }
+    JdkSslContext jdk = new JdkSslContext(sslContext, false, null,
+        IdentityCipherSuiteFilter.INSTANCE,
+        protocolConfig, clientAuth, protocol, false);
+
+    return jdk;
   }
 }

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -21,6 +21,9 @@
     <module>jooby-jetty</module>
     <module>jooby-netty</module>
     <module>jooby-utow</module>
+    <module>jooby-http2-jetty</module>
+    <module>jooby-http2-netty</module>
+    <module>jooby-http2-undertow</module>
 
     <module>jooby-openapi</module>
     <module>jooby-swagger-ui</module>

--- a/pom.xml
+++ b/pom.xml
@@ -235,13 +235,31 @@
 
       <dependency>
         <groupId>io.jooby</groupId>
+        <artifactId>jooby-http2-undertow</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jooby</groupId>
         <artifactId>jooby-netty</artifactId>
         <version>${jooby.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.jooby</groupId>
+        <artifactId>jooby-http2-netty</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jooby</groupId>
         <artifactId>jooby-jetty</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jooby</groupId>
+        <artifactId>jooby-http2-jetty</artifactId>
         <version>${jooby.version}</version>
       </dependency>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,17 +21,17 @@
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
-      <artifactId>jooby-netty</artifactId>
+      <artifactId>jooby-http2-netty</artifactId>
       <version>${jooby.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
-      <artifactId>jooby-utow</artifactId>
+      <artifactId>jooby-http2-undertow</artifactId>
       <version>${jooby.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
-      <artifactId>jooby-jetty</artifactId>
+      <artifactId>jooby-http2-jetty</artifactId>
       <version>${jooby.version}</version>
     </dependency>
     <dependency>
@@ -165,6 +165,13 @@
       <artifactId>fluent-hc</artifactId>
       <version>4.5.13</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-client</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tests/src/test/java/io/jooby/Http2Test.java
+++ b/tests/src/test/java/io/jooby/Http2Test.java
@@ -1,0 +1,150 @@
+package io.jooby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Phaser;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.api.server.ServerSessionListener;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FuturePromise;
+import org.eclipse.jetty.util.Jetty;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import com.google.common.collect.ImmutableMap;
+import io.jooby.junit.ServerTest;
+import io.jooby.junit.ServerTestRunner;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class Http2Test {
+
+  @ServerTest
+  public void http2(ServerTestRunner runner) {
+    runner.define(app -> {
+
+      app.setServerOptions(
+          new ServerOptions()
+              .setHttp2(true)
+              .setSecurePort(8443)
+      );
+
+      app.get("/",
+          ctx -> ImmutableMap.of("secure", ctx.isSecure(), "protocol", ctx.getProtocol(), "scheme",
+              ctx.getScheme()));
+    }).ready((http, https) -> {
+      https.get("/", rsp -> {
+        assertEquals("{secure=true, protocol=HTTP/2.0, scheme=https}",
+            rsp.body().string());
+      });
+      http.get("/", rsp -> {
+        assertEquals("{secure=false, protocol=HTTP/1.1, scheme=http}",
+            rsp.body().string());
+      });
+    });
+  }
+
+  @ServerTest
+  public void http2c(ServerTestRunner runner) {
+    runner.define(app -> {
+      app.setServerOptions(
+          new ServerOptions()
+              .setHttp2(true)
+      );
+
+      app.get("/",
+          ctx -> ImmutableMap.of("secure", ctx.isSecure(), "protocol", ctx.getProtocol(), "scheme",
+              ctx.getScheme()));
+    }).ready(http -> {
+      http.get("/", rsp -> {
+        assertEquals("{secure=false, protocol=HTTP/1.1, scheme=http}",
+            rsp.body().string());
+      });
+
+      hc2(http, "/", rsp -> {
+        assertEquals("{secure=false, protocol=HTTP/2.0, scheme=http}",
+            rsp.body().string());
+      });
+    });
+  }
+
+  private void hc2(WebClient http, String path, SneakyThrows.Consumer<Response> consumer)
+      throws ExecutionException, InterruptedException {
+    HttpFields requestFields = new HttpFields();
+    requestFields.put("User-Agent", h2c.getClass().getName() + "/" + Jetty.VERSION);
+    HttpURI uri = new HttpURI("http://localhost:" + http.getPort() + path);
+    MetaData.Request metaData = new MetaData.Request("GET", uri, HttpVersion.HTTP_2,
+        requestFields);
+    HeadersFrame frame = new HeadersFrame(metaData, null, true);
+    final Phaser phaser = new Phaser(2);
+    FuturePromise<org.eclipse.jetty.http2.api.Session> sessionPromise = new FuturePromise<>();
+    h2c.connect(null, new InetSocketAddress("localhost", http.getPort()),
+        new ServerSessionListener.Adapter(), sessionPromise);
+    Session session = sessionPromise.get();
+    Response.Builder builder = new Response.Builder();
+    session.newStream(frame, new Promise.Adapter<>(), new Stream.Listener.Adapter() {
+      @Override
+      public void onHeaders(final Stream stream, final HeadersFrame frame) {
+        MetaData.Response md = (MetaData.Response) frame.getMetaData();
+        StatusCode statusCode = StatusCode.valueOf(md.getStatus());
+        builder.code(statusCode.value())
+            .message(statusCode.reason());
+        md.forEach(f ->
+            builder.addHeader(f.getName().toLowerCase(), f.getValue().toLowerCase())
+        );
+        if (frame.isEndStream()) {
+          phaser.arrive();
+        }
+      }
+
+      @Override
+      public void onData(final Stream stream, final DataFrame frame, final Callback callback) {
+        byte[] bytes = new byte[frame.getData().remaining()];
+        frame.getData().get(bytes);
+        ResponseBody responseBody = ResponseBody.create(bytes, MediaType.parse("text/plain"));
+        builder.body(responseBody);
+        callback.succeeded();
+        if (frame.isEndStream()) {
+          phaser.arrive();
+        }
+      }
+    });
+
+    phaser.awaitAdvanceInterruptibly(phaser.arrive());
+
+    consumer.accept(
+        builder.request(new Request.Builder().url(uri.toString()).method("GET", null)
+            .build())
+            .protocol(Protocol.HTTP_2)
+            .build()
+    );
+  }
+
+  private static HTTP2Client h2c;
+
+  @BeforeAll
+  public static void init() throws Exception {
+    h2c = new HTTP2Client();
+    h2c.start();
+  }
+
+  @AfterAll
+  public static void close() throws Exception {
+    h2c.stop();
+  }
+}

--- a/tests/src/test/java/io/jooby/HttpsTest.java
+++ b/tests/src/test/java/io/jooby/HttpsTest.java
@@ -11,7 +11,7 @@ public class HttpsTest {
   public void httpsPkcs12(ServerTestRunner runner) {
     runner.define(app -> {
 
-      app.setServerOptions(new ServerOptions().setSecurePort(8433));
+      app.setServerOptions(new ServerOptions().setSecurePort(8443));
       app.get("/",
           ctx -> "schema: " + ctx.getScheme() + "; protocol: " + ctx.getProtocol() + "; secure: "
               + ctx.isSecure() + "; ssl: " + app.getServerOptions().getSsl().getType());
@@ -54,7 +54,7 @@ public class HttpsTest {
       app.setTrustProxy(true);
       app.setContextPath("/secure");
 
-      app.setServerOptions(new ServerOptions().setSecurePort(8433));
+      app.setServerOptions(new ServerOptions().setSecurePort(8443));
 
       app.before(new SSLHandler());
 
@@ -80,7 +80,7 @@ public class HttpsTest {
     runner.define(app -> {
       app.setTrustProxy(true);
 
-      app.setServerOptions(new ServerOptions().setSecurePort(8433));
+      app.setServerOptions(new ServerOptions().setSecurePort(8443));
 
       app.before(new SSLHandler());
 
@@ -106,7 +106,7 @@ public class HttpsTest {
   public void forceSSLStatic(ServerTestRunner runner) {
     runner.define(app -> {
 
-      app.setServerOptions(new ServerOptions().setSecurePort(8433));
+      app.setServerOptions(new ServerOptions().setSecurePort(8443));
 
       app.before(new SSLHandler("static.org"));
 
@@ -131,7 +131,7 @@ public class HttpsTest {
   public void forceSSLStatic2(ServerTestRunner runner) {
     runner.define(app -> {
       app.setContextPath("/ppp");
-      app.setServerOptions(new ServerOptions().setSecurePort(8433));
+      app.setServerOptions(new ServerOptions().setSecurePort(8443));
 
       app.before(new SSLHandler("static.org"));
 

--- a/tests/src/test/java/io/jooby/junit/ServerExtensionImpl.java
+++ b/tests/src/test/java/io/jooby/junit/ServerExtensionImpl.java
@@ -1,10 +1,10 @@
 package io.jooby.junit;
 
 import io.jooby.ExecutionMode;
-import io.jooby.Server;
 import io.jooby.jetty.Jetty;
 import io.jooby.netty.Netty;
 import io.jooby.utow.Utow;
+
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;

--- a/tests/src/test/java/io/jooby/junit/ServerProvider.java
+++ b/tests/src/test/java/io/jooby/junit/ServerProvider.java
@@ -1,14 +1,14 @@
 package io.jooby.junit;
 
-import io.jooby.Server;
-import io.jooby.jetty.Jetty;
-import io.jooby.netty.Netty;
-import io.jooby.utow.Utow;
+import static java.util.stream.StreamSupport.stream;
 
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
-import static java.util.stream.StreamSupport.stream;
+import io.jooby.Server;
+import io.jooby.jetty.Jetty;
+import io.jooby.netty.Netty;
+import io.jooby.utow.Utow;
 
 public class ServerProvider implements Supplier<Server> {
   private Class serverClass;
@@ -40,4 +40,5 @@ public class ServerProvider implements Supplier<Server> {
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException("Server not found: " + serverClass));
   }
+
 }

--- a/tests/src/test/java/io/jooby/junit/ServerTestRunner.java
+++ b/tests/src/test/java/io/jooby/junit/ServerTestRunner.java
@@ -1,17 +1,17 @@
 package io.jooby.junit;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import io.jooby.ExecutionMode;
 import io.jooby.Jooby;
 import io.jooby.Server;
 import io.jooby.ServerOptions;
 import io.jooby.SneakyThrows;
 import io.jooby.WebClient;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class ServerTestRunner {
 
@@ -64,7 +64,9 @@ public class ServerTestRunner {
       if (serverOptions != null) {
         server.setOptions(serverOptions);
       }
+      // HTTP/2 is off while testing unless explicit set
       ServerOptions options = server.getOptions();
+      options.setHttp2(Optional.ofNullable(options.isHttp2()).orElse(Boolean.FALSE));
       options.setPort(Integer.parseInt(System.getenv().getOrDefault("BUILD_PORT", "9999")));
       WebClient https;
       if (options.isSSLEnabled()) {


### PR DESCRIPTION
- Add new/internal extension Http2Configurer
- The new extension operates as function or side-effect  (depends on web server)
- H2, H2C and HTTP 1.1 Upgrade support
- No push support yet
- Update tests
- Update docs

Fixes #1780