### PR TITLE
SSL: Conscrypt provider

### DIFF
--- a/docs/asciidoc/servers.adoc
+++ b/docs/asciidoc/servers.adoc
@@ -329,10 +329,25 @@ none of which are supported, an exception will be thrown.
 ====
 *TLSv1.3 protocol is available in*
 
+- Open SSL via Conscrypt (see next section)
 - 8u261-b12 from Oracle JDK
 - TLS 1.3 support in OpenJDK is (beside Azul's OpenJSSE) expected to come into 8u272.
 - Java 11.0.3 or higher.
 ====
+
+==== OpenSSL
+
+SSL support is provided using built-in JDK capabilities. Jooby offers an OpenSSL support using
+https://github.com/google/conscrypt[Conscrypt].
+
+To enable, just add the required dependency:
+
+[dependency, artifactId="jooby-conscrypt"]
+.
+
+Conscrypt is a Java Security Provider (JSP) that implements parts of the Java Cryptography Extension
+(JCE) and Java Secure Socket Extension (JSSE). It uses https://boringssl.googlesource.com/boringssl[BoringSSL] to provide cryptographic
+primitives and Transport Layer Security (TLS) for Java applications on Android and OpenJDK.
 
 === HTTP/2 Support
 

--- a/jooby/pom.xml
+++ b/jooby/pom.xml
@@ -160,13 +160,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- SSL -->
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-      <optional>true</optional>
-    </dependency>
-
     <!-- unbescape -->
     <dependency>
       <groupId>org.unbescape</groupId>

--- a/jooby/pom.xml
+++ b/jooby/pom.xml
@@ -160,6 +160,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- SSL -->
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- unbescape -->
     <dependency>
       <groupId>org.unbescape</groupId>

--- a/jooby/src/main/java/io/jooby/SslProvider.java
+++ b/jooby/src/main/java/io/jooby/SslProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby;
+
+import java.security.Provider;
+
+/**
+ * Allow to configure a custom SSLContext provider. Default SSL Context is JDK specific.
+ *
+ * OpenSSL (via Conscryt) is available as separated dependency (jooby-conscrypt).
+ *
+ * @author edgar.
+ */
+public interface SslProvider {
+
+  /**
+   * Provider name.
+   *
+   * @return Provider name.
+   */
+  String getName();
+
+  /**
+   * Creates a new provider.
+   *
+   * @return Creates a new provider.
+   */
+  Provider create();
+}

--- a/jooby/src/main/java/io/jooby/internal/SslX509Provider.java
+++ b/jooby/src/main/java/io/jooby/internal/SslX509Provider.java
@@ -28,11 +28,10 @@ public class SslX509Provider implements SslContextProvider {
       }
       InputStream keyStoreCert = options.getResource(loader, options.getCert());
       InputStream keyStoreKey = options.getResource(loader, options.getPrivateKey());
-      String keyStorePass = null;
 
       SSLContext context = SslContext
-          .newServerContextInternal(provider, trustCert, keyStoreCert, keyStoreKey,
-              keyStorePass, 0, 0)
+          .newServerContextInternal(provider, trustCert,
+              keyStoreCert, keyStoreKey, null, 0, 0)
           .context();
 
       return context;

--- a/modules/jooby-conscrypt/pom.xml
+++ b/modules/jooby-conscrypt/pom.xml
@@ -52,25 +52,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <!-- empty javadoc require by Maven Central -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/modules/jooby-conscrypt/pom.xml
+++ b/modules/jooby-conscrypt/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jooby-utow</artifactId>
+  <artifactId>jooby-conscrypt</artifactId>
 
   <dependencies>
     <dependency>
@@ -25,16 +25,10 @@
       <version>${jooby.version}</version>
     </dependency>
 
-    <!-- utow -->
-    <dependency>
-      <groupId>io.undertow</groupId>
-      <artifactId>undertow-core</artifactId>
-    </dependency>
-
+    <!-- SSL -->
     <dependency>
       <groupId>org.conscrypt</groupId>
       <artifactId>conscrypt-openjdk-uber</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -57,4 +51,26 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- empty javadoc require by Maven Central -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/jooby-conscrypt/src/main/java/io/jooby/conscrypt/ConscryptSslProvider.java
+++ b/modules/jooby-conscrypt/src/main/java/io/jooby/conscrypt/ConscryptSslProvider.java
@@ -7,13 +7,19 @@ package io.jooby.conscrypt;
 
 import java.security.Provider;
 
-import org.conscrypt.Conscrypt;
 import org.conscrypt.OpenSSLProvider;
 
 import io.jooby.SslProvider;
 
+/**
+ * OpenSSL/Conscrypt SSL provider.
+ *
+ * @author edgar
+ * @since 2.9.6
+ */
 public class ConscryptSslProvider implements SslProvider {
   private static final String NAME = "Conscrypt";
+
   @Override public String getName() {
     return NAME;
   }

--- a/modules/jooby-conscrypt/src/main/java/io/jooby/conscrypt/ConscryptSslProvider.java
+++ b/modules/jooby-conscrypt/src/main/java/io/jooby/conscrypt/ConscryptSslProvider.java
@@ -1,0 +1,24 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.conscrypt;
+
+import java.security.Provider;
+
+import org.conscrypt.Conscrypt;
+import org.conscrypt.OpenSSLProvider;
+
+import io.jooby.SslProvider;
+
+public class ConscryptSslProvider implements SslProvider {
+  private static final String NAME = "Conscrypt";
+  @Override public String getName() {
+    return NAME;
+  }
+
+  @Override public Provider create() {
+    return new OpenSSLProvider(NAME);
+  }
+}

--- a/modules/jooby-conscrypt/src/main/resources/META-INF/services/io.jooby.SslProvider
+++ b/modules/jooby-conscrypt/src/main/resources/META-INF/services/io.jooby.SslProvider
@@ -1,0 +1,1 @@
+io.jooby.conscrypt.ConscryptSslProvider

--- a/modules/jooby-http2-jetty/pom.xml
+++ b/modules/jooby-http2-jetty/pom.xml
@@ -25,6 +25,13 @@
       <version>${jooby.version}</version>
     </dependency>
 
+    <!-- SSL -->
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-conscrypt</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
       <artifactId>http2-server</artifactId>

--- a/modules/jooby-http2-jetty/src/main/java/io/jooby/internal/jetty/JettyHttp2Configurer.java
+++ b/modules/jooby-http2-jetty/src/main/java/io/jooby/internal/jetty/JettyHttp2Configurer.java
@@ -5,12 +5,10 @@
  */
 package io.jooby.internal.jetty;
 
-import java.security.Security;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.conscrypt.OpenSSLProvider;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
@@ -22,12 +20,6 @@ import io.jooby.Http2Configurer;
 
 public class JettyHttp2Configurer
     implements Http2Configurer<HttpConfiguration, List<ConnectionFactory>> {
-
-  static {
-    if (Security.getProvider("Conscrypt") == null) {
-      Security.addProvider(new OpenSSLProvider());
-    }
-  }
 
   private static final String H2 = "h2";
   private static final String H2_17 = "h2-17";

--- a/modules/jooby-jetty/src/main/java/io/jooby/jetty/Jetty.java
+++ b/modules/jooby-jetty/src/main/java/io/jooby/jetty/Jetty.java
@@ -133,10 +133,9 @@ public class Jetty extends io.jooby.Server.Base {
       server.addConnector(http);
 
       if (options.isSSLEnabled()) {
-        String provider = http2 == null ? null : "Conscrypt";
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory
-            .setSslContext(options.getSSLContext(application.getEnvironment().getClassLoader(), provider));
+            .setSslContext(options.getSSLContext(application.getEnvironment().getClassLoader()));
         List<String> protocol = options.getSsl().getProtocol();
         sslContextFactory.setIncludeProtocols(protocol.toArray(new String[0]));
         // exclude

--- a/modules/jooby-utow/src/main/java/io/jooby/internal/undertow/ConscriptAlpnProvider.java
+++ b/modules/jooby-utow/src/main/java/io/jooby/internal/undertow/ConscriptAlpnProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.undertow;
+
+import javax.net.ssl.SSLEngine;
+
+import org.conscrypt.Conscrypt;
+
+import io.undertow.protocols.alpn.ALPNProvider;
+
+public class ConscriptAlpnProvider implements ALPNProvider {
+  @Override public boolean isEnabled(SSLEngine sslEngine) {
+    return sslEngine.getClass().getName().startsWith("org.conscrypt.");
+  }
+
+  @Override public SSLEngine setProtocols(SSLEngine engine, String[] protocols) {
+    Impl.setProtocols(engine, protocols);
+    return engine;
+  }
+
+  @Override public String getSelectedProtocol(SSLEngine engine) {
+    return Impl.getSelectedProtocol(engine);
+  }
+
+  @Override public int getPriority() {
+    return 400;
+  }
+
+  private static class Impl {
+    static SSLEngine setProtocols(SSLEngine engine, String[] protocols) {
+      Conscrypt.setApplicationProtocols(engine, protocols);
+      return engine;
+    }
+
+    static String getSelectedProtocol(SSLEngine engine) {
+      return Conscrypt.getApplicationProtocol(engine);
+    }
+  }
+}

--- a/modules/jooby-utow/src/main/resources/META-INF/services/io.undertow.protocols.alpn.ALPNProvider
+++ b/modules/jooby-utow/src/main/resources/META-INF/services/io.undertow.protocols.alpn.ALPNProvider
@@ -1,0 +1,1 @@
+io.jooby.internal.undertow.ConscriptAlpnProvider

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -18,6 +18,8 @@
 
     <module>jooby-apt</module>
 
+    <module>jooby-conscrypt</module>
+
     <module>jooby-jetty</module>
     <module>jooby-netty</module>
     <module>jooby-utow</module>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
     <undertow.version>2.2.3.Final</undertow.version>
     <jetty.version>9.4.35.v20201120</jetty.version>
     <netty.version>4.1.56.Final</netty.version>
-    <boringssl.version>2.0.27.Final</boringssl.version>
 
     <!-- Reactive -->
     <rxjava.version>2.2.20</rxjava.version>
@@ -80,6 +79,9 @@
     <swagger.version>2.1.6</swagger.version>
     <swagger-parser.version>2.0.24</swagger-parser.version>
     <redoc.version>2.0.0-rc.20</redoc.version>
+
+    <!-- SSL -->
+    <conscrypt.version>2.5.1</conscrypt.version>
 
     <!-- javax -->
     <javax.inject.version>1</javax.inject.version>
@@ -503,6 +505,12 @@
         <version>${caffeine.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.jooby</groupId>
+        <artifactId>jooby-conscrypt</artifactId>
+        <version>${jooby.version}</version>
+      </dependency>
+
       <!-- ASM -->
       <dependency>
         <groupId>org.ow2.asm</groupId>
@@ -844,6 +852,13 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${jsr305.version}</version>
+      </dependency>
+
+      <!-- SSL -->
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <version>${conscrypt.version}</version>
       </dependency>
 
       <!-- Undertow -->


### PR DESCRIPTION
- OpenSSL option across 3 web-server implementation
- Conscrypt(boring-ssl) provider implemenation for OpenSSL version (via ServiceLoader: jooby-conscrypt)
- Netty/Undertow still works with both JDK-SSL/OpenSSL version, while Jetty only works with OpenSSL


Fixes #2194
/cc @hc-codersatlas 