### PR TITLE
WebSocket enhancements

### DIFF
--- a/jooby/src/main/java/io/jooby/Server.java
+++ b/jooby/src/main/java/io/jooby/Server.java
@@ -139,8 +139,10 @@ public interface Server {
       String message = cause.getMessage();
       if (message != null) {
         String msg = message.toLowerCase();
-        return msg.contains("reset by peer") || msg.contains("broken pipe") || msg
-            .contains("forcibly closed");
+        return msg.contains("reset by peer")
+            || msg.contains("broken pipe")
+            || msg.contains("forcibly closed")
+            || msg.contains("connection reset");
       }
     }
     return (cause instanceof ClosedChannelException) || (cause instanceof EOFException);


### PR DESCRIPTION
- Netty: fix NPE when there is no message callback
- Undertow: fix double close event fired
- Undertow: silent connection reset exception while closing browser tab

Fixes #2210 