### PR TITLE
Flexible coroutine context

### DIFF
--- a/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
+++ b/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
@@ -5,16 +5,10 @@
  */
 package io.jooby
 
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
-internal class RouterCoroutineScope(coroutineContext: CoroutineContext) : CoroutineScope {
-  override val coroutineContext = coroutineContext
-}
+internal class RouterCoroutineScope(override val coroutineContext: CoroutineContext) : CoroutineScope
 
 class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
 
@@ -64,10 +58,7 @@ class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
 
   fun route(method: String, pattern: String, handler: suspend HandlerContext.() -> Any): Route {
     return router.route(method, pattern) { ctx ->
-      val xhandler = CoroutineExceptionHandler { _, x ->
-        ctx.sendError(x)
-      }
-      coroutineScope.launch(xhandler, coroutineStart) {
+      launch(ctx) {
         val result = handler(HandlerContext(ctx))
         if (result != ctx) {
           ctx.render(result)
@@ -75,5 +66,10 @@ class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
       }
     }.setHandle(handler)
      .attribute("coroutine", true)
+  }
+
+  internal fun launch(ctx: Context, block: suspend CoroutineScope.() -> Unit) {
+    val exceptionHandler = CoroutineExceptionHandler { _, x -> ctx.sendError(x) }
+    coroutineScope.launch(exceptionHandler, coroutineStart, block)
   }
 }

--- a/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
+++ b/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
@@ -5,6 +5,7 @@
  */
 package io.jooby
 
+import io.jooby.Router.*
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
@@ -22,56 +23,46 @@ class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
   }
 
   @RouterDsl
-  fun get(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.GET, pattern, handler)
-  }
+  fun get(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(GET, pattern, handler)
 
   @RouterDsl
-  fun post(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.POST, pattern, handler)
-  }
+  fun post(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(POST, pattern, handler)
 
   @RouterDsl
-  fun put(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.PUT, pattern, handler)
-  }
+  fun put(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(PUT, pattern, handler)
 
   @RouterDsl
-  fun delete(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.DELETE, pattern, handler)
-  }
+  fun delete(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(DELETE, pattern, handler)
 
   @RouterDsl
-  fun patch(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.PATCH, pattern, handler)
-  }
+  fun patch(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(PATCH, pattern, handler)
 
   @RouterDsl
-  fun head(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.HEAD, pattern, handler)
-  }
+  fun head(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(HEAD, pattern, handler)
 
   @RouterDsl
-  fun trace(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.TRACE, pattern, handler)
-  }
+  fun trace(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(TRACE, pattern, handler)
 
   @RouterDsl
-  fun options(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return route(Router.OPTIONS, pattern, handler)
-  }
+  fun options(pattern: String, handler: suspend HandlerContext.() -> Any) =
+    route(OPTIONS, pattern, handler)
 
-  fun route(method: String, pattern: String, handler: suspend HandlerContext.() -> Any): Route {
-    return router.route(method, pattern) { ctx ->
+  fun route(method: String, pattern: String, handler: suspend HandlerContext.() -> Any): Route =
+    router.route(method, pattern) { ctx ->
       launch(ctx) {
         val result = handler(HandlerContext(ctx))
         if (result != ctx) {
           ctx.render(result)
         }
       }
-    }.setHandle(handler)
-     .attribute("coroutine", true)
-  }
+    }.setHandle(handler).attribute("coroutine", true)
 
   internal fun launch(ctx: Context, block: suspend CoroutineScope.() -> Unit) {
     val exceptionHandler = CoroutineExceptionHandler { _, x -> ctx.sendError(x) }

--- a/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
+++ b/jooby/src/main/kotlin/io/jooby/CoroutineRouter.kt
@@ -16,6 +16,11 @@ class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
     RouterCoroutineScope(router.worker.asCoroutineDispatcher())
   }
 
+  private var extendCoroutineContext: (CoroutineContext) -> CoroutineContext = { it }
+  fun launchContext(block: (CoroutineContext) -> CoroutineContext) {
+    extendCoroutineContext = block
+  }
+
   @RouterDsl
   fun get(pattern: String, handler: suspend HandlerContext.() -> Any): Route {
     return route(Router.GET, pattern, handler)
@@ -70,6 +75,6 @@ class CoroutineRouter(val coroutineStart: CoroutineStart, val router: Router) {
 
   internal fun launch(ctx: Context, block: suspend CoroutineScope.() -> Unit) {
     val exceptionHandler = CoroutineExceptionHandler { _, x -> ctx.sendError(x) }
-    coroutineScope.launch(exceptionHandler, coroutineStart, block)
+    coroutineScope.launch(extendCoroutineContext(exceptionHandler), coroutineStart, block)
   }
 }

--- a/jooby/src/test/kotlin/io/jooby/CoroutineRouterTest.kt
+++ b/jooby/src/test/kotlin/io/jooby/CoroutineRouterTest.kt
@@ -1,0 +1,51 @@
+package io.jooby
+
+import io.jooby.Router.GET
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineStart
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.*
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+class CoroutineRouterTest {
+  private val router = mock(Router::class.java, RETURNS_DEEP_STUBS)
+  private val ctx = mock(Context::class.java)
+
+  @Test
+  fun withoutLaunchContext() {
+    CoroutineRouter(CoroutineStart.UNDISPATCHED, router).apply {
+      get("/path") { "Result" }
+    }
+
+    val handlerCaptor = ArgumentCaptor.forClass(Route.Handler::class.java)
+    verify(router).route(eq(GET), eq("/path"), handlerCaptor.capture())
+    handlerCaptor.value.apply(ctx)
+
+    verify(ctx).render("Result")
+  }
+
+  @Test
+  fun launchContext_isRunEveryTime() {
+    val mockCoroutineContext = mock(CoroutineContext::class.java)
+    `when`(mockCoroutineContext.plus(any() ?: mockCoroutineContext)).thenReturn(mockCoroutineContext, ExtraContext())
+
+    CoroutineRouter(CoroutineStart.DEFAULT, router).apply {
+      launchContext { mockCoroutineContext + it + ExtraContext() }
+      get("/path") { "Result" }
+    }
+
+    val handlerCaptor = ArgumentCaptor.forClass(Route.Handler::class.java)
+    verify(router).route(eq(GET), eq("/path"), handlerCaptor.capture())
+    verifyNoInteractions(mockCoroutineContext)
+
+    handlerCaptor.value.apply(ctx)
+    verify(mockCoroutineContext).plus(argThat { it is CoroutineExceptionHandler } ?: mockCoroutineContext)
+    verify(mockCoroutineContext).plus(argThat { it is ExtraContext } ?: mockCoroutineContext)
+  }
+
+  class ExtraContext : AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<ExtraContext>
+  }
+}


### PR DESCRIPTION
Make it possible to redefine coroutine context for every launch to be able to properly implement suspend/restore of additional state, e.g. MDC, transactions, etc

Fixes #2257