### PR TITLE
Add test scope to usages of mockito-core in jooby modules

### DIFF
--- a/modules/jooby-banner/pom.xml
+++ b/modules/jooby-banner/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/modules/jooby-caffeine/pom.xml
+++ b/modules/jooby-caffeine/pom.xml
@@ -42,6 +42,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/modules/jooby-commons-email/pom.xml
+++ b/modules/jooby-commons-email/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/modules/jooby-guice/pom.xml
+++ b/modules/jooby-guice/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The mockito dependency is not needed in production code and should not be
consumed by consuming applications.