### PR TITLE
Improve coroutine context redefinition introduced in Jooby 2.9.6

### DIFF
--- a/docs/asciidoc/responses.adoc
+++ b/docs/asciidoc/responses.adoc
@@ -625,7 +625,7 @@ Jooby allows you to use this experimental API by setting the `coroutineStart` op
 [source, kotlin]
 ----
 {
-  coroutine (CoroutineStart.UNDISPATCHED) {
+  coroutine(CoroutineStart.UNDISPATCHED) {
     get("/") {
       val n = 5 * 5        // <1>
       delay(100)           // <2>
@@ -638,6 +638,25 @@ Jooby allows you to use this experimental API by setting the `coroutineStart` op
 <1> Statement run in the *event loop* (caller thread)
 <2> Call a suspending function and dispatch to *worker executor*
 <3> Produces a response from *worker executor*
+
+You can also extend the `CoroutineContext` in which the coroutine routes run:
+
+.launchContext
+[source, kotlin]
+----
+{
+  coroutine {
+    launchContext { MDCContext() } // <1>
+  
+    get("/") {
+      ...
+    }
+  }
+}
+----
+
+<1> The lambda is run before launching each coroutine, so it can customize the `CoroutineContext` for
+the request, e.g. store/restore MDC, transaction, or anything else that your handlers need. 
 
 {love} {love}!
 

--- a/jooby/src/main/kotlin/io/jooby/HandlerContext.kt
+++ b/jooby/src/main/kotlin/io/jooby/HandlerContext.kt
@@ -9,8 +9,8 @@ class AfterContext(val ctx: Context, val result: Any?, val failure: Any?)
 
 class DecoratorContext(val ctx: Context, val next: Route.Handler)
 
-class HandlerContext (val ctx: Context)
+class HandlerContext(val ctx: Context)
 
-class WebSocketInitContext (val ctx: Context, val configurer: WebSocketConfigurer)
+class WebSocketInitContext(val ctx: Context, val configurer: WebSocketConfigurer)
 
-class ServerSentHandler (val ctx: Context, val sse: ServerSentEmitter)
+class ServerSentHandler(val ctx: Context, val sse: ServerSentEmitter)

--- a/jooby/src/main/kotlin/io/jooby/Kooby.kt
+++ b/jooby/src/main/kotlin/io/jooby/Kooby.kt
@@ -6,7 +6,6 @@
 package io.jooby
 
 import kotlinx.coroutines.CoroutineStart
-import kotlin.math.max
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
@@ -309,7 +308,7 @@ fun <T : Jooby> runApp(args: Array<String>, mode: ExecutionMode, application: KC
 }
 
 internal fun configurePackage(value: Any) {
-  var appname = value::class.java.name
+  val appname = value::class.java.name
   val start = appname.indexOf(".").let { if (it == -1) 0 else it + 1 }
 
   val end = appname.indexOf("Kt$")

--- a/jooby/src/main/kotlin/io/jooby/internal/mvc/CoroutineLauncher.kt
+++ b/jooby/src/main/kotlin/io/jooby/internal/mvc/CoroutineLauncher.kt
@@ -7,6 +7,7 @@ package io.jooby.internal.mvc
 
 import io.jooby.Context
 import io.jooby.CoroutineRouter
+import io.jooby.HandlerContext
 import io.jooby.Route
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 
@@ -16,7 +17,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 class CoroutineLauncher(val next: Route.Handler) : Route.Handler {
   override fun apply(ctx: Context) = ctx.also {
     val router = ctx.router.attribute<CoroutineRouter>("coroutineRouter")
-    router.launch(ctx) {
+    router.launch(HandlerContext(ctx)) {
       val result = suspendCoroutineUninterceptedOrReturn<Any> {
         ctx.attribute("___continuation", it)
         next.apply(ctx)

--- a/jooby/src/test/kotlin/io/jooby/CoroutineRouterTest.kt
+++ b/jooby/src/test/kotlin/io/jooby/CoroutineRouterTest.kt
@@ -1,18 +1,16 @@
 package io.jooby
 
 import io.jooby.Router.GET
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.coroutineScope
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.any
-import org.mockito.Mockito.argThat
 import org.mockito.Mockito.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
@@ -35,26 +33,24 @@ class CoroutineRouterTest {
 
   @Test
   fun launchContext_isRunEveryTime() {
-    val mockCoroutineContext = mock(CoroutineContext::class.java)
-    `when`(mockCoroutineContext.plus(any()
-        ?: mockCoroutineContext)).thenReturn(mockCoroutineContext, ExtraContext())
-
-    CoroutineRouter(CoroutineStart.DEFAULT, router).apply {
-      launchContext { mockCoroutineContext + it + ExtraContext() }
-      get("/path") { "Result" }
+    var coroutineRouteCalled = false
+    CoroutineRouter(CoroutineStart.UNDISPATCHED, router).apply {
+      launchContext { SampleCoroutineContext(ctx) }
+      get("/path") {
+        coroutineScope {
+          assertSame(ctx, coroutineContext[SampleCoroutineContext.Key]!!.ctx)
+          coroutineRouteCalled = true
+        }
+      }
     }
 
     val handlerCaptor = ArgumentCaptor.forClass(Route.Handler::class.java)
     verify(router).route(eq(GET), eq("/path"), handlerCaptor.capture())
-    verifyNoInteractions(mockCoroutineContext)
-
     handlerCaptor.value.apply(ctx)
-    verify(mockCoroutineContext).plus(argThat { it is CoroutineExceptionHandler }
-        ?: mockCoroutineContext)
-    verify(mockCoroutineContext).plus(argThat { it is ExtraContext } ?: mockCoroutineContext)
+    assertTrue(coroutineRouteCalled)
   }
 
-  class ExtraContext : AbstractCoroutineContextElement(Key) {
-    companion object Key : CoroutineContext.Key<ExtraContext>
+  class SampleCoroutineContext(val ctx: Context) : AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<SampleCoroutineContext>
   }
 }


### PR DESCRIPTION
Reasons:

1. Extra coroutine context often needs to access Jooby Context
2. Relying on users to extend the default CoroutineContext can be error prone - users can forget to include the ExceptionHandler, resuling in "hanging" asynchronous requests

Signature of launchContext lambda has changed in not 100%-compatible way, but as launchContext was a recent new feature and wasn't yet documented, probably backwards-compatibility with previous API is not needed.
