### PR TITLE
Validate HTTP headers in Netty

### DIFF
--- a/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyPush.java
+++ b/modules/jooby-netty/src/main/java/org/jooby/internal/netty/NettyPush.java
@@ -261,7 +261,7 @@ public class NettyPush implements NativePushPromise {
       // TODO: Is there another way of handling a push promise?
       DefaultFullHttpRequest pushRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
           HttpMethod.valueOf(method.toUpperCase()), path, Unpooled.EMPTY_BUFFER,
-          new DefaultHttpHeaders(false).set(streamIdHeader, nextStreamId),
+          new DefaultHttpHeaders().set(streamIdHeader, nextStreamId),
           EmptyHttpHeaders.INSTANCE);
       ctx.pipeline().fireChannelRead(pushRequest);
       ctx.pipeline().fireChannelReadComplete();


### PR DESCRIPTION
Fixes #2252 for the 1.x branch. As such it has the same effect as b66e3342cf95205324023cfdf2cb5811e8a6dcf4 had for the 2.x branch.