### PR TITLE
Adds support for JSON-B (JSR 367) using yasson as the implementation.

### DIFF
--- a/docs/asciidoc/modules/modules.adoc
+++ b/docs/asciidoc/modules/modules.adoc
@@ -35,6 +35,7 @@ Available modules are listed next.
 === JSON
    * link:/modules/gson[Gson]: Gson module for Jooby.
    * link:/modules/jackson[Jackson]: Jackson module for Jooby.
+   * link:/modules/yasson[JSON-B]: JSON-B module for Jooby.
 
 === OpenAPI
    * link:/modules/openapi[OpenAPI]: OpenAPI supports.

--- a/docs/asciidoc/modules/yasson.adoc
+++ b/docs/asciidoc/modules/yasson.adoc
@@ -1,0 +1,112 @@
+== JSON-B
+
+JSON support using https://github.com/eclipse-ee4j/jsonb-api[Jakarta JSON Binding (JSON-B)] api and https://github.com/eclipse-ee4j/yasson[Yasson] implementation.
+
+=== Usage
+
+1) Add the dependency:
+
+[dependency, artifactId="jooby-yasson"]
+.
+
+2) Install and encode/decode JSON
+
+.Java
+[source, java, role="primary"]
+----
+import io.jooby.json.YassonModule;
+
+{
+  install(new YassonModule());                        <1>
+
+  get("/", ctx -> {
+    MyObject myObject = ...;
+    return myObject;                                <2>
+  });
+
+  post("/", ctx -> {
+    MyObject myObject = ctx.body(MyObject.class);   <3>
+    ...
+  });
+}
+----
+
+.Kotlin
+[source, kt, role="secondary"]
+----
+import io.jooby.json.YassonModule
+
+{
+  install(YassonModule())                             <1>
+
+  get("/") {
+    val myObject = ...;
+    myObject                                        <2>
+  }
+
+  post("/") {
+    val myObject = ctx.body<MyObject>()             <3>
+    ...
+  }
+}
+----
+
+<1> Install JSON-B Yasson Module
+<2> Use JSON-B to encode arbitrary object as JSON
+<3> Use JSON-B to decode JSON to Java object. Client must specify the `Content-Type: application/json` header
+
+=== Working with JSON-B
+
+Access to default object mapper is available via require call:
+
+.Default object mapper
+[source, java, role="primary"]
+----
+import io.jooby.json.YassonModule;
+
+{
+  install(new YassonModule());
+
+  Jsonb jsonb = require(Jsonb.class);
+  
+  ...
+}
+----
+
+.Kotlin
+[source, kt, role="secondary"]
+----
+import io.jooby.json.YassonModule
+
+{
+  install(YassonModule())
+
+  val mapper = require<Jsonb>()
+}
+----
+
+You can provide your own `Jsonb`:
+
+.Custom ObjectMapper
+[source, java, role="primary"]
+----
+import io.jooby.json.YassonModule;
+
+{
+  Jsonb jsonb = JsonbBuilder.create();
+
+  install(new YassonModule(jsonb));
+}
+----
+
+.Kotlin
+[source, kt, role="secondary"]
+----
+import io.jooby.json.YassonModule
+
+{
+  val jsonb = JsonbBuilder.create()
+
+  install(YassonModule(jsonb))
+}
+----

--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -188,6 +188,12 @@
     </dependency>
     <dependency>
       <groupId>io.jooby</groupId>
+      <artifactId>jooby-yasson</artifactId>
+      <version>${jooby.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>io.jooby</groupId>
       <artifactId>jooby-openapi</artifactId>
       <version>${jooby.version}</version>
       <type>jar</type>

--- a/modules/jooby-yasson/pom.xml
+++ b/modules/jooby-yasson/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.10.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-yasson</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.json.bind</groupId>
+      <artifactId>jakarta.json.bind-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse</groupId>
+      <artifactId>yasson</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-yasson/src/main/java/io/jooby/json/YassonModule.java
+++ b/modules/jooby-yasson/src/main/java/io/jooby/json/YassonModule.java
@@ -1,0 +1,113 @@
+package io.jooby.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.jooby.Body;
+import io.jooby.Context;
+import io.jooby.Extension;
+import io.jooby.Jooby;
+import io.jooby.MediaType;
+import io.jooby.MessageDecoder;
+import io.jooby.MessageEncoder;
+import io.jooby.ServiceRegistry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+/**
+ * JSON module using JSON-B: https://github.com/eclipse-ee4j/jsonb-api.
+ *
+ * Usage:
+ *
+ * <pre>{@code
+ * {
+ *
+ *   install(new YassonModule());
+ *
+ *   get("/", ctx -> {
+ *     MyObject myObject = ...;
+ *     // send json
+ *     return myObject;
+ *   });
+ *
+ *   post("/", ctx -> {
+ *     // read json
+ *     MyObject myObject = ctx.body(MyObject.class);
+ *     // send json
+ *     return myObject;
+ *   });
+ * }
+ * }</pre>
+ *
+ * For body decoding the client must specify the <code>Content-Type</code> header set to
+ * <code>application/json</code>.
+ *
+ * You can retrieve the {@link Jsonb} object via require call:
+ *
+ * <pre>{@code
+ * {
+ *
+ *   Jsonb jsonb = require(Jsonb.class);
+ *
+ * }
+ * }</pre>
+ *
+ * Complete documentation is available at: https://jooby.io/modules/jsonb.
+ *
+ */
+public class YassonModule implements Extension, MessageDecoder, MessageEncoder {
+
+  private final Jsonb jsonb;
+
+  /**
+   * Creates a new Jsonb module.
+   */
+  public YassonModule() {
+    jsonb = JsonbBuilder.create();
+  }
+
+  /**
+   * Creates a new module and use a Jsonb instance.
+   *
+   * @param jsonb Jsonb to use.
+   */
+  public YassonModule(@Nonnull final Jsonb jsonb) {
+    this.jsonb = jsonb;
+  }
+
+  @Override
+  public void install(@Nonnull final Jooby application) throws Exception {
+    application.decoder(MediaType.json, this);
+    application.encoder(MediaType.json, this);
+
+    ServiceRegistry services = application.getServices();
+    services.put(Jsonb.class, jsonb);
+  }
+
+  @Nonnull
+  @Override
+  public Object decode(
+      @Nonnull final Context ctx,
+      @Nonnull final Type type) throws IOException {
+
+    Body body = ctx.body();
+    try (InputStream stream = body.stream()) {
+      return jsonb.fromJson(new InputStreamReader(stream), type);
+    }
+  }
+
+  @Nullable
+  @Override
+  public byte[] encode(
+      @Nonnull final Context ctx,
+      @Nonnull final Object value) {
+    ctx.setDefaultResponseType(MediaType.json);
+    return jsonb.toJson(value).getBytes(UTF_8);
+  }
+}

--- a/modules/jooby-yasson/src/test/java/io/jooby/json/YassonModuleTest.java
+++ b/modules/jooby-yasson/src/test/java/io/jooby/json/YassonModuleTest.java
@@ -1,0 +1,58 @@
+package io.jooby.json;
+
+import io.jooby.Body;
+import io.jooby.Context;
+import io.jooby.MediaType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class YassonModuleTest {
+
+  public static class User {
+    public long id;
+    public String name;
+    public int age;
+  }
+
+  @Test
+  public void render() {
+
+    YassonModule YassonModule = new YassonModule();
+    User user = new User();
+    user.id = -1;
+    user.name = "Lorem €@!?";
+    user.age = Integer.MAX_VALUE;
+
+    Context ctx = mock(Context.class);
+    byte[] bytes = YassonModule.encode(ctx, user);
+    assertEquals("{\"age\":2147483647,\"id\":-1,\"name\":\"Lorem €@!?\"}", new String(bytes, StandardCharsets.UTF_8));
+
+    verify(ctx).setDefaultResponseType(MediaType.json);
+  }
+
+  @Test
+  public void parse() throws IOException {
+    byte[] bytes = "{\"age\":2147483647,\"id\":-1,\"name\":\"Lorem €@!?\"}".getBytes(StandardCharsets.UTF_8);
+    Body body = mock(Body.class);
+    when(body.stream()).thenReturn(new ByteArrayInputStream(bytes));
+
+    Context ctx = mock(Context.class);
+    when(ctx.body()).thenReturn(body);
+
+    YassonModule YassonModule = new YassonModule();
+
+    User user = (User) YassonModule.decode(ctx, User.class);
+
+    assertEquals(-1, user.id);
+    assertEquals(Integer.MAX_VALUE, user.age);
+    assertEquals("Lorem €@!?", user.name);
+  }
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -43,6 +43,7 @@
 
     <module>jooby-jackson</module>
     <module>jooby-gson</module>
+    <module>jooby-yasson</module>
     <module>jooby-graphql</module>
     <module>jooby-graphiql</module>
     <module>jooby-graphql-playground</module>

--- a/pom.xml
+++ b/pom.xml
@@ -573,6 +573,18 @@
         <version>${gson.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>jakarta.json.bind</groupId>
+        <artifactId>jakarta.json.bind-api</artifactId>
+        <version>1.0.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse</groupId>
+        <artifactId>yasson</artifactId>
+        <version>1.0.9</version>
+      </dependency>
+
       <!-- Jackson 2.x -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
There was a previous similar addition for jooby 1 that was not included in
jooby 2:
https://github.com/jooby-project/jooby/pull/1248
https://jooby.io/v1/doc/yasson/

this pull request replaces #2368 