### PR TITLE
Enable netty ws compression for HTTP 1.1

### DIFF
--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyPipeline.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyPipeline.java
@@ -18,13 +18,9 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http.multipart.HttpDataFactory;
-import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
-import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker;
-import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
 import io.netty.handler.ssl.SslContext;
 
 public class NettyPipeline extends ChannelInitializer<SocketChannel> {
@@ -74,15 +70,7 @@ public class NettyPipeline extends ChannelInitializer<SocketChannel> {
 
       if (compressionLevel != null) {
         p.addLast("compressor", new HttpChunkContentCompressor(compressionLevel));
-        p.addLast("ws-compressor", new WebSocketServerExtensionHandler(
-            new PerMessageDeflateServerExtensionHandshaker(
-                compressionLevel,
-                ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
-                PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE,
-                false,
-                false
-            ),
-            new DeflateFrameServerExtensionHandshaker(compressionLevel)));
+        p.addLast("ws-compressor", new NettyWebSocketCompressor(compressionLevel));
       }
 
       p.addLast("handler", createHandler());
@@ -114,6 +102,7 @@ public class NettyPipeline extends ChannelInitializer<SocketChannel> {
     p.addLast("codec", codec);
     if (compressionLevel != null) {
       p.addLast("compressor", new HttpChunkContentCompressor(compressionLevel));
+      p.addLast("ws-compressor", new NettyWebSocketCompressor(compressionLevel));
     }
     p.addLast("handler", createHandler());
   }

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyWebSocketCompressor.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyWebSocketCompressor.java
@@ -1,0 +1,23 @@
+/**
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.internal.netty;
+
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
+
+class NettyWebSocketCompressor extends WebSocketServerExtensionHandler {
+  public NettyWebSocketCompressor(int compressionLevel) {
+    super(new PerMessageDeflateServerExtensionHandshaker(
+            compressionLevel,
+            ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+            PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE,
+            false,
+            false),
+        new DeflateFrameServerExtensionHandshaker(compressionLevel));
+  }
+}


### PR DESCRIPTION
In previous PR #2377 it was enabled only for HTTP 2.

Original issue: #2364