### PR TITLE
Implemented getting client certificates from the context for all 3 se…

### DIFF
--- a/docs/asciidoc/context.adoc
+++ b/docs/asciidoc/context.adoc
@@ -659,6 +659,33 @@ get("/{foo}") { ctx ->
 In case of a request like `/bar?foo=baz`, `foo is: baz` will be returned since the query parameter
 takes precedence over the path parameter.
 
+==== Client Certificates
+
+If mutual TLS is enabled, you can access the client's certificates from the context. The first 
+certificate in the list is the peer certificate, followed by the ca certificates in the chain 
+(the order is preserved).
+
+.Java
+[source,java,role="primary"]
+----
+get("/{foo}", ctx -> {
+  List<Certificate> certificates = ctx.getClientCertificates(); <1>
+  Certificate peerCertificate = certificates.get(0);            <2>
+});
+----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+get("/{foo}") { ctx ->
+  val certificates = ctx.clientCertificates                     <1>
+  val peerCertificate = certificates.first()                    <2>
+}
+----
+
+<1> Get all of the certificates presented by the client during the SSL handshake.
+<2> Get only the peer certificate.
+
 include::value-api.adoc[]
 
 include::body.adoc[]

--- a/jooby/src/main/java/io/jooby/Context.java
+++ b/jooby/src/main/java/io/jooby/Context.java
@@ -21,6 +21,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.security.cert.Certificate;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -626,6 +627,13 @@ public interface Context extends Registry {
    * @return The name of the protocol the request. Always in lower-case.
    */
   @Nonnull String getProtocol();
+
+  /**
+   * The certificates presented by the client for mutual TLS. Empty if ssl is not enabled, or client authentication is not required.
+   *
+   * @return The certificates presented by the client for mutual TLS. Empty if ssl is not enabled, or client authentication is not required.
+   */
+  @Nonnull Certificate[] getClientCertificates();
 
   /**
    * Server port for current request.

--- a/jooby/src/main/java/io/jooby/Context.java
+++ b/jooby/src/main/java/io/jooby/Context.java
@@ -633,7 +633,7 @@ public interface Context extends Registry {
    *
    * @return The certificates presented by the client for mutual TLS. Empty if ssl is not enabled, or client authentication is not required.
    */
-  @Nonnull Certificate[] getClientCertificates();
+  @Nonnull List<Certificate> getClientCertificates();
 
   /**
    * Server port for current request.

--- a/jooby/src/main/java/io/jooby/ForwardingContext.java
+++ b/jooby/src/main/java/io/jooby/ForwardingContext.java
@@ -18,6 +18,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.security.cert.Certificate;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
- * Utility to class that helps to wrap and delegate to another context.
+ * Utility class that helps to wrap and delegate to another context.
  *
  * @since 2.0.2
  * @author edgar
@@ -265,6 +266,10 @@ public class ForwardingContext implements Context {
 
   @Override @Nonnull public String getProtocol() {
     return ctx.getProtocol();
+  }
+
+  @Override @Nonnull public Certificate[] getClientCertificates() {
+    return ctx.getClientCertificates();
   }
 
   @Override @Nonnull public String getScheme() {

--- a/jooby/src/main/java/io/jooby/ForwardingContext.java
+++ b/jooby/src/main/java/io/jooby/ForwardingContext.java
@@ -268,7 +268,7 @@ public class ForwardingContext implements Context {
     return ctx.getProtocol();
   }
 
-  @Override @Nonnull public Certificate[] getClientCertificates() {
+  @Override @Nonnull public List<Certificate> getClientCertificates() {
     return ctx.getClientCertificates();
   }
 

--- a/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
+++ b/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
@@ -59,6 +59,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -279,6 +280,10 @@ public class JettyContext implements DefaultContext {
 
   @Nonnull @Override public String getProtocol() {
     return request.getProtocol();
+  }
+
+  @Nonnull @Override public Certificate[] getClientCertificates() {
+    return (Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
   }
 
   @Nonnull @Override public String getScheme() {

--- a/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
+++ b/modules/jooby-jetty/src/main/java/io/jooby/internal/jetty/JettyContext.java
@@ -61,6 +61,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -282,8 +283,8 @@ public class JettyContext implements DefaultContext {
     return request.getProtocol();
   }
 
-  @Nonnull @Override public Certificate[] getClientCertificates() {
-    return (Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+  @Nonnull @Override public List<Certificate> getClientCertificates() {
+    return Arrays.asList((Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate"));
   }
 
   @Nonnull @Override public String getScheme() {

--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyContext.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyContext.java
@@ -32,6 +32,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -288,16 +289,16 @@ public class NettyContext implements DefaultContext, ChannelFutureListener {
     }
   }
 
-  @Nonnull @Override public Certificate[] getClientCertificates() {
+  @Nonnull @Override public List<Certificate> getClientCertificates() {
     SslHandler sslHandler = (SslHandler) ctx.channel().pipeline().get("ssl");
     if (sslHandler != null) {
       try {
-        return sslHandler.engine().getSession().getPeerCertificates();
+        return Arrays.asList(sslHandler.engine().getSession().getPeerCertificates());
       } catch (SSLPeerUnverifiedException x) {
          throw SneakyThrows.propagate(x);
       }
     }
-    return new Certificate[0];
+    return new ArrayList<Certificate>();
   }
 
   @Nonnull @Override public String getScheme() {

--- a/modules/jooby-test/src/main/java/io/jooby/MockContext.java
+++ b/modules/jooby-test/src/main/java/io/jooby/MockContext.java
@@ -541,8 +541,8 @@ public class MockContext implements DefaultContext {
     return "HTTP/1.1";
   }
 
-  @Nonnull @Override public Certificate[] getClientCertificates() {
-    return new Certificate[0];
+  @Nonnull @Override public List<Certificate> getClientCertificates() {
+    return new ArrayList<Certificate>();
   }
 
   @Nonnull @Override public String getScheme() {

--- a/modules/jooby-test/src/main/java/io/jooby/MockContext.java
+++ b/modules/jooby-test/src/main/java/io/jooby/MockContext.java
@@ -22,6 +22,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -538,6 +539,10 @@ public class MockContext implements DefaultContext {
 
   @Nonnull @Override public String getProtocol() {
     return "HTTP/1.1";
+  }
+
+  @Nonnull @Override public Certificate[] getClientCertificates() {
+    return new Certificate[0];
   }
 
   @Nonnull @Override public String getScheme() {

--- a/modules/jooby-utow/src/main/java/io/jooby/internal/utow/UtowContext.java
+++ b/modules/jooby-utow/src/main/java/io/jooby/internal/utow/UtowContext.java
@@ -23,12 +23,15 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -210,16 +213,16 @@ public class UtowContext implements DefaultContext, IoCallback {
     return exchange.getProtocol().toString();
   }
 
-  @Nonnull @Override public Certificate[] getClientCertificates() {
+  @Nonnull @Override public List<Certificate> getClientCertificates() {
     SSLSessionInfo ssl = exchange.getConnection().getSslSessionInfo();
     if (ssl != null) {
       try {
-       return ssl.getPeerCertificates();
+       return Arrays.asList(ssl.getPeerCertificates());
       } catch (SSLPeerUnverifiedException | RenegotiationRequiredException x) {
         throw SneakyThrows.propagate(x);
       }
     }
-    return new Certificate[0];
+    return new ArrayList<Certificate>();
   }
 
   @Nonnull @Override public String getScheme() {


### PR DESCRIPTION
Should resolve #2401.  

Added a "getClientCertificates()" function to the context that returns the certificates presented by the client during the SSL handshake, and implemented for all 3 servers.  I didn't see any tests that setup/verified client authentication certificates, or even used ClientAuth.REQUIRED, therefore I didn't modify or add any tests. I have verified that this works for netty (and probably also utow since it's practically the same code) through actual code.