### PR TITLE
Support NonNull TYPE_USE annotations

### DIFF
--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ParamDefinition.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ParamDefinition.java
@@ -119,6 +119,11 @@ public class ParamDefinition {
         return true;
       }
     }
+    for (AnnotationMirror annotation : this.type.getType().getAnnotationMirrors()) {
+      if (annotation.getAnnotationType().toString().endsWith(type)) {
+        return true;
+      }
+    }
     return false;
   }
 


### PR DESCRIPTION
Currently the NonNull detection is for annotations of `@Target({PARAMETER})` and friends.

The future NonNull annotations are `@Target({TYPE_USE})` and thus **the annotations are actually on the type declaration**.

This change checks both the parameter and type annotations.

It is a very subtle difference that can be confusing similar to erasure and parameterized types.

See #2380

I tested on 2.10.0 since had kotlin compiling issues with 2.x