### PR TITLE
Upgrade to Hibernate 5.5.7 for best Java 17 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <mysql-connector-java.version>8.0.25</mysql-connector-java.version>
     <log4jdbc.version>1.2</log4jdbc.version>
     <h2.version>1.4.200</h2.version>
-    <hibernate.version>5.5.4.Final</hibernate.version>
+    <hibernate.version>5.5.7.Final</hibernate.version>
     <ebean.version>12.11.4</ebean.version>
     <jdbi.version>3.20.0</jdbi.version>
     <flyway.version>7.5.1</flyway.version>


### PR DESCRIPTION
Reference: https://in.relation.to/2021/09/14/ready-for-jdk17/