### PR TITLE
Fix OpenAPI generation for newer Kotlin compiler and support java.time types

### DIFF
--- a/jooby/src/main/kotlin/io/jooby/Kooby.kt
+++ b/jooby/src/main/kotlin/io/jooby/Kooby.kt
@@ -133,7 +133,7 @@ open class Kooby constructor() : Jooby() {
   }
 
   @RouterDsl
-  fun after(handler: AfterContext.() -> Any): Kooby {
+  fun after(handler: AfterContext.() -> Unit): Kooby {
     super.after { ctx, result, failure -> AfterContext(ctx, result, failure).handler() }
     return this
   }

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
@@ -37,16 +37,7 @@ import org.objectweb.asm.tree.ParameterNode;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -170,16 +161,16 @@ public class AnnotationParser {
 
   static final String PACKAGE = GET.class.getPackage().getName();
 
-  static final Set<String> IGNORED_PARAM_TYPE = asList(
+  static final Set<String> IGNORED_PARAM_TYPE = new HashSet<>(asList(
       Context.class.getName(),
       Session.class.getName(),
       "java.util.Optional<" + Session.class.getName() + ">",
       "kotlin.coroutines.Continuation"
-  ).stream().collect(Collectors.toSet());
+  ));
 
-  static final Set<String> IGNORED_ANNOTATIONS = asList(
+  static final Set<String> IGNORED_ANNOTATIONS = new HashSet<>(asList(
       ContextParam.class.getName()
-  ).stream().collect(Collectors.toSet());
+  ));
 
   public static List<OperationExt> parse(ParserContext ctx, String prefix,
       Signature signature, MethodInsnNode node) {
@@ -481,7 +472,7 @@ public class AnnotationParser {
     if (annotations != null) {
 
       List<Map<String, Object>> values = findAnnotationByType(annotations,
-          asList(PACKAGE + "." + httpMethod)).stream()
+          singletonList(PACKAGE + "." + httpMethod)).stream()
           .flatMap(annotation -> Stream.of(annotation)
               .map(AsmUtils::toMap)
           )
@@ -489,7 +480,7 @@ public class AnnotationParser {
           .collect(Collectors.toList());
 
       if (values.isEmpty()) {
-        values = findAnnotationByType(annotations, asList(Path.class.getName())).stream()
+        values = findAnnotationByType(annotations, singletonList(Path.class.getName())).stream()
             .flatMap(annotation -> Stream.of(annotation)
                 .map(AsmUtils::toMap)
             )
@@ -498,7 +489,7 @@ public class AnnotationParser {
 
         if (values.isEmpty()) {
           values = findAnnotationByType(annotations,
-              asList(javax.ws.rs.Path.class.getName())).stream()
+              singletonList(javax.ws.rs.Path.class.getName())).stream()
               .flatMap(annotation -> Stream.of(annotation)
                   .map(AsmUtils::toMap)
               )
@@ -510,7 +501,7 @@ public class AnnotationParser {
       for (Map<String, Object> map : values) {
         Object value = map.getOrDefault("value", Collections.emptyList());
         if (!(value instanceof Collection)) {
-          value = asList(value);
+          value = singletonList(value);
         }
         ((List) value)
             .forEach(v -> patterns.add(RoutePath.path(prefix, v.toString())));
@@ -532,7 +523,7 @@ public class AnnotationParser {
         .distinct()
         .collect(Collectors.toList());
     if (methods.size() == 1 && methods.contains("Path")) {
-      return asList(Router.GET);
+      return singletonList(Router.GET);
     }
     methods.remove("Path");
     return methods;
@@ -569,5 +560,4 @@ public class AnnotationParser {
     }
     return annotationTypes;
   }
-
 }

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 import static io.jooby.internal.openapi.AsmUtils.*;
 import static io.jooby.internal.openapi.TypeFactory.KT_FUN_0;
 import static io.jooby.internal.openapi.TypeFactory.KT_KLASS;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 public class AnnotationParser {
@@ -129,7 +130,7 @@ public class AnnotationParser {
     }
 
     public Optional<String> getHttpName(List<AnnotationNode> annotations) {
-      List<Class> names = new ArrayList<>(Arrays.asList(annotations()));
+      List<Class> names = new ArrayList<>(asList(annotations()));
       names.add(Named.class);
       return annotations.stream()
           .filter(a ->
@@ -169,14 +170,14 @@ public class AnnotationParser {
 
   static final String PACKAGE = GET.class.getPackage().getName();
 
-  static final Set<String> IGNORED_PARAM_TYPE = Arrays.asList(
+  static final Set<String> IGNORED_PARAM_TYPE = asList(
       Context.class.getName(),
       Session.class.getName(),
       "java.util.Optional<" + Session.class.getName() + ">",
       "kotlin.coroutines.Continuation"
   ).stream().collect(Collectors.toSet());
 
-  static final Set<String> IGNORED_ANNOTATIONS = Arrays.asList(
+  static final Set<String> IGNORED_ANNOTATIONS = asList(
       ContextParam.class.getName()
   ).stream().collect(Collectors.toSet());
 
@@ -328,12 +329,12 @@ public class AnnotationParser {
         ParameterNode parameter = method.parameters.get(i);
 
         List<String> javaName;
-        if (parameter.name.equals("continuation") && i == method.parameters.size() - 1) {
-          javaName = Arrays.asList(parameter.name, "$" + parameter.name);
+        if ((parameter.name.equals("continuation") || parameter.name.equals("$completion")) && i == method.parameters.size() - 1) {
+          javaName = asList(parameter.name, "$continuation");
         } else {
           javaName = singletonList(parameter.name);
         }
-        /** Java Type: */
+        /* Java Type: */
         LocalVariableNode variable = method.localVariables.stream()
             .filter(var -> javaName.contains(var.name))
             .findFirst()
@@ -348,7 +349,7 @@ public class AnnotationParser {
           continue;
         }
 
-        /** HTTP Type: */
+        /* HTTP Type: */
         List<AnnotationNode> annotations;
         if (method.visibleParameterAnnotations != null
             && i < method.visibleParameterAnnotations.length) {
@@ -365,7 +366,7 @@ public class AnnotationParser {
 
         ParamType paramType = ParamType.find(annotations);
 
-        /** Required: */
+        /* Required: */
         boolean required = isPrimitive(javaType) || !isNullable(method, i);//!javaType.startsWith("java.util.Optional");
 
         if (paramType == ParamType.BODY) {
@@ -480,7 +481,7 @@ public class AnnotationParser {
     if (annotations != null) {
 
       List<Map<String, Object>> values = findAnnotationByType(annotations,
-          Arrays.asList(PACKAGE + "." + httpMethod)).stream()
+          asList(PACKAGE + "." + httpMethod)).stream()
           .flatMap(annotation -> Stream.of(annotation)
               .map(AsmUtils::toMap)
           )
@@ -488,7 +489,7 @@ public class AnnotationParser {
           .collect(Collectors.toList());
 
       if (values.isEmpty()) {
-        values = findAnnotationByType(annotations, Arrays.asList(Path.class.getName())).stream()
+        values = findAnnotationByType(annotations, asList(Path.class.getName())).stream()
             .flatMap(annotation -> Stream.of(annotation)
                 .map(AsmUtils::toMap)
             )
@@ -497,7 +498,7 @@ public class AnnotationParser {
 
         if (values.isEmpty()) {
           values = findAnnotationByType(annotations,
-              Arrays.asList(javax.ws.rs.Path.class.getName())).stream()
+              asList(javax.ws.rs.Path.class.getName())).stream()
               .flatMap(annotation -> Stream.of(annotation)
                   .map(AsmUtils::toMap)
               )
@@ -509,7 +510,7 @@ public class AnnotationParser {
       for (Map<String, Object> map : values) {
         Object value = map.getOrDefault("value", Collections.emptyList());
         if (!(value instanceof Collection)) {
-          value = Arrays.asList(value);
+          value = asList(value);
         }
         ((List) value)
             .forEach(v -> patterns.add(RoutePath.path(prefix, v.toString())));
@@ -531,7 +532,7 @@ public class AnnotationParser {
         .distinct()
         .collect(Collectors.toList());
     if (methods.size() == 1 && methods.contains("Path")) {
-      return Arrays.asList(Router.GET);
+      return asList(Router.GET);
     }
     methods.remove("Path");
     return methods;

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ParserContext.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ParserContext.java
@@ -9,6 +9,7 @@ import static io.jooby.internal.openapi.TypeFactory.COROUTINE_ROUTER;
 import static io.jooby.internal.openapi.TypeFactory.JOOBY;
 import static io.jooby.internal.openapi.TypeFactory.KOOBY;
 import static io.jooby.internal.openapi.TypeFactory.ROUTER;
+import static java.util.Arrays.asList;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,7 +85,7 @@ public class ParserContext {
     this.debug = Optional.ofNullable(debug).orElse(Collections.emptySet());
     this.nodes = nodes;
 
-    List<ObjectMapper> mappers = Arrays.asList(Json.mapper(), Yaml.mapper());
+    List<ObjectMapper> mappers = asList(Json.mapper(), Yaml.mapper());
     jacksonModules(source.getClassLoader(), mappers);
     this.converters = ModelConverters.getInstance();
     mappers.stream()
@@ -342,8 +343,7 @@ public class ParserContext {
   }
 
   public boolean isRouter(Type type) {
-    return Stream.of(router, JOOBY, KOOBY, ROUTER, COROUTINE_ROUTER)
-        .anyMatch(it -> it.equals(type));
+    return asList(router, JOOBY, KOOBY, ROUTER, COROUTINE_ROUTER).contains(type);
   }
 
   public boolean process(AbstractInsnNode instruction) {
@@ -351,8 +351,7 @@ public class ParserContext {
   }
 
   public ParserContext newContext(Type router) {
-    ParserContext ctx = new ParserContext(source, nodes, router, debug);
-    return ctx;
+    return new ParserContext(source, nodes, router, debug);
   }
 
   public String getMainClass() {

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ParserContext.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/ParserContext.java
@@ -21,24 +21,15 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.time.*;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.swagger.v3.oas.models.media.*;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
@@ -66,18 +57,6 @@ import io.swagger.v3.core.converter.ResolvedSchema;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.RefUtils;
 import io.swagger.v3.core.util.Yaml;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.BinarySchema;
-import io.swagger.v3.oas.models.media.BooleanSchema;
-import io.swagger.v3.oas.models.media.ByteArraySchema;
-import io.swagger.v3.oas.models.media.FileSchema;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.MapSchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
-import io.swagger.v3.oas.models.media.UUIDSchema;
 
 public class ParserContext {
 
@@ -209,12 +188,19 @@ public class ParserContext {
       return new StringSchema().format(type.getSimpleName().toLowerCase());
     }
     if (BigInteger.class == type) {
-      return new IntegerSchema()
-          .format(null);
+      return new IntegerSchema().format(null);
     }
     if (BigDecimal.class == type) {
-      return new NumberSchema()
-          .format(null);
+      return new NumberSchema().format(null);
+    }
+    if (Date.class == type || LocalDate.class == type) {
+      return new DateSchema();
+    }
+    if (LocalDateTime.class == type || Instant.class == type || OffsetDateTime.class == type || ZonedDateTime.class == type) {
+      return new DateTimeSchema();
+    }
+    if (Period.class == type || Duration.class == type || Currency.class == type || Locale.class == type) {
+      return new StringSchema();
     }
     if (type.isArray()) {
       return new ArraySchema();


### PR DESCRIPTION
This fixes the latest Jooby 2.11.0:

1. It seems that newer Kotlin compiler (e.g. 1.5.30, with IR backend) sometimes names the Continuation parameter as `$completion` in suspending functions. Let's add support for it, or otherwise OpenAPI generation crashes with messages that parameter type cannot be found for `$completion`.
2. Not related to Kotlin: do not crash when routes have LocalDate, LocalDateTime, Instant, etc parameters - use the correct DateSchema or DateTimeSchema for these.

Having these fixes, we now can successfully generate openapi spec for our project. Without these fixes, openapi crashes with mostly meaningless error messages, like in issue #1805