### PR TITLE
fix websocket ByteBuf array usage issue #2449

### DIFF
--- a/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyWebSocket.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/internal/netty/NettyWebSocket.java
@@ -241,13 +241,9 @@ public class NettyWebSocket implements WebSocketConfigurer, WebSocket, ChannelFu
   }
 
   private static byte[] array(ByteBuf buffer) {
-    if (buffer.hasArray()) {
-      return buffer.array();
-    } else {
-      byte[] bytes = new byte[buffer.readableBytes()];
-      buffer.getBytes(0, bytes);
-      return bytes;
-    }
+    byte[] bytes = new byte[buffer.readableBytes()];
+    buffer.getBytes(0, bytes);
+    return bytes;
   }
 
   private static WebSocketCloseStatus toWebSocketCloseStatus(CloseWebSocketFrame frame) {


### PR DESCRIPTION
This is a proposed solution described in #2449. 

It's the same fix as one mentioned in the issue: https://github.com/apaulau/jooby-test-ws/tree/byte-array