### PR TITLE
add jooq-module for jooby 2.x

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -62,6 +62,7 @@
   <jmespath-java.version>1.12.57</jmespath-java.version>
   <jooby-maven-plugin.version>2.11.1-SNAPSHOT</jooby-maven-plugin.version>
   <jooby.version>2.11.1-SNAPSHOT</jooby.version>
+  <jooq.version>3.13.6</jooq.version>
   <jsonwebtoken.version>0.11.2</jsonwebtoken.version>
   <jsr305.version>3.0.2</jsr305.version>
   <junit.version>5.8.1</junit.version>
@@ -227,6 +228,12 @@
     <dependency>
       <groupId>io.jooby</groupId>
       <artifactId>jooby-hibernate</artifactId>
+      <version>${jooby.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-jooq</artifactId>
       <version>${jooby.version}</version>
       <type>jar</type>
     </dependency>

--- a/modules/jooby-jooq/pom.xml
+++ b/modules/jooby-jooq/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>io.jooby</groupId>
+    <artifactId>modules</artifactId>
+    <version>2.11.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jooby-jooq</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jooby</groupId>
+      <artifactId>jooby-hibernate</artifactId>
+      <version>${jooby.version}</version>
+    </dependency>
+
+    <!-- jooq -->
+    <dependency>
+      <groupId>org.jooq</groupId>
+      <artifactId>jooq</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jooq</groupId>
+      <artifactId>jooq-meta</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/jooby-jooq/src/main/java/io/jooby/jooq/JOOQModule.java
+++ b/modules/jooby-jooq/src/main/java/io/jooby/jooq/JOOQModule.java
@@ -1,0 +1,148 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.jooq;
+
+import com.typesafe.config.Config;
+import io.jooby.*;
+import org.jooq.Configuration;
+import org.jooq.ConnectionProvider;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DataSourceConnectionProvider;
+import org.jooq.impl.DefaultConfiguration;
+import org.jooq.impl.DefaultTransactionProvider;
+import org.jooq.tools.jdbc.JDBCUtils;
+
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * jOOQ module:  https://jooby.io/modules/jooq.
+ *
+ * Usage:
+ *
+ * - Add hikari and jOOQ dependency
+ *
+ * - Install them
+ *
+ * <pre>{@code
+ * {
+ *   install(new HikariModule());
+ *
+ *   install(new JOOQModule());
+ * }
+ * }</pre>
+ *
+ * - Use it
+ *
+ * <pre>{@code
+ * {
+ *   get("/", ctx -> {
+ *     try (DSLContext dsl = require(DSLContext.class)) {
+ *       // do with jooq
+ *     }
+ *   });
+ * }
+ * }</pre>
+ *
+ * usage with database property key (see HikariModule)
+ *
+ *  * <pre>{@code
+ *  * {
+ *  *   install(new HikariModule("jooby_makes_fun_db"));
+ *  *
+ *  *   install(new JOOQModule("jooby_makes_fun_db"));
+ *  * }
+ *  * }</pre>
+ *  *
+ *  * - Use it
+ *  *
+ *  * <pre>{@code
+ *  * {
+ *  *   get("/", ctx -> {
+ *  *     try (DSLContext dsl = require(DSLContext.class, "jooby_makes_fun_db")) {
+ *  *       // do with jooq
+ *  *     }
+ *  *   });
+ *  * }
+ *  * }</pre>
+ *
+ */
+public class JOOQModule implements Extension {
+
+  private final String name;
+
+  private BiConsumer<Configuration, Config> callback;
+
+  /**
+   * Creates a new {@link JOOQModule} module.
+   *
+   * @param database name of database.
+   */
+  public JOOQModule(final String database) {
+    this.name = database;
+  }
+
+  /**
+   * Creates a new {@link JOOQModule} module with default database <i>db</i>
+   */
+  public JOOQModule() {
+    this("db");
+  }
+
+  /**
+   * Configuration callback.
+   *
+   * @param configurer Callback.
+   * @return This module.
+   */
+  public JOOQModule doWith(BiConsumer<Configuration, Config> configurer) {
+    this.callback = configurer;
+    return this;
+  }
+
+  /**
+   * Configuration callback.
+   *
+   * @param configurer Callback.
+   * @return This module.
+   */
+  public JOOQModule doWith(Consumer<Configuration> configurer) {
+    return doWith((configuration, conf) -> configurer.accept(configuration));
+  }
+
+  @Override
+  public void install(@Nonnull Jooby application) throws Exception {
+    Environment env = application.getEnvironment();
+    Config config = application.getConfig();
+    ServiceRegistry registry = application.getServices();
+
+    DataSource dataSource = registry.getOrNull(ServiceKey.key(DataSource.class, name));
+    if (dataSource == null) {
+      // TODO moh-sushi 2021-11-19: replace with usage exception
+      dataSource = registry.require(DataSource.class);
+    }
+    Configuration jooqconf = new DefaultConfiguration();
+    ConnectionProvider dscp = new DataSourceConnectionProvider(dataSource);
+    jooqconf.set(JDBCUtils.dialect(
+        Objects.requireNonNull(env.getProperty(name + ".url"), () -> "no db-url found under " + name + ".url"))
+    );
+    jooqconf.set(dscp);
+    jooqconf.set(new DefaultTransactionProvider(dscp));
+
+    if (callback != null) {
+      callback.accept(jooqconf, config);
+    }
+
+    registry.putIfAbsent(Configuration.class, jooqconf);
+    registry.put(ServiceKey.key(Configuration.class, name), jooqconf);
+    registry.putIfAbsent(DSLContext.class, DSL.using(jooqconf));
+    registry.put(ServiceKey.key(DSLContext.class, name), DSL.using(jooqconf));
+  }
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -40,6 +40,7 @@
     <module>jooby-redis</module>
     <module>jooby-kafka</module>
     <module>jooby-caffeine</module>
+    <module>jooby-jooq</module>
 
     <module>jooby-jackson</module>
     <module>jooby-gson</module>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <h2.version>1.4.200</h2.version>
     <hibernate.version>5.5.4.Final</hibernate.version>
     <ebean.version>12.11.4</ebean.version>
+    <jooq.version>3.13.6</jooq.version>
     <jdbi.version>3.20.0</jdbi.version>
     <flyway.version>7.5.1</flyway.version>
     <graphql-java.version>16.2</graphql-java.version>
@@ -826,6 +827,25 @@
         <groupId>io.ebean</groupId>
         <artifactId>ebean-test</artifactId>
         <version>${ebean.version}</version>
+      </dependency>
+
+      <!-- jooq -->
+      <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq</artifactId>
+        <version>${jooq.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq-meta</artifactId>
+        <version>${jooq.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq-codegen</artifactId>
+        <version>${jooq.version}</version>
       </dependency>
 
       <!-- mySQL -->


### PR DESCRIPTION
Hi,

i have ported the jooq-module from jooby v1 into jooby v2.

@advortsov :  Can you test it?  in #2410 you have asked for this jooq module.
steps for local tests:
- clone my [jooby fork](https://github.com/moh-sushi/jooby), branch `j00q-module`
- execute from project root dir : `mvn clean  source:jar-no-fork install -DskipTests`
- add following dependency into your test project
```
    <dependency>
      <groupId>io.jooby</groupId>
      <artifactId>jooby-jooq</artifactId>
      <version>2.11.1-SNAPSHOT</version>
    </dependency>
```
- see javadoc in class `JOOQModule` for usage

@jknack : i ask you for a code review. Is anything more to do for accepting this merge request? Further documentation?