### PR TITLE
Add support for nullable schema field for Openapi generation

### DIFF
--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/OpenAPIParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/OpenAPIParser.java
@@ -617,6 +617,10 @@ public class OpenAPIParser {
     }
 
     Optional.ofNullable(schemaMap.get("not")).ifPresent(not -> schema.not(not.get(0)));
+    
+    Optional.ofNullable(annotation.get("nullable"))
+    	.filter(nullable -> nullable instanceof Boolean)
+    	.ifPresent(nullable -> schema.setNullable((Boolean)nullable));
 
     annotationValue(annotation, "externalDocs",
         value -> externalDocumentation(value, schema::setExternalDocs));


### PR DESCRIPTION
Schemas can have an annotation stating that they are nullable.
This fix uses a possibly set nullable field for the resulting OpenAPI description.