### PR TITLE
Could starter:graphql-starter:1.0.0 drop off redundant dependencies? 

### DIFF
--- a/starters/graphql-starter/pom.xml
+++ b/starters/graphql-starter/pom.xml
@@ -25,6 +25,12 @@
     <dependency>
       <groupId>io.jooby</groupId>
       <artifactId>jooby-netty</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -35,11 +41,35 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>io.jooby</groupId>
       <artifactId>jooby-graphql</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_starter:graphql-starter:1.0.0_** introduced **_49_** dependencies. However, among them, **_6_** libraries (**_12%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.errorprone:error_prone_annotations:jar:2.3.4:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
org.reactivestreams:reactive-streams:jar:1.0.2:compile
org.jetbrains:annotations:jar:13.0:test

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_starter:graphql-starter:1.0.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_starter:graphql-starter:1.0.0_**’s maven tests.

Best regards