### PR TITLE
Fix GsonModule to also use UTF-8 encoding while decoding

### DIFF
--- a/modules/jooby-gson/src/main/java/io/jooby/json/GsonModule.java
+++ b/modules/jooby-gson/src/main/java/io/jooby/json/GsonModule.java
@@ -99,10 +99,10 @@ public class GsonModule implements Extension, MessageDecoder, MessageEncoder {
       throws Exception {
     Body body = ctx.body();
     if (body.isInMemory()) {
-      return gson.fromJson(new InputStreamReader(new ByteArrayInputStream(body.bytes())), type);
+      return gson.fromJson(new InputStreamReader(new ByteArrayInputStream(body.bytes()), UTF_8), type);
     } else {
       try (InputStream stream = body.stream()) {
-        return gson.fromJson(new InputStreamReader(stream), type);
+        return gson.fromJson(new InputStreamReader(stream, UTF_8), type);
       }
     }
   }


### PR DESCRIPTION
Close #2560

At the moment, the GsonModule only encodes using UTF-8. With this change, UTF-8 is also used during decoding which solves problems with weirds looking strings.