### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/quick-build.yml
+++ b/.github/workflows/quick-build.yml
@@ -2,6 +2,9 @@ name: Quick Build
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/starter.yml
+++ b/.github/workflows/starter.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'starters/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
