### PR TITLE
Add httpsOnly option

### DIFF
--- a/docs/asciidoc/servers.adoc
+++ b/docs/asciidoc/servers.adoc
@@ -48,6 +48,7 @@ Server options are available via javadoc:ServerOptions[] class:
       .setMaxRequestSize(10485760)
       .setSecurePort(8433)
       .setSsl(SslOptions.selfSigned())
+      .setHttpsOnly(false)
       .setHttp2(true)
       .setExpectContinue(true)
   ); 
@@ -70,8 +71,9 @@ Server options are available via javadoc:ServerOptions[] class:
     maxRequestSize = 10485760
     securePort = 8443
     ssl = SslOptions.selfSigned()
-    http2 = true
-    expectContinue = true
+    isHttpsOnly = true
+    isHttp2 = true
+    isExpectContinue = true
   }
 }
 ----
@@ -87,8 +89,9 @@ Server options are available via javadoc:ServerOptions[] class:
 - maxRequestSize: Maximum request size in bytes. Request exceeding this value results in 413(REQUEST_ENTITY_TOO_LARGE) response. Default is `10mb`.
 - securePort: Enable HTTPS. This option is fully covered in next section.
 - ssl: SSL options with certificate details. This option is fully covered in next section.
-- http2: Enable HTTP 2.0.
-- expectContinue: Whenever 100-Expect and continue requests are handled by the server. This is off
+- isHttpsOnly: bind only to HTTPS port, not HTTP. This requires SSL options to be configured.
+- isHttp2: Enable HTTP 2.0.
+- isExpectContinue: Whenever 100-Expect and continue requests are handled by the server. This is off
   by default, except for Jetty which is always ON.
 
 Server options are available as application configuration properties too:
@@ -107,6 +110,7 @@ server.defaultHeaders = true
 server.maxRequestSize = 10485760
 server.securePort = 8443
 server.ssl.type = self-signed | PKCS12 | X509
+server.ssl.httpsOnly = false
 server.http2 = true
 server.expectContinue = false
 ----

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -893,17 +893,19 @@ public class Jooby implements Router, Registry {
     log.info("    app dir: {}", System.getProperty("user.dir"));
     log.info("    tmp dir: {}", tmpdir);
 
+    List<Object> args = new ArrayList<>();
     StringBuilder buff = new StringBuilder();
     buff.append("routes: \n\n{}\n\nlistening on:\n");
+    args.add(router);
 
     ServerOptions options = server.getOptions();
     String host = options.getHost().replace("0.0.0.0", "localhost");
-    List<Object> args = new ArrayList<>();
-    args.add(router);
-    args.add(host);
-    args.add(options.getPort());
-    args.add(router.getContextPath());
-    buff.append("  http://{}:{}{}\n");
+    if (!options.isHttpsOnly()) {
+      args.add(host);
+      args.add(options.getPort());
+      args.add(router.getContextPath());
+      buff.append("  http://{}:{}{}\n");
+    }
 
     if (options.isSSLEnabled()) {
       args.add(host);

--- a/jooby/src/main/java/io/jooby/ServerOptions.java
+++ b/jooby/src/main/java/io/jooby/ServerOptions.java
@@ -101,6 +101,11 @@ public class ServerOptions {
 
   private Integer securePort;
 
+  /**
+   * Bind only https port. Default is false.
+   */
+  private boolean httpsOnly;
+
   private Integer compressionLevel;
 
   private Boolean http2;
@@ -155,6 +160,9 @@ public class ServerOptions {
       }
       // ssl
       SslOptions.from(conf, "server.ssl").ifPresent(options::setSsl);
+      if (conf.hasPath("server.httpsOnly")) {
+        options.httpsOnly = conf.getBoolean("server.httpsOnly");
+      }
       if (conf.hasPath("server.http2")) {
         options.setHttp2(conf.getBoolean("server.http2"));
       }
@@ -174,6 +182,7 @@ public class ServerOptions {
     buff.append(", workerThreads: ").append(getWorkerThreads());
     buff.append(", bufferSize: ").append(bufferSize);
     buff.append(", maxRequestSize: ").append(maxRequestSize);
+    buff.append(", httpsOnly: ").append(httpsOnly);
     if (compressionLevel != null) {
       buff.append(", gzip");
     }
@@ -246,12 +255,27 @@ public class ServerOptions {
    * @param securePort Port number or <code>0</code> for random number.
    * @return This options.
    */
-  public @Nullable ServerOptions setSecurePort(@Nullable Integer securePort) {
+  public @Nonnull ServerOptions setSecurePort(@Nullable Integer securePort) {
     if (securePort == null) {
       this.securePort = null;
     } else {
       this.securePort = securePort.intValue() == 0 ? randomPort() : securePort.intValue();
     }
+    return this;
+  }
+
+  /**
+   * Bind only https port. Default is false.
+   */
+  public boolean isHttpsOnly() {
+    return httpsOnly;
+  }
+
+  /**
+   * Bind only https port. Default is false.
+   */
+  public @Nonnull ServerOptions setHttpsOnly(boolean httpsOnly) {
+    this.httpsOnly = httpsOnly;
     return this;
   }
 

--- a/jooby/src/test/java/io/jooby/ServerOptionsTest.java
+++ b/jooby/src/test/java/io/jooby/ServerOptionsTest.java
@@ -22,6 +22,7 @@ public class ServerOptionsTest {
         .withValue("server.maxRequestSize", fromAnyRef(2048))
         .withValue("server.workerThreads", fromAnyRef(32))
         .withValue("server.host", fromAnyRef("0.0.0.0"))
+        .withValue("server.httpsOnly", fromAnyRef(true))
         .resolve()
     ).get();
     assertEquals(9090, options.getPort());
@@ -34,5 +35,6 @@ public class ServerOptionsTest {
     assertEquals(2048, options.getMaxRequestSize());
     assertEquals(32, options.getWorkerThreads());
     assertEquals("0.0.0.0", options.getHost());
+    assertEquals(true, options.isHttpsOnly());
   }
 }

--- a/modules/jooby-jetty/src/main/java/io/jooby/jetty/Jetty.java
+++ b/modules/jooby-jetty/src/main/java/io/jooby/jetty/Jetty.java
@@ -125,12 +125,14 @@ public class Jetty extends io.jooby.Server.Base {
       Optional.ofNullable(http2)
           .ifPresent(extension -> connectionFactories.addAll(extension.configure(httpConf)));
 
-      ServerConnector http = new ServerConnector(server,
-          connectionFactories.toArray(new ConnectionFactory[0]));
-      http.setPort(options.getPort());
-      http.setHost(options.getHost());
+      if (!options.isHttpsOnly()) {
+        ServerConnector http = new ServerConnector(server,
+            connectionFactories.toArray(new ConnectionFactory[0]));
+        http.setPort(options.getPort());
+        http.setHost(options.getHost());
 
-      server.addConnector(http);
+        server.addConnector(http);
+      }
 
       if (options.isSSLEnabled()) {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
@@ -170,6 +172,8 @@ public class Jetty extends io.jooby.Server.Base {
         secureConnector.setHost(options.getHost());
 
         server.addConnector(secureConnector);
+      } else if (options.isHttpsOnly()) {
+        throw new IllegalArgumentException("Server configured for httpsOnly, but ssl options not set");
       }
 
       ContextHandler context = new ContextHandler();

--- a/modules/jooby-netty/src/main/java/io/jooby/netty/Netty.java
+++ b/modules/jooby-netty/src/main/java/io/jooby/netty/Netty.java
@@ -127,12 +127,13 @@ public class Netty extends Server.Base {
       }
 
       /** Bootstrap: */
-      ServerBootstrap http = transport.configure(acceptorloop, eventloop)
-          .childHandler(newPipeline(factory, null, http2))
-          .childOption(ChannelOption.SO_REUSEADDR, true)
-          .childOption(ChannelOption.TCP_NODELAY, true);
-
-      http.bind(options.getHost(), options.getPort()).get();
+      if (!options.isHttpsOnly()) {
+        ServerBootstrap http = transport.configure(acceptorloop, eventloop)
+            .childHandler(newPipeline(factory, null, http2))
+            .childOption(ChannelOption.SO_REUSEADDR, true)
+            .childOption(ChannelOption.TCP_NODELAY, true);
+        http.bind(options.getHost(), options.getPort()).get();
+      }
 
       if (options.isSSLEnabled()) {
         SSLContext javaSslContext = options
@@ -152,6 +153,8 @@ public class Netty extends Server.Base {
             .childOption(ChannelOption.TCP_NODELAY, true);
 
         https.bind(options.getHost(), options.getSecurePort()).get();
+      } else if (options.isHttpsOnly()) {
+        throw new IllegalArgumentException("Server configured for httpsOnly, but ssl options not set");
       }
 
       fireReady(applications);

--- a/tests/src/test/java/io/jooby/HttpsTest.java
+++ b/tests/src/test/java/io/jooby/HttpsTest.java
@@ -3,7 +3,10 @@ package io.jooby;
 import io.jooby.junit.ServerTest;
 import io.jooby.junit.ServerTestRunner;
 
+import java.net.ConnectException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HttpsTest {
 
@@ -149,6 +152,19 @@ public class HttpsTest {
             rsp.header("Location"));
         assertEquals(302, rsp.code());
       });
+    });
+  }
+
+  @ServerTest
+  public void httpsOnly(ServerTestRunner runner) {
+    runner.define(app -> {
+      app.setServerOptions(new ServerOptions().setSecurePort(8443).setHttpsOnly(true));
+
+      app.get("/test", ctx -> "test");
+    }).ready((http, https) -> {
+      assertThrows(ConnectException.class, () -> http.get("/test", null));
+
+      https.get("/test", rsp -> assertEquals("test", rsp.body().string()));
     });
   }
 }


### PR DESCRIPTION
Fixes #2569. There was also a small fix for the documentation for kotlin server config, the boolean properties were missing the `is` prefix.