### PR TITLE
Jakarta inject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target
 .classpath
 .project
 .settings
+.factorypath
 dependency-reduced-pom.xml
 bin
 

--- a/docs/asciidoc/di-dagger.adoc
+++ b/docs/asciidoc/di-dagger.adoc
@@ -134,7 +134,7 @@ fun main(args: Array<String>) {
 <2> Register MVC route provided by Dagger
 
 Due the static nature of Dagger mvc integration identical to normal usage. For custom scopes/lifecycles
-Dagger generate a `javax.inject.Provider` on such use cases you need to switch and use the provider
+Dagger generate a `jakarta.inject.Provider` on such use cases you need to switch and use the provider
 version of the `mvc` method:
 
 .MVC and Dagger provider

--- a/docs/asciidoc/modules/guice.adoc
+++ b/docs/asciidoc/modules/guice.adoc
@@ -132,4 +132,4 @@ fun main(args: Array<String>) {
 The lifecycle of `MyController` is now managed by Guice. Also:
 
 - In Guice, the default scope is `prototype` (creates a new instance per request)
-- If you prefer a single instance add the `javax.inject.Singleton` annotation
+- If you prefer a single instance add the `jakarta.inject.Singleton` annotation

--- a/docs/asciidoc/modules/quartz.adoc
+++ b/docs/asciidoc/modules/quartz.adoc
@@ -186,7 +186,7 @@ This other example uses Guice as dependency provider:
 .Guice provisioning
 [source,java]
 ----
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 {
   install(new GuiceModule());

--- a/docs/asciidoc/modules/spring.adoc
+++ b/docs/asciidoc/modules/spring.adoc
@@ -92,7 +92,7 @@ public class BillingService {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
-import javax.inject.Inject
+import jakarta.inject.Inject
 import org.springframework.beans.factory.annotation.Value
 
 class BillingService @Inject constructor(@Value("\${currency}") val currency: String) {

--- a/docs/asciidoc/modules/weld.adoc
+++ b/docs/asciidoc/modules/weld.adoc
@@ -97,7 +97,7 @@ The Weld extension does a bit more in relation to MVC routes:
 automatically registered. No need to register it manually
 
 - The default scope is `prototype` (creates a new instance per request). If you prefer a single 
-instance add the `javax.inject.Singleton` annotation
+instance add the `jakarta.inject.Singleton` annotation
 
 .MVC route
 [source, java, role="primary"]

--- a/docs/asciidoc/mvc-api.adoc
+++ b/docs/asciidoc/mvc-api.adoc
@@ -183,7 +183,7 @@ one you like most.
 [source, java, role = "primary"]
 ----
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class App extends Jooby {
   {
@@ -201,7 +201,7 @@ public class App extends Jooby {
 .Kotlin
 [source, kotlin, role = "secondary"]
 ----
-import javax.inject.Provider
+import jakarta.inject.Provider
 import io.jooby.*
 
 fun main(args: Array<String>) {
@@ -212,7 +212,7 @@ fun main(args: Array<String>) {
 }
 ----
 
-The javadoc:Jooby[mvc, javax.inject.Provider] does the same job, might or might not delegate
+The javadoc:Jooby[mvc, jakarta.inject.Provider] does the same job, might or might not delegate
 instantiation to a dependency injection framework but most important let you control lifecycle of
 MVC routes (Singleton vs Non-Singleton routes).
 

--- a/docs/asciidoc/value-api.adoc
+++ b/docs/asciidoc/value-api.adoc
@@ -400,15 +400,14 @@ The target `POJO` must follow one of these rules:
 
 - Has a zero argguments/default constructor, or
 - Has only one constructor
-- Has multiple constructors, but only one is annotated with 
-https://static.javadoc.io/jakarta.inject/jakarta.inject/1/javax/inject/Inject.html[Inject]
+- Has multiple constructors, but only one is annotated with https://javadoc.io/doc/jakarta.inject/jakarta.inject-api/2.0.1/jakarta.inject/jakarta/inject/Inject.html[Inject]
 
 The decoder matches HTTP parameters in the following order:
 
 - As constructor arguments
 - As setter method
 
-HTTP parameter name which are not a valid Java identifier must be annotated with https://static.javadoc.io/jakarta.inject/jakarta.inject/1/javax/inject/Named.html[Named]:
+HTTP parameter name which are not a valid Java identifier must be annotated with https://javadoc.io/doc/jakarta.inject/jakarta.inject-api/2.0.1/jakarta.inject/jakarta/inject/Named.html[Named]:
 
 .Java
 [source, java,role="primary"]

--- a/docs/asciidoc/value-api.adoc
+++ b/docs/asciidoc/value-api.adoc
@@ -401,14 +401,14 @@ The target `POJO` must follow one of these rules:
 - Has a zero argguments/default constructor, or
 - Has only one constructor
 - Has multiple constructors, but only one is annotated with 
-https://static.javadoc.io/javax.inject/javax.inject/1/javax/inject/Inject.html[Inject]
+https://static.javadoc.io/jakarta.inject/jakarta.inject/1/javax/inject/Inject.html[Inject]
 
 The decoder matches HTTP parameters in the following order:
 
 - As constructor arguments
 - As setter method
 
-HTTP parameter name which are not a valid Java identifier must be annotated with https://static.javadoc.io/javax.inject/javax.inject/1/javax/inject/Named.html[Named]:
+HTTP parameter name which are not a valid Java identifier must be annotated with https://static.javadoc.io/jakarta.inject/jakarta.inject/1/javax/inject/Named.html[Named]:
 
 .Java
 [source, java,role="primary"]

--- a/jooby/pom.xml
+++ b/jooby/pom.xml
@@ -167,10 +167,10 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- javax.inject -->
+    <!-- jakarta.inject -->
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
 
     <!-- config -->

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jooby/src/main/java/io/jooby/MvcFactory.java
+++ b/jooby/src/main/java/io/jooby/MvcFactory.java
@@ -6,7 +6,7 @@
 package io.jooby;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 /**
  * Created by a Jooby annotation processor tool using the {@link java.util.ServiceLoader} API.

--- a/jooby/src/main/java/io/jooby/Router.java
+++ b/jooby/src/main/java/io/jooby/Router.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/jooby/src/main/java/io/jooby/ServiceRegistry.java
+++ b/jooby/src/main/java/io/jooby/ServiceRegistry.java
@@ -9,7 +9,7 @@ import io.jooby.exception.RegistryException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.Map;
 import java.util.Set;
 

--- a/jooby/src/main/java/io/jooby/annotations/Header.java
+++ b/jooby/src/main/java/io/jooby/annotations/Header.java
@@ -5,7 +5,7 @@
  */
 package io.jooby.annotations;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
+++ b/jooby/src/main/java/io/jooby/internal/ContextAsServiceInitializer.java
@@ -9,7 +9,7 @@ import io.jooby.Context;
 import io.jooby.RequestScope;
 import io.jooby.exception.RegistryException;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import static io.jooby.RequestScope.bind;
 import static io.jooby.RequestScope.unbind;

--- a/jooby/src/main/java/io/jooby/internal/RouterImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/RouterImpl.java
@@ -31,7 +31,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jooby/src/main/java/io/jooby/internal/ServiceRegistryImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/ServiceRegistryImpl.java
@@ -10,7 +10,7 @@ import io.jooby.ServiceRegistry;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/jooby/src/main/java/io/jooby/internal/converter/ReflectiveBeanConverter.java
+++ b/jooby/src/main/java/io/jooby/internal/converter/ReflectiveBeanConverter.java
@@ -24,8 +24,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import io.jooby.BeanConverter;
 import io.jooby.FileUpload;

--- a/jooby/src/test/java/io/jooby/ValueToBeanTest.java
+++ b/jooby/src/test/java/io/jooby/ValueToBeanTest.java
@@ -4,8 +4,8 @@ import io.jooby.internal.UrlParser;
 import io.jooby.internal.ValueConverterHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/HandlerCompiler.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/HandlerCompiler.java
@@ -19,7 +19,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;

--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/HandlerCompiler.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/HandlerCompiler.java
@@ -112,12 +112,12 @@ public class HandlerCompiler {
     String methodName = nameRegistry.generate(key);
 
     methodVisitor
-        .visitInvokeDynamicInsn("apply", "(Ljavax/inject/Provider;)Lio/jooby/Route$Handler;",
+        .visitInvokeDynamicInsn("apply", "(Ljakarta/inject/Provider;)Lio/jooby/Route$Handler;",
             new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory",
                 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
                 false), new Object[]{Type.getType("(Lio/jooby/Context;)Ljava/lang/Object;"),
                 new Handle(Opcodes.H_INVOKESTATIC, internalName, methodName,
-                    "(Ljavax/inject/Provider;Lio/jooby/Context;)Ljava/lang/Object;", false),
+                    "(Ljakarta/inject/Provider;Lio/jooby/Context;)Ljava/lang/Object;", false),
                 Type.getType("(Lio/jooby/Context;)Ljava/lang/Object;")});
 
     /** Apply implementation: */
@@ -146,7 +146,7 @@ public class HandlerCompiler {
     String methodDescriptor = methodDescriptor();
     MethodVisitor apply = writer
         .visitMethod(ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC, lambdaName,
-            "(Ljavax/inject/Provider;Lio/jooby/Context;)Ljava/lang/Object;", null,
+            "(Ljakarta/inject/Provider;Lio/jooby/Context;)Ljava/lang/Object;", null,
             new String[]{"java/lang/Exception"});
     apply.visitParameter("provider", ACC_FINAL | ACC_SYNTHETIC);
     apply.visitParameter("ctx", ACC_SYNTHETIC);

--- a/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ModuleCompiler.java
+++ b/modules/jooby-apt/src/main/java/io/jooby/internal/apt/ModuleCompiler.java
@@ -113,17 +113,17 @@ public class ModuleCompiler {
   private void create(ClassWriter writer) {
     String lambdaCreate = "makeExtension";
     MethodVisitor methodVisitor = writer
-        .visitMethod(ACC_PUBLIC, "create", "(Ljavax/inject/Provider;)Lio/jooby/Extension;", null,
+        .visitMethod(ACC_PUBLIC, "create", "(Ljakarta/inject/Provider;)Lio/jooby/Extension;", null,
             null);
     methodVisitor.visitParameter("provider", 0);
     methodVisitor.visitCode();
     methodVisitor.visitVarInsn(ALOAD, 1);
-    methodVisitor.visitInvokeDynamicInsn("install", "(Ljavax/inject/Provider;)Lio/jooby/Extension;",
+    methodVisitor.visitInvokeDynamicInsn("install", "(Ljakarta/inject/Provider;)Lio/jooby/Extension;",
         new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory",
             "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
             false), new Object[]{Type.getType("(Lio/jooby/Jooby;)V"),
             new Handle(Opcodes.H_INVOKESTATIC, moduleInternalName, lambdaCreate,
-                "(Ljavax/inject/Provider;Lio/jooby/Jooby;)V", false),
+                "(Ljakarta/inject/Provider;Lio/jooby/Jooby;)V", false),
             Type.getType("(Lio/jooby/Jooby;)V")});
     methodVisitor.visitInsn(ARETURN);
     methodVisitor.visitMaxs(0, 0);
@@ -135,7 +135,7 @@ public class ModuleCompiler {
   private void makeExtension(ClassWriter writer, String methodName) {
     MethodVisitor methodVisitor = writer
         .visitMethod(ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC, methodName,
-            "(Ljavax/inject/Provider;Lio/jooby/Jooby;)V", null,
+            "(Ljakarta/inject/Provider;Lio/jooby/Jooby;)V", null,
             new String[]{"java/lang/Exception"});
     methodVisitor.visitParameter("provider", Opcodes.ACC_FINAL | ACC_SYNTHETIC);
     methodVisitor.visitParameter("app", ACC_SYNTHETIC);
@@ -143,7 +143,7 @@ public class ModuleCompiler {
     methodVisitor.visitVarInsn(ALOAD, 1);
     methodVisitor.visitVarInsn(ALOAD, 0);
     methodVisitor.visitMethodInsn(INVOKESTATIC, moduleInternalName, "install",
-        "(Lio/jooby/Jooby;Ljavax/inject/Provider;)V", false);
+        "(Lio/jooby/Jooby;Ljakarta/inject/Provider;)V", false);
     methodVisitor.visitInsn(RETURN);
     methodVisitor.visitMaxs(0, 0);
     methodVisitor.visitEnd();
@@ -151,8 +151,8 @@ public class ModuleCompiler {
 
   private void install(ClassWriter writer, List<HandlerCompiler> handlers) throws Exception {
     MethodVisitor visitor = writer.visitMethod(ACC_PRIVATE | ACC_STATIC, "install",
-        "(Lio/jooby/Jooby;Ljavax/inject/Provider;)V",
-        "(Lio/jooby/Jooby;Ljavax/inject/Provider<" + Type.getObjectType(controllerClass.replace(".", "/")) + ">;)V",
+        "(Lio/jooby/Jooby;Ljakarta/inject/Provider;)V",
+        "(Lio/jooby/Jooby;Ljakarta/inject/Provider<" + Type.getObjectType(controllerClass.replace(".", "/")) + ">;)V",
         new String[]{"java/lang/Exception"});
     visitor.visitParameter("app", 0);
     visitor.visitParameter("provider", 0);

--- a/modules/jooby-apt/src/test/java/io/jooby/apt/MvcModuleCompilerRunner.java
+++ b/modules/jooby-apt/src/test/java/io/jooby/apt/MvcModuleCompilerRunner.java
@@ -10,7 +10,7 @@ import io.jooby.SneakyThrows;
 import io.jooby.internal.converter.ReflectiveBeanConverter;
 import org.objectweb.asm.util.ASMifier;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.lang.reflect.Constructor;

--- a/modules/jooby-apt/src/test/java/output/MvcExtension.java
+++ b/modules/jooby-apt/src/test/java/output/MvcExtension.java
@@ -6,7 +6,7 @@ import io.jooby.MvcFactory;
 import source.Controller1527;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class MvcExtension implements MvcFactory {
 

--- a/modules/jooby-apt/src/test/java/output/MyControllerHandler.java
+++ b/modules/jooby-apt/src/test/java/output/MyControllerHandler.java
@@ -1,7 +1,7 @@
 package output;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import io.jooby.Context;
 import io.jooby.Route;

--- a/modules/jooby-apt/src/test/java/tests/Expected1786b.java
+++ b/modules/jooby-apt/src/test/java/tests/Expected1786b.java
@@ -6,7 +6,7 @@ import io.jooby.exception.MissingValueException;
 import source.Controller1786b;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.UUID;
 
 public class Expected1786b implements MvcFactory {

--- a/modules/jooby-apt/src/test/java/tests/i1807/Expected1807.java
+++ b/modules/jooby-apt/src/test/java/tests/i1807/Expected1807.java
@@ -6,7 +6,7 @@ import io.jooby.exception.MissingValueException;
 import source.Controller1786b;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.UUID;
 
 public class Expected1807 implements MvcFactory {

--- a/modules/jooby-apt/src/test/java/tests/i1814/Expected1814.java
+++ b/modules/jooby-apt/src/test/java/tests/i1814/Expected1814.java
@@ -5,7 +5,7 @@ import io.jooby.MvcFactory;
 import io.jooby.Route;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class Expected1814 implements MvcFactory {
 

--- a/modules/jooby-apt/src/test/java/tests/i1859/Expected1859.java
+++ b/modules/jooby-apt/src/test/java/tests/i1859/Expected1859.java
@@ -5,7 +5,7 @@ import io.jooby.MvcFactory;
 import io.jooby.Route;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class Expected1859 implements MvcFactory {
 

--- a/modules/jooby-apt/src/test/java/tests/i2026/Expected2026.java
+++ b/modules/jooby-apt/src/test/java/tests/i2026/Expected2026.java
@@ -1,6 +1,6 @@
 package tests.i2026;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import io.jooby.Extension;
 import io.jooby.Jooby;

--- a/modules/jooby-apt/src/test/java/tests/i2325/Expected2325.java
+++ b/modules/jooby-apt/src/test/java/tests/i2325/Expected2325.java
@@ -1,6 +1,6 @@
 package tests.i2325;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import io.jooby.Extension;
 import io.jooby.Jooby;

--- a/modules/jooby-banner/src/main/java/io/jooby/banner/BannerModule.java
+++ b/modules/jooby-banner/src/main/java/io/jooby/banner/BannerModule.java
@@ -10,7 +10,7 @@ import io.jooby.Jooby;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.Optional;
 
 import static com.github.lalyos.jfiglet.FigletFont.convertOneLine;

--- a/modules/jooby-banner/src/test/java/io/jooby/banner/BannerModuleTest.java
+++ b/modules/jooby-banner/src/test/java/io/jooby/banner/BannerModuleTest.java
@@ -9,7 +9,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 import static com.github.lalyos.jfiglet.FigletFont.convertOneLine;
 import static io.jooby.banner.BannerModule.fontPath;

--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -56,7 +56,7 @@
   <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
   <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
   <jasypt.version>1.9.3</jasypt.version>
-  <javax.inject.version>1</javax.inject.version>
+  <jakarta.inject.version>1</jakarta.inject.version>
   <jboss-modules.version>1.11.0.Final</jboss-modules.version>
   <jdbi.version>3.32.0</jdbi.version>
   <jetty.version>11.0.11</jetty.version>
@@ -719,9 +719,9 @@
       <type>jar</type>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>${javax.inject.version}</version>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject</artifactId>
+      <version>${jakarta.inject.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/modules/jooby-commons-email/src/main/java/io/jooby/email/CommonsEmailModule.java
+++ b/modules/jooby-commons-email/src/main/java/io/jooby/email/CommonsEmailModule.java
@@ -20,7 +20,7 @@ import org.apache.commons.mail.MultiPartEmail;
 import org.apache.commons.mail.SimpleEmail;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;

--- a/modules/jooby-guice/src/main/java/io/jooby/di/JoobyModule.java
+++ b/modules/jooby-guice/src/main/java/io/jooby/di/JoobyModule.java
@@ -19,7 +19,7 @@ import io.jooby.ServiceKey;
 import io.jooby.ServiceRegistry;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;

--- a/modules/jooby-guice/src/main/java/io/jooby/di/JoobyModule.java
+++ b/modules/jooby-guice/src/main/java/io/jooby/di/JoobyModule.java
@@ -61,7 +61,10 @@ public class JoobyModule extends AbstractModule {
       } else {
         binding = bind(key.getType());
       }
-      binding.toProvider(provider);
+      //Guice does not support jakarta inject yet
+      //https://github.com/google/guice/issues/1383
+      javax.inject.Provider legacyProvider = () -> provider.get();
+      binding.toProvider(legacyProvider);
     }
   }
 

--- a/modules/jooby-hibernate/src/main/java/io/jooby/hibernate/HibernateModule.java
+++ b/modules/jooby-hibernate/src/main/java/io/jooby/hibernate/HibernateModule.java
@@ -28,7 +28,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;

--- a/modules/jooby-hibernate/src/main/java/io/jooby/internal/hibernate/SessionServiceProvider.java
+++ b/modules/jooby-hibernate/src/main/java/io/jooby/internal/hibernate/SessionServiceProvider.java
@@ -10,7 +10,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class SessionServiceProvider implements Provider<Session> {
   private final SessionFactory sessionFactory;

--- a/modules/jooby-hibernate/src/main/java/io/jooby/internal/hibernate/UnitOfWorkProvider.java
+++ b/modules/jooby-hibernate/src/main/java/io/jooby/internal/hibernate/UnitOfWorkProvider.java
@@ -12,7 +12,7 @@ import io.jooby.hibernate.TransactionalRequest;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class UnitOfWorkProvider implements Provider<UnitOfWork> {
 

--- a/modules/jooby-jdbi/src/main/java/io/jooby/internal/jdbi/HandleProvider.java
+++ b/modules/jooby-jdbi/src/main/java/io/jooby/internal/jdbi/HandleProvider.java
@@ -9,7 +9,7 @@ import io.jooby.RequestScope;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class HandleProvider implements Provider<Handle> {
   private Jdbi jdbi;

--- a/modules/jooby-jdbi/src/main/java/io/jooby/internal/jdbi/SqlObjectProvider.java
+++ b/modules/jooby-jdbi/src/main/java/io/jooby/internal/jdbi/SqlObjectProvider.java
@@ -10,7 +10,7 @@ import io.jooby.jdbi.TransactionalRequest;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class SqlObjectProvider implements Provider {
   private Jdbi jdbi;

--- a/modules/jooby-jdbi/src/main/java/io/jooby/jdbi/JdbiModule.java
+++ b/modules/jooby-jdbi/src/main/java/io/jooby/jdbi/JdbiModule.java
@@ -15,7 +15,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.Collections;

--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
@@ -35,8 +35,8 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.ParameterNode;
 
-import javax.inject.Named;
-import javax.inject.Provider;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;

--- a/modules/jooby-openapi/src/test/java/issues/i2594/ControllerV12594.java
+++ b/modules/jooby-openapi/src/test/java/issues/i2594/ControllerV12594.java
@@ -1,6 +1,6 @@
 package issues.i2594;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;

--- a/modules/jooby-openapi/src/test/java/issues/i2594/ControllerV22594.java
+++ b/modules/jooby-openapi/src/test/java/issues/i2594/ControllerV22594.java
@@ -1,6 +1,6 @@
 package issues.i2594;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;

--- a/modules/jooby-openapi/src/test/java/issues/i2594/HealthController2594.java
+++ b/modules/jooby-openapi/src/test/java/issues/i2594/HealthController2594.java
@@ -1,6 +1,6 @@
 package issues.i2594;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.google.common.collect.ImmutableMap;
 import io.jooby.Context;

--- a/modules/jooby-openapi/src/test/kotlin/kt/KtController.kt
+++ b/modules/jooby-openapi/src/test/kotlin/kt/KtController.kt
@@ -3,7 +3,7 @@ package kt
 import examples.ABean
 import kotlinx.coroutines.delay
 import java.util.concurrent.CompletableFuture
-import javax.inject.Named
+import jakarta.inject.Named
 import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam

--- a/modules/jooby-openapi/src/test/kotlin/kt/KtObjectController.kt
+++ b/modules/jooby-openapi/src/test/kotlin/kt/KtObjectController.kt
@@ -3,7 +3,7 @@ package kt
 import examples.ABean
 import kotlinx.coroutines.delay
 import java.util.concurrent.CompletableFuture
-import javax.inject.Named
+import jakarta.inject.Named
 import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam

--- a/modules/jooby-quartz/src/main/java/io/jooby/internal/quartz/JobGenerator.java
+++ b/modules/jooby-quartz/src/main/java/io/jooby/internal/quartz/JobGenerator.java
@@ -31,7 +31,7 @@ import org.quartz.TriggerKey;
 import org.quartz.impl.JobDetailImpl;
 import org.quartz.spi.MutableTrigger;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;

--- a/modules/jooby-spring/src/main/java/io/jooby/di/SpringModule.java
+++ b/modules/jooby-spring/src/main/java/io/jooby/di/SpringModule.java
@@ -19,7 +19,7 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.stereotype.Controller;
 
 import javax.annotation.Nonnull;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.util.Map;
 
 /**

--- a/modules/jooby-weld/src/main/java/io/jooby/di/JoobyExtension.java
+++ b/modules/jooby-weld/src/main/java/io/jooby/di/JoobyExtension.java
@@ -26,7 +26,7 @@ import javax.enterprise.inject.spi.InjectionTarget;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
 import javax.enterprise.inject.spi.configurator.BeanConfigurator;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <conscrypt.version>2.5.2</conscrypt.version>
 
     <!-- javax -->
-    <javax.inject.version>1</javax.inject.version>
+    <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <jsr305.version>3.0.2</jsr305.version>
     <jakarta.ws.rs-api.version>3.0.0</jakarta.ws.rs-api.version>
 
@@ -850,11 +850,11 @@
         <version>${h2.version}</version>
       </dependency>
 
-      <!-- javax.inject -->
+      <!-- jakarta.inject -->
       <dependency>
-        <groupId>javax.inject</groupId>
-        <artifactId>javax.inject</artifactId>
-        <version>${javax.inject.version}</version>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>${jakarta.inject.version}</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/org.flywaydb/flyway-core -->

--- a/starters/guice-starter/src/main/java/starter/domain/DatabaseOrderRepository.java
+++ b/starters/guice-starter/src/main/java/starter/domain/DatabaseOrderRepository.java
@@ -4,7 +4,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class DatabaseOrderRepository implements OrderRepository {
   private Jdbi jdbi;

--- a/starters/guice-starter/src/main/java/starter/service/BillingService.java
+++ b/starters/guice-starter/src/main/java/starter/service/BillingService.java
@@ -3,7 +3,7 @@ package starter.service;
 import starter.domain.Order;
 import starter.domain.OrderRepository;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class BillingService {
   private final OrderRepository transactionLog;

--- a/starters/spring-starter/src/main/java/starter/api/PetController.java
+++ b/starters/spring-starter/src/main/java/starter/api/PetController.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import starter.domain.Pet;
 import starter.domain.PetRepository;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.List;
 
 @Controller

--- a/tests/src/test/java/io/jooby/i2325/MyID2325.java
+++ b/tests/src/test/java/io/jooby/i2325/MyID2325.java
@@ -1,6 +1,6 @@
 package io.jooby.i2325;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class MyID2325 {
 

--- a/tests/src/test/java/io/jooby/i2457/ControllerV12457.java
+++ b/tests/src/test/java/io/jooby/i2457/ControllerV12457.java
@@ -1,15 +1,18 @@
 package io.jooby.i2457;
 
-import jakarta.inject.Inject;
-
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;
 
 @Path("/")
 public class ControllerV12457 {
 
-  @Inject
   private WelcomeService2457 welcomeService;
+
+  @javax.inject.Inject //Guice does not support jakarta annotations
+  public ControllerV12457(WelcomeService2457 welcomeService) {
+    super();
+    this.welcomeService = welcomeService;
+  }
 
   @GET("/welcome")
   public String sayHi() {

--- a/tests/src/test/java/io/jooby/i2457/ControllerV12457.java
+++ b/tests/src/test/java/io/jooby/i2457/ControllerV12457.java
@@ -1,6 +1,6 @@
 package io.jooby.i2457;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;

--- a/tests/src/test/java/io/jooby/i2457/ControllerV22457.java
+++ b/tests/src/test/java/io/jooby/i2457/ControllerV22457.java
@@ -1,6 +1,5 @@
 package io.jooby.i2457;
 
-import jakarta.inject.Inject;
 
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;
@@ -8,7 +7,7 @@ import io.jooby.annotations.Path;
 @Path("/")
 public class ControllerV22457 {
 
-  @Inject
+  @javax.inject.Inject // Guice does not support jakarta inject yet.
   private WelcomeService2457 welcomeService;
 
   @GET("/welcome")

--- a/tests/src/test/java/io/jooby/i2457/ControllerV22457.java
+++ b/tests/src/test/java/io/jooby/i2457/ControllerV22457.java
@@ -1,6 +1,6 @@
 package io.jooby.i2457;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import io.jooby.annotations.GET;
 import io.jooby.annotations.Path;

--- a/tests/src/test/java/io/jooby/i2457/HealthController2457.java
+++ b/tests/src/test/java/io/jooby/i2457/HealthController2457.java
@@ -1,6 +1,5 @@
 package io.jooby.i2457;
 
-import jakarta.inject.Inject;
 
 import com.google.common.collect.ImmutableMap;
 import io.jooby.Context;
@@ -10,8 +9,13 @@ import io.jooby.annotations.Path;
 @Path("/")
 public class HealthController2457 {
 
-  @Inject
   private WelcomeService2457 welcomeService;
+
+  @javax.inject.Inject //Guice does not support jakarta annotations
+  public HealthController2457(WelcomeService2457 welcomeService) {
+    super();
+    this.welcomeService = welcomeService;
+  }
 
   @GET("/healthcheck")
   public void healthCheck(Context ctx) {

--- a/tests/src/test/java/io/jooby/i2457/HealthController2457.java
+++ b/tests/src/test/java/io/jooby/i2457/HealthController2457.java
@@ -1,6 +1,6 @@
 package io.jooby.i2457;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.google.common.collect.ImmutableMap;
 import io.jooby.Context;


### PR DESCRIPTION
First step to modularization (#2630) is switch to javax.inject to the new jakarta.inject-api. 

Unfortunately Guice does not yet support jakarta.inject: https://github.com/google/guice/issues/1383

I put in a temporary hack for now. Knowing Google I'm sure Dagger probably doesn't support jakarta inject either however I'm fairly sure that doesn't matter as Dagger generates code.
