### PR TITLE
fix(sec): upgrade com.amazonaws:aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns='http://maven.apache.org/POM/4.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-         xsi:schemaLocation='http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd'>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>io.jooby</groupId>
     <artifactId>modules</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.amazonaws:aws-java-sdk-s3 1.12.230
- [CVE-2022-31159](https://www.oscs1024.com/hd/CVE-2022-31159)


### What did I do？
Upgrade com.amazonaws:aws-java-sdk-s3 from 1.12.230 to 1.12.261 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS