### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 2.7.2

### DIFF
--- a/modules/jooby-bom/pom.xml
+++ b/modules/jooby-bom/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns='http://maven.apache.org/POM/4.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-         xsi:schemaLocation='http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd'>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <groupId>io.jooby</groupId>
     <artifactId>modules</artifactId>
@@ -67,7 +66,7 @@
   <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
   <jsr305.version>3.0.2</jsr305.version>
   <junit.version>5.8.2</junit.version>
-  <kafka.version>2.7.0</kafka.version>
+  <kafka.version>2.7.2</kafka.version>
   <kotlin.version>1.6.21</kotlin.version>
   <kotlinx-coroutines-core.version>1.6.2</kotlinx-coroutines-core.version>
   <lettuce.version>6.1.8.RELEASE</lettuce.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.jooby</groupId>
@@ -43,7 +41,7 @@
     <graphql-java.version>19.2</graphql-java.version>
     <lettuce.version>6.1.8.RELEASE</lettuce.version>
     <commons-pool2.version>2.11.1</commons-pool2.version>
-    <kafka.version>2.7.0</kafka.version>
+    <kafka.version>2.7.2</kafka.version>
     <caffeine.version>3.1.1</caffeine.version>
 
     <config.version>1.4.2</config.version>
@@ -1416,10 +1414,8 @@
               </goals>
               <configuration>
                 <transformers>
-                  <transformer
-                      implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                  <transformer
-                      implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                     <mainClass>${application.class}</mainClass>
                   </transformer>
                 </transformers>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 2.7.0
- [CVE-2021-38153](https://www.oscs1024.com/hd/CVE-2021-38153)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 2.7.0 to 2.7.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS