### PR TITLE
encoder: should consider all produce types before default TO_STRING

### DIFF
--- a/jooby/src/main/java/io/jooby/internal/HttpMessageEncoder.java
+++ b/jooby/src/main/java/io/jooby/internal/HttpMessageEncoder.java
@@ -12,9 +12,13 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.annotation.Nonnull;
 
@@ -104,9 +108,18 @@ public class HttpMessageEncoder implements MessageEncoder {
       if (produces.isEmpty()) {
         produces = new ArrayList<>(encoders.keySet());
       }
-      MediaType type = ctx.accept(produces);
-      MessageEncoder encoder = encoders.getOrDefault(type, MessageEncoder.TO_STRING);
-      return encoder.encode(ctx, value);
+
+      List<MediaType> producesSubList = new ArrayList<>(produces);
+      while (!producesSubList.isEmpty()){
+        final MediaType type = ctx.accept(producesSubList);
+        MessageEncoder encoder = encoders.get(type);
+        if (encoder != null){
+          return encoder.encode(ctx, value);
+        }
+        producesSubList = producesSubList.subList(1, producesSubList.size());
+      }
+
+      return MessageEncoder.TO_STRING.encode(ctx, value);
     } else {
       return MessageEncoder.TO_STRING.encode(ctx, value);
     }

--- a/tests/src/test/java/io/jooby/i2804/Issue2804.java
+++ b/tests/src/test/java/io/jooby/i2804/Issue2804.java
@@ -1,0 +1,63 @@
+package io.jooby.i2804;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.jooby.MediaType;
+import io.jooby.StatusCode;
+import io.jooby.json.JacksonModule;
+import io.jooby.junit.ServerTest;
+import io.jooby.junit.ServerTestRunner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2804 {
+
+    public static class Error {
+        public String message;
+    }
+
+    public static class Errors {
+        public List<Error> errors = new ArrayList<>();
+    }
+
+    @ServerTest
+    public void shouldConsiderRouteProduces(ServerTestRunner runner) {
+        runner.define(app -> {
+
+            app.install(new JacksonModule());
+            app.get("/pdf", ctx -> {
+
+                if (ctx.header("Authorization").isMissing()){
+                    ctx.setResponseCode(StatusCode.UNAUTHORIZED).setResponseType(MediaType.json);
+                    final Errors errors = new Errors();
+                    final Error error = new Error();
+                    error.message = "No Authorization provided";
+                    errors.errors.add(error);
+                    return errors;
+                }
+
+                ctx.setResponseCode(StatusCode.OK).setResponseType(MediaType.byFileExtension("pdf"));
+                byte[] dummyData = new byte[1024];
+                Arrays.fill(dummyData, (byte) 0x0a);
+                return new ByteArrayInputStream(dummyData);
+
+            }).produces(MediaType.byFileExtension("pdf"), MediaType.json);
+
+        }).ready(http -> {
+            http.get("/pdf", rsp -> {
+                assertEquals(StatusCode.UNAUTHORIZED_CODE, rsp.code());
+                assertEquals(MediaType.json.toContentTypeHeader(StandardCharsets.UTF_8).toLowerCase(), rsp.header("Content-Type").toLowerCase());
+                assertEquals("{\"errors\":[{\"message\":\"No Authorization provided\"}]}", rsp.body().string());
+            });
+            http.get("/pdf").prepare(req -> req.addHeader("Authorization", "foo")).execute(rsp -> {
+                assertEquals(StatusCode.OK_CODE, rsp.code());
+                assertEquals(MediaType.byFileExtension("pdf").getValue(), rsp.header("Content-Type"));
+                assertEquals(1024, rsp.body().bytes().length);
+            });
+        });
+    }
+}


### PR DESCRIPTION
fixes #2804

Fixes regression introduced by 9640984a949890948f15c472e47df3086005b890 to fix issue #2613 internal.HttpMessageEncoder should consider the Route produces for determining MediaType