### PR TITLE
Add Rocker style pre-encoding for JStachio

### DIFF
--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/ByteBufferedOutputStream.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/ByteBufferedOutputStream.java
@@ -1,0 +1,117 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.jstachio;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * This is basically the same as Rockers byte buffer but as an OutputStream because JStachio wants
+ * that interface. Currently it is internal.
+ *
+ * @author agentgt
+ */
+class ByteBufferedOutputStream extends OutputStream {
+
+  /** Default buffer size: <code>4k</code>. */
+  public static final int BUFFER_SIZE = 4096;
+
+  /**
+   * The maximum size of array to allocate. Some VMs reserve some header words in an array. Attempts
+   * to allocate larger arrays may result in OutOfMemoryError: Requested array size exceeds VM limit
+   */
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+  /** The buffer where data is stored. */
+  protected byte[] buf;
+
+  /** The number of valid bytes in the buffer. */
+  protected int count;
+
+  ByteBufferedOutputStream(int bufferSize) {
+    this.buf = new byte[bufferSize];
+  }
+
+  void reset() {
+    count = 0;
+  }
+
+  @Override
+  public void close() {
+    this.reset();
+  }
+
+  @Override
+  public void write(byte[] bytes) {
+    int len = bytes.length;
+    ensureCapacity(count + len);
+    System.arraycopy(bytes, 0, buf, count, len);
+    count += len;
+  }
+
+  public int size() {
+    return count;
+  }
+
+  /**
+   * Copy internal byte array into a new array.
+   *
+   * @return Byte array.
+   */
+  public byte[] toByteArray() {
+    byte[] array = new byte[count];
+    System.arraycopy(buf, 0, array, 0, count);
+    return array;
+  }
+
+  /**
+   * Get a view of the byte buffer.
+   *
+   * @return Byte buffer.
+   */
+  public ByteBuffer toBuffer() {
+    return ByteBuffer.wrap(buf, 0, count);
+  }
+
+  private void ensureCapacity(int minCapacity) {
+    // overflow-conscious code
+    if (minCapacity - buf.length > 0) {
+      grow(minCapacity);
+    }
+  }
+
+  /**
+   * Increases the capacity to ensure that it can hold at least the number of elements specified by
+   * the minimum capacity argument.
+   *
+   * @param minCapacity the desired minimum capacity
+   */
+  private void grow(int minCapacity) {
+    // overflow-conscious code
+    int oldCapacity = buf.length;
+    int newCapacity = oldCapacity << 1;
+    if (newCapacity - minCapacity < 0) {
+      newCapacity = minCapacity;
+    }
+    if (newCapacity - MAX_ARRAY_SIZE > 0) {
+      newCapacity = hugeCapacity(minCapacity);
+    }
+    buf = Arrays.copyOf(buf, newCapacity);
+  }
+
+  private static int hugeCapacity(int minCapacity) {
+    if (minCapacity < 0) {
+      throw new OutOfMemoryError();
+    }
+    return (minCapacity > MAX_ARRAY_SIZE) ? Integer.MAX_VALUE : MAX_ARRAY_SIZE;
+  }
+
+  @Override
+  public void write(int b) {
+    throw new UnsupportedOperationException("expecting only write(byte[])");
+  }
+}

--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioBuffer.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioBuffer.java
@@ -1,0 +1,55 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.jstachio;
+
+/**
+ * To provide Rocker like buffer support
+ *
+ * @author agentgt
+ */
+interface JStachioBuffer {
+
+  public ByteBufferedOutputStream acquire();
+
+  public void release(ByteBufferedOutputStream buffer);
+
+  static JStachioBuffer of(int bufferSize, boolean reuseBuffer) {
+    if (reuseBuffer) {
+      return new ReuseBuffer(bufferSize);
+    } else {
+      return new NoReuseBuffer(bufferSize);
+    }
+  }
+}
+
+record NoReuseBuffer(int bufferSize) implements JStachioBuffer {
+  @Override
+  public ByteBufferedOutputStream acquire() {
+    return new ByteBufferedOutputStream(bufferSize);
+  }
+
+  @Override
+  public void release(ByteBufferedOutputStream buffer) {}
+}
+
+class ReuseBuffer implements JStachioBuffer {
+  private final ThreadLocal<ByteBufferedOutputStream> localBuffer;
+
+  public ReuseBuffer(int bufferSize) {
+    super();
+    this.localBuffer = ThreadLocal.withInitial(() -> new ByteBufferedOutputStream(bufferSize));
+  }
+
+  @Override
+  public ByteBufferedOutputStream acquire() {
+    return localBuffer.get();
+  }
+
+  @Override
+  public void release(ByteBufferedOutputStream buffer) {
+    buffer.reset();
+  }
+}

--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioHandler.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioHandler.java
@@ -1,30 +1,31 @@
 /*
  * Jooby https://jooby.io
  * Apache License Version 2.0 https://jooby.io/LICENSE.txt
- * Copyright 2023 Edgar Espina
+ * Copyright 2014 Edgar Espina
  */
 package io.jooby.jstachio;
 
+import java.io.IOException;
+
+import io.jooby.Context;
 import io.jooby.MediaType;
 import io.jooby.Route;
 import io.jooby.Route.Handler;
+import io.jstach.jstachio.JStachio;
+import io.jstach.jstachio.Template;
 
-class JStachioHandler implements Route.Filter {
-  
-  private final JStachioMessageEncoder encoder;
-  
-  public JStachioHandler(JStachioMessageEncoder encoder) {
-    super();
-    this.encoder = encoder;
+class JStachioHandler extends JStachioRenderer<Context> implements Route.Filter {
+
+  public JStachioHandler(JStachio jstachio, JStachioBuffer buffer) {
+    super(jstachio, buffer);
   }
 
   @Override
   public Handler apply(Handler next) {
     return ctx -> {
       try {
-        Object model =  next.apply(ctx);
-        ctx.setResponseType(MediaType.html);
-        return ctx.send(encoder.render(model));
+        Object model = next.apply(ctx);
+        return render(ctx, model);
       } catch (Throwable x) {
         ctx.sendError(x);
         return x;
@@ -32,4 +33,24 @@ class JStachioHandler implements Route.Filter {
     };
   }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  Context render(
+      Context ctx,
+      @SuppressWarnings("rawtypes") Template template,
+      Object model,
+      ByteBufferedOutputStream stream)
+      throws IOException {
+    ctx.setResponseType(MediaType.html);
+    template.write(model, stream);
+    /*
+     * Rocker used a byte buffer here BUT it just wraps the internal buffer in the stream
+     * instead of copying.
+     *
+     * Which is good for performance but bad if the ctx.send call is not blocking aka
+     * hand the buffer off to another thread.
+     */
+    ctx.send(stream.toBuffer());
+    return ctx;
+  }
 }

--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioMessageEncoder.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioMessageEncoder.java
@@ -5,68 +5,39 @@
  */
 package io.jooby.jstachio;
 
-import java.nio.charset.Charset;
+import java.io.IOException;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jooby.Context;
 import io.jooby.MessageEncoder;
 import io.jstach.jstachio.JStachio;
+import io.jstach.jstachio.Template;
 
 /*
  * Should this be public?
  */
-class JStachioMessageEncoder implements MessageEncoder {
+class JStachioMessageEncoder extends JStachioRenderer<byte[]> implements MessageEncoder {
 
-  private final JStachio jstachio;
-  private final Charset charset;
-  private final int bufferSize;
-
-  public JStachioMessageEncoder(
-      @NonNull JStachio jstachio, @NonNull Charset charset, int bufferSize) {
-    super();
-    this.jstachio = jstachio;
-    this.charset = charset;
-    this.bufferSize = bufferSize;
+  public JStachioMessageEncoder(JStachio jstachio, JStachioBuffer buffer) {
+    super(jstachio, buffer);
   }
 
   @Override
   public byte[] encode(Context ctx, Object value) throws Exception {
     if (supportsType(value.getClass())) {
-      return render(value);
+      return render(ctx, value);
     }
     return null;
   }
 
-  protected boolean supportsType(Class<?> modelClass) {
-    return jstachio.supportsType(modelClass);
-  }
-
-  protected byte[] render(Object value) {
-    StringBuilder b = acquireBuffer();
-    try {
-      jstachio.execute(value, b);
-      return b.toString().getBytes(charset);
-    } finally {
-      releaseBuffer(b);
-    }
-  }
-
-  /**
-   * Returns a new buffer. {@link #releaseBuffer(StringBuilder)) should be
-   * called when done.
-   *
-   * @return a buffer either from a pool or a new one.
-   */
-  protected StringBuilder acquireBuffer() {
-    return new StringBuilder(bufferSize);
-  }
-
-  /**
-   * Releases the buffer. Override for pooling buffers.
-   *
-   * @param sb
-   */
-  protected void releaseBuffer(StringBuilder sb) {
-    return;
+  @SuppressWarnings("unchecked")
+  @Override
+  byte[] render(
+      Context ctx,
+      @SuppressWarnings("rawtypes") Template template,
+      Object model,
+      ByteBufferedOutputStream stream)
+      throws IOException {
+    template.write(model, stream);
+    return stream.toByteArray();
   }
 }

--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioRenderer.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioRenderer.java
@@ -1,0 +1,62 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.jstachio;
+
+import java.io.IOException;
+
+import io.jooby.Context;
+import io.jooby.MediaType;
+import io.jstach.jstachio.JStachio;
+import io.jstach.jstachio.Template;
+
+/**
+ * Shared logic between encoder and result handler
+ *
+ * @author agentgt
+ * @param <T> results of render call
+ */
+abstract class JStachioRenderer<T> {
+
+  private final JStachio jstachio;
+  private final JStachioBuffer buffer;
+
+  public JStachioRenderer(JStachio jstachio, JStachioBuffer buffer) {
+    super();
+    this.jstachio = jstachio;
+    this.buffer = buffer;
+  }
+
+  public T render(Context ctx, Object model) throws Exception {
+    var stream = buffer.acquire();
+    try {
+      @SuppressWarnings("rawtypes")
+      Template template = jstachio.findTemplate(model);
+      /*
+       * TODO we probably should resolve the correct media type here and more importantly charset
+       * Or at least validate that it is text/html UTF-8.
+       * However this would slow things down.
+       *
+       * The Rocker module apparently just assumes "text/html; charset=utf-8"
+       * So for now we will as well.
+       */
+      ctx.setResponseType(MediaType.html);
+      return render(ctx, template, model, stream);
+    } finally {
+      buffer.release(stream);
+    }
+  }
+
+  abstract T render(
+      Context ctx,
+      @SuppressWarnings("rawtypes") Template template,
+      Object model,
+      ByteBufferedOutputStream stream)
+      throws IOException;
+
+  protected boolean supportsType(Class<?> modelClass) {
+    return jstachio.supportsType(modelClass);
+  }
+}

--- a/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioResultHandler.java
+++ b/modules/jooby-jstachio/src/main/java/io/jooby/jstachio/JStachioResultHandler.java
@@ -10,18 +10,22 @@ import java.lang.reflect.Type;
 import io.jooby.Reified;
 import io.jooby.ResultHandler;
 import io.jooby.Route.Filter;
+import io.jstach.jstachio.JStachio;
 
 class JStachioResultHandler implements ResultHandler {
 
-  private final JStachioMessageEncoder encoder;
+  private final JStachio jstachio;
+  private final JStachioBuffer buffer;
 
-  public JStachioResultHandler(JStachioMessageEncoder encoder) {
-    this.encoder = encoder;
+  public JStachioResultHandler(JStachio jstachio, JStachioBuffer buffer) {
+    super();
+    this.jstachio = jstachio;
+    this.buffer = buffer;
   }
 
   @Override
   public boolean matches(Type type) {
-    return encoder.supportsType(Reified.rawType(type));
+    return jstachio.supportsType(Reified.rawType(type));
   }
 
   @Override
@@ -31,6 +35,6 @@ class JStachioResultHandler implements ResultHandler {
 
   @Override
   public Filter create() {
-    return new JStachioHandler(encoder);
+    return new JStachioHandler(jstachio, buffer);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <!-- Parser and Renderer -->
     <freemarker.version>2.3.32</freemarker.version>
     <handlebars.version>4.3.1</handlebars.version>
-    <jstachio.version>0.16.0</jstachio.version>
+    <jstachio.version>0.17.0</jstachio.version>
     <pebble.version>3.2.1</pebble.version>
     <jackson.version>2.15.0</jackson.version>
     <jackson-dataformat-yaml.version>${jackson.version}</jackson-dataformat-yaml.version>


### PR DESCRIPTION
@jknack I have updated the JStachio module so that it can take advantage of pre-encoding (the static parts of the template are generated as bytes[] in advance).

The reason I did this is that in the techempower benchmarks Rocker performed better than JStachio's naive `String.getBytes()`.

I also have added threadlocal buffering and removed setting charset.

Setting the charset was a bad idea anyway as JStachio unlike others cannot always re-read the template from the filesystem furthermore escaping is naturally tied to charset.

I noticed that Rocker just assumes MediaType.html (and thus UTF-8) so I have done likewise.

I just released jstachio 0.17.0 but it will take an hour or so before central shows it.