### PR TITLE
Add information about application properties used by Jooby in the documentation

### DIFF
--- a/docs/asciidoc/configuration.adoc
+++ b/docs/asciidoc/configuration.adoc
@@ -371,3 +371,20 @@ There are a couple of solution is for this:
 - use an instance logger
 - use the getLog() method of Jooby
 ====
+
+=== Application Properties
+
+These are the application properties that Jooby uses:
+
+[options="header"]
+|===
+|Property name | Description | Default value
+|application.charset | Charset used by your application. | `UTF-8`
+|application.env | The active <<configuration-environment, environment>> names. | `dev`
+|application.lang | The languages your application supports. | A single locale provided by `Locale.getDefault()`.
+|application.logfile | The logging configuration file your application uses. You don't need to set this property, see <<configuration-logging, logging configuration>>. |
+|application.package | The base package of your application. |
+|application.pid | JVM process ID. | The native process ID assigned by the operating system.
+|application.startupSummary | The level of information logged during startup. |
+|application.tmpdir | Temporary directory used by your application. | `tmp`
+|===


### PR DESCRIPTION
Added a table with a short description and default value for application properties, as discussed in issue #2981.