### PR TITLE
doc: fix javadoc links

### DIFF
--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -25,7 +25,7 @@ public class JavadocProcessor extends InlineMacroProcessor {
   public Object process(ContentNode parent, String clazz, Map<String, Object> attributes) {
 
     StringBuilder link =
-        new StringBuilder("https://www.javadoc.io/doc/io.jooby/jooby/latest/io/jooby/");
+        new StringBuilder("https://www.javadoc.io/doc/io.jooby/jooby/latest/io.jooby/io/jooby/");
     StringBuilder text = new StringBuilder();
     String[] names = clazz.split("\\.");
     List<String> pkg = new ArrayList<>();


### PR DESCRIPTION
Links to javadoc in the documentation are not working. This should fix them.