### PR TITLE
Improve asset API

### DIFF
--- a/jooby/src/main/java/io/jooby/Router.java
+++ b/jooby/src/main/java/io/jooby/Router.java
@@ -721,11 +721,15 @@ public interface Router extends Registry {
    * Add a static resource handler.
    *
    * @param pattern Path pattern.
-   * @param sources Asset sources. At least one source is required.
+   * @param source Asset source.
+   * @param sources additional Asset sources.
    * @return A route.
    */
-  default @NonNull Route assets(@NonNull String pattern, @NonNull AssetSource... sources) {
-    return assets(pattern, new AssetHandler(sources));
+  default @NonNull Route assets(@NonNull String pattern, @NonNull AssetSource source, @NonNull AssetSource... sources) {
+    AssetSource[] array = new AssetSource[1 + sources.length];
+    array[0] = source;
+    System.arraycopy(sources, 0, array, 1, sources.length);
+    return assets(pattern, new AssetHandler(array));
   }
 
   /**


### PR DESCRIPTION
This will make it impossible for zero asset sources.

In theory this will break semver API but I know this is the right way and we don't follow semver :P 

Ideally this would be on the AssetHandler as well.

For the odd place where someone actually passes an array you can add an additional method:

```java
default @NonNull Route assets(@NonNull String pattern, @NonNull AssetSource[] sources)
```

Let me know and I can add that as well.