### PR TITLE
Cleanup starting and dagger docs

### DIFF
--- a/docs/asciidoc/di-dagger.adoc
+++ b/docs/asciidoc/di-dagger.adoc
@@ -34,11 +34,11 @@
 [source, kotlin, role = "secondary"]
 ----
 plugins {
-  id "net.ltgt.apt" version "0.21"
+  id "org.jetbrains.kotlin.kapt" version "1.9.10"
 }
 
 dependencies {
-  apt 'com.google.dagger:dagger-compiler:2.20'
+  kapt 'com.google.dagger:dagger-compiler:2.20'
 }
 ----
 
@@ -88,6 +88,12 @@ fun main(args: Array<String>) {
 
 <1> Bootstrap dagger component
 <2> Use dagger provided objects
+
+[NOTE]
+====
+`DaggerAppComponent` in the example above is a generated source.
+Check out the https://dagger.dev/tutorial[Dagger tutorial] to learn more.
+====
 
 ==== MVC routes
 

--- a/docs/asciidoc/getting-started.adoc
+++ b/docs/asciidoc/getting-started.adoc
@@ -26,7 +26,7 @@ to make it globally accessible from any location.
 
 [NOTE]
 ====
-To simplify documentation we use `jooby` as command. Windows users must use `jooby.bat`
+To simplify documentation we use `jooby` as command, it requires Java 17 as minimum. Windows users must use `jooby.bat`
 ====
 
 .Setting workspace:


### PR DESCRIPTION
*  Add note about what java version needs to be used when running the cli
* Update dagger section with up-do-date kotlin information (use kapt)