### PR TITLE
Support correct mime type for .wasm files fix #3403

### DIFF
--- a/jooby/src/main/java/io/jooby/MediaType.java
+++ b/jooby/src/main/java/io/jooby/MediaType.java
@@ -848,6 +848,8 @@ public final class MediaType implements Comparable<MediaType> {
         return new MediaType("application/x-cabinet", null);
       case "gif":
         return new MediaType("image/gif", null);
+      case "wasm":
+        return new MediaType("application/wasm", null);
       default:
         return octetStream;
     }


### PR DESCRIPTION
Send `application/wasm` for `*.wasm` files.