### PR TITLE
Fix/dagger mvc openapi

### DIFF
--- a/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
+++ b/modules/jooby-openapi/src/main/java/io/jooby/internal/openapi/AnnotationParser.java
@@ -204,15 +204,21 @@ public class AnnotationParser {
             // mvc(daggerApp.myController());
             Type type = Type.getReturnType(methodInsnNode.desc);
             return parse(ctx, prefix, type);
-          } else if(methodPrev instanceof LdcInsnNode ldcInsnNode) {
+          } else if (methodPrev instanceof LdcInsnNode ldcInsnNode) {
             // mvc(beanScope.get(...));
             Type type = (Type) (ldcInsnNode).cst;
             return parse(ctx, prefix, type);
           }
         } else {
-          // mvc(some.myController());
-          Type type = Type.getReturnType(methodInsnNode.desc);
-          return parse(ctx, prefix, type);
+          if (methodInsnNode.getPrevious() instanceof LdcInsnNode ldcInsnNode) {
+            // mvc(require(Controller.class))
+            Type type = (Type) (ldcInsnNode).cst;
+            return parse(ctx, prefix, type);
+          } else {
+            // mvc(some.myController());
+            Type type = Type.getReturnType(methodInsnNode.desc);
+            return parse(ctx, prefix, type);
+          }
         }
       } else if (previous instanceof FieldInsnNode) {
         FieldInsnNode fieldInsnNode = (FieldInsnNode) previous;

--- a/modules/jooby-openapi/src/test/java/examples/MvcDaggerApp.java
+++ b/modules/jooby-openapi/src/test/java/examples/MvcDaggerApp.java
@@ -1,0 +1,38 @@
+package examples;
+
+import io.jooby.Jooby;
+import io.jooby.OpenAPIModule;
+import io.jooby.annotation.GET;
+import io.jooby.annotation.Path;
+
+public class MvcDaggerApp extends Jooby {
+
+    // simulate dagger app
+    interface DaggerApp {
+        Controller controller();
+    }
+    static class DaggerAppImpl implements DaggerApp {
+
+        public Controller controller() {
+            return new Controller();
+        }
+
+    }
+
+
+    @Path("/")
+    static class Controller {
+
+        @GET("/welcome")
+        public String sayHi() {
+            return "hi";
+        }
+    }
+
+    {
+        install(new OpenAPIModule());
+        DaggerApp daggerApp = new DaggerAppImpl();
+
+        mvc(daggerApp.controller());
+    }
+}

--- a/modules/jooby-openapi/src/test/java/examples/MvcRequireApp.java
+++ b/modules/jooby-openapi/src/test/java/examples/MvcRequireApp.java
@@ -1,0 +1,24 @@
+package examples;
+
+import io.jooby.Jooby;
+import io.jooby.OpenAPIModule;
+import io.jooby.annotation.GET;
+import io.jooby.annotation.Path;
+
+public class MvcRequireApp extends Jooby {
+
+    @Path("/")
+    static class Controller {
+
+        @GET("/welcome")
+        public String sayHi() {
+            return "hi";
+        }
+    }
+
+    {
+        install(new OpenAPIModule());
+
+        mvc(require(Controller.class));
+    }
+}

--- a/modules/jooby-openapi/src/test/java/io/jooby/openapi/OpenAPIYamlTest.java
+++ b/modules/jooby-openapi/src/test/java/io/jooby/openapi/OpenAPIYamlTest.java
@@ -595,4 +595,26 @@ public class OpenAPIYamlTest {
                     + "                type: string\n",
             result.toYaml());
   }
+
+  @OpenAPITest(value = MvcRequireApp.class)
+  public void shouldParseMvcRequireController(OpenAPIResult result) {
+    assertEquals(
+            "openapi: 3.0.1\n"
+                    + "info:\n"
+                    + "  title: MvcRequire API\n"
+                    + "  description: MvcRequire API description\n"
+                    + "  version: \"1.0\"\n"
+                    + "paths:\n"
+                    + "  /welcome:\n"
+                    + "    get:\n"
+                    + "      operationId: sayHi\n"
+                    + "      responses:\n"
+                    + "        \"200\":\n"
+                    + "          description: Success\n"
+                    + "          content:\n"
+                    + "            application/json:\n"
+                    + "              schema:\n"
+                    + "                type: string\n",
+            result.toYaml());
+  }
 }

--- a/modules/jooby-openapi/src/test/java/io/jooby/openapi/OpenAPIYamlTest.java
+++ b/modules/jooby-openapi/src/test/java/io/jooby/openapi/OpenAPIYamlTest.java
@@ -5,13 +5,10 @@
  */
 package io.jooby.openapi;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import examples.FilterApp;
-import examples.FormApp;
-import examples.FormMvcApp;
-import examples.MinApp;
+import examples.*;
 import kt.KtMinApp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OpenAPIYamlTest {
 
@@ -575,5 +572,27 @@ public class OpenAPIYamlTest {
             + "              schema:\n"
             + "                type: string\n",
         result.toYaml());
+  }
+
+  @OpenAPITest(value = MvcDaggerApp.class)
+  public void shouldParseDaggerController(OpenAPIResult result) {
+    assertEquals(
+            "openapi: 3.0.1\n"
+                    + "info:\n"
+                    + "  title: MvcDagger API\n"
+                    + "  description: MvcDagger API description\n"
+                    + "  version: \"1.0\"\n"
+                    + "paths:\n"
+                    + "  /welcome:\n"
+                    + "    get:\n"
+                    + "      operationId: sayHi\n"
+                    + "      responses:\n"
+                    + "        \"200\":\n"
+                    + "          description: Success\n"
+                    + "          content:\n"
+                    + "            application/json:\n"
+                    + "              schema:\n"
+                    + "                type: string\n",
+            result.toYaml());
   }
 }

--- a/modules/jooby-openapi/src/test/java/issues/i3397/Issue3397.java
+++ b/modules/jooby-openapi/src/test/java/issues/i3397/Issue3397.java
@@ -9,7 +9,6 @@ public class Issue3397 {
 
   @OpenAPITest(value = App3397.class)
   public void shouldParseAvajeBeanScopeControllers(OpenAPIResult result) {
-   var s = result.toYaml();
     assertEquals(
         "openapi: 3.0.1\n"
             + "info:\n"


### PR DESCRIPTION
@jknack    
My previous PR https://github.com/jooby-project/jooby/pull/3398 about Avaje BeanScope controllers parsing in openapi broke the dagger controllers parsing. My apologies, here is the fix