### PR TITLE
Fixes case insensitive headerMap

### DIFF
--- a/jooby/src/main/java/io/jooby/Context.java
+++ b/jooby/src/main/java/io/jooby/Context.java
@@ -397,7 +397,7 @@ public interface Context extends Registry {
   /**
    * Header as single-value map.
    *
-   * @return Header as single-value map.
+   * @return Header as single-value map, with case insensitive keys.
    */
   @NonNull Map<String, String> headerMap();
 

--- a/jooby/src/main/java/io/jooby/DefaultContext.java
+++ b/jooby/src/main/java/io/jooby/DefaultContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -221,7 +222,10 @@ public interface DefaultContext extends Context {
 
   @Override
   @NonNull default Map<String, String> headerMap() {
-    return header().toMap();
+    final var header = header();
+    Map<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    header.toMultimap().forEach((k, v) -> map.put(k, v.get(0)));
+    return map;
   }
 
   @Override

--- a/tests/src/test/java/io/jooby/test/Issue2357.java
+++ b/tests/src/test/java/io/jooby/test/Issue2357.java
@@ -26,6 +26,9 @@ class Issue2357 {
                       Assertions.assertEquals("value1", ctx.header("x-header1").value());
                       Assertions.assertEquals("value1", ctx.header("X-HEADER1").value());
                       Assertions.assertEquals("value1", ctx.header("X-hEaDeR1").value());
+                      Assertions.assertEquals("value1", ctx.headerMap().get("x-header1"));
+                      Assertions.assertEquals("value1", ctx.headerMap().get("X-HEADER1"));
+                      Assertions.assertEquals("value1", ctx.headerMap().get("X-hEaDeR1"));
                       return "OK";
                     }))
         .ready(


### PR DESCRIPTION
Makes map returned by headerMap consistent with header() method.