### PR TITLE
Fixes case insensitive headerMap and header toMultimap

### DIFF
--- a/jooby/src/main/java/io/jooby/Context.java
+++ b/jooby/src/main/java/io/jooby/Context.java
@@ -397,7 +397,7 @@ public interface Context extends Registry {
   /**
    * Header as single-value map.
    *
-   * @return Header as single-value map.
+   * @return Header as single-value map, with case insensitive keys.
    */
   @NonNull Map<String, String> headerMap();
 

--- a/jooby/src/main/java/io/jooby/Value.java
+++ b/jooby/src/main/java/io/jooby/Value.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -25,6 +24,7 @@ import io.jooby.exception.MissingValueException;
 import io.jooby.exception.TypeMismatchException;
 import io.jooby.internal.ArrayValue;
 import io.jooby.internal.HashValue;
+import io.jooby.internal.HeadersValue;
 import io.jooby.internal.MissingValue;
 import io.jooby.internal.MultipartNode;
 import io.jooby.internal.SingleValue;
@@ -545,7 +545,7 @@ public interface Value {
    * @return A hash/object value.
    */
   static @NonNull ValueNode headers(Context ctx, @NonNull Map<String, Collection<String>> values) {
-    HashValue node = new HashValue(ctx, null, () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+    HeadersValue node = new HeadersValue(ctx);
     node.put(values);
     return node;
   }

--- a/jooby/src/main/java/io/jooby/internal/HashValue.java
+++ b/jooby/src/main/java/io/jooby/internal/HashValue.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -29,17 +28,11 @@ import io.jooby.FileUpload;
 import io.jooby.ValueNode;
 
 public class HashValue implements ValueNode {
-  private static final Map<String, ValueNode> EMPTY = Collections.emptyMap();
+  protected static final Map<String, ValueNode> EMPTY = Collections.emptyMap();
   private Context ctx;
-  private Map<String, ValueNode> hash = EMPTY;
+  protected Map<String, ValueNode> hash = EMPTY;
   private final String name;
   private boolean arrayLike;
-
-  public HashValue(Context ctx, String name, Supplier<Map<String, ValueNode>> mapSupplier) {
-    this.ctx = ctx;
-    this.name = name;
-    this.hash = mapSupplier.get();
-  }
 
   public HashValue(Context ctx, String name) {
     this.ctx = ctx;
@@ -164,7 +157,7 @@ public class HashValue implements ValueNode {
     return true;
   }
 
-  private Map<String, ValueNode> hash() {
+  protected Map<String, ValueNode> hash() {
     if (hash == EMPTY) {
       hash = new LinkedHashMap<>();
     }

--- a/jooby/src/main/java/io/jooby/internal/HeadersValue.java
+++ b/jooby/src/main/java/io/jooby/internal/HeadersValue.java
@@ -1,0 +1,44 @@
+package io.jooby.internal;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jooby.Context;
+import io.jooby.ValueNode;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+public class HeadersValue extends HashValue implements ValueNode {
+
+	public HeadersValue(final Context ctx) {
+		super(ctx);
+	}
+
+	@Override
+	protected Map<String, ValueNode> hash() {
+		if (hash == EMPTY) {
+			hash = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		}
+		return hash;
+	}
+
+	@NonNull
+	@Override
+	public Map<String, String> toMap() {
+		Map<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		toMultimap().forEach((k, v) -> map.put(k, v.get(0)));
+		return map;
+	}
+
+	@NonNull
+	@Override
+	public Map<String, List<String>> toMultimap() {
+		Map<String, List<String>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		Set<Map.Entry<String, ValueNode>> entries = hash.entrySet();
+		for (Map.Entry<String, ValueNode> entry : entries) {
+			ValueNode value = entry.getValue();
+			result.putAll(value.toMultimap());
+		}
+		return result;
+	}
+}

--- a/tests/src/test/java/io/jooby/test/Issue2357.java
+++ b/tests/src/test/java/io/jooby/test/Issue2357.java
@@ -26,6 +26,12 @@ class Issue2357 {
                       Assertions.assertEquals("value1", ctx.header("x-header1").value());
                       Assertions.assertEquals("value1", ctx.header("X-HEADER1").value());
                       Assertions.assertEquals("value1", ctx.header("X-hEaDeR1").value());
+                      Assertions.assertEquals("value1", ctx.headerMap().get("x-header1"));
+                      Assertions.assertEquals("value1", ctx.headerMap().get("X-HEADER1"));
+                      Assertions.assertEquals("value1", ctx.headerMap().get("X-hEaDeR1"));
+                      Assertions.assertEquals("value1", ctx.header().toMultimap().get("x-header1").get(0));
+                      Assertions.assertEquals("value1", ctx.header().toMultimap().get("X-HEADER1").get(0));
+                      Assertions.assertEquals("value1", ctx.header().toMultimap().get("X-hEaDeR1").get(0));
                       return "OK";
                     }))
         .ready(


### PR DESCRIPTION
Makes all ways to work with headers consistent and comply with the HTTP Headers RFC.

Continues from #2358 
Replaces #3517 