### PR TITLE
problem details in modules

### DIFF
--- a/docs/asciidoc/modules/avaje-validator.adoc
+++ b/docs/asciidoc/modules/avaje-validator.adoc
@@ -167,13 +167,6 @@ import io.jooby.validation.BeanValidator
 }
 ----
 
-[IMPORTANT]
-====
-Please note, if you are mixing both approaches (MVC/scripts), it's better to avoid using a filter,
-as it may lead to double validation on MVC routes. In this case,
-it's recommended to use the handler version (see below).
-====
-
 `BeanValidator.validate()` behaves identically to validation in MVC routes.
 It also supports validating list, array, and map of beans.
 
@@ -222,6 +215,12 @@ catches `ConstraintViolationException` and transforms it into the following resp
   ]
 }
 ----
+
+[NOTE]
+====
+`AvajeValidatorModule` is compliant with `ProblemDetails`. Therefore, if you enable 
+the Problem Details feature, the response above will be transformed into an `RFC 7807` compliant format
+====
 
 It is possible to override the `title` and `status` code of the response above:
 

--- a/docs/asciidoc/modules/hibernate-validator.adoc
+++ b/docs/asciidoc/modules/hibernate-validator.adoc
@@ -130,13 +130,6 @@ import io.jooby.validation.BeanValidator
 }
 ----
 
-[IMPORTANT]
-====
-Please note, if you are mixing both approaches (MVC/scripts), it's better to avoid using a filter,
-as it may lead to double validation on MVC routes. In this case,
-it's recommended to use the handler version (see below).
-====
-
 `BeanValidator.validate()` behaves identically to validation in MVC routes.
 It also supports validating list, array, and map of beans
 
@@ -185,6 +178,12 @@ catches `ConstraintViolationException` and transforms it into the following resp
   ]
 }
 ----
+
+[NOTE]
+====
+`HibernateValidatorModule` is compliant with `ProblemDetails`. Therefore, if you enable the Problem Details feature, 
+the response above will be transformed into an `RFC 7807` compliant format
+====
 
 It is possible to override the `title` and `status` code of the response above:
 

--- a/docs/asciidoc/problem-details.adoc
+++ b/docs/asciidoc/problem-details.adoc
@@ -10,51 +10,43 @@ Thankfully, there’s a standard called https://www.rfc-editor.org/rfc/rfc7807[I
 By adopting `RFC 7807`, API designers don’t have to spend time creating a custom solution, and users benefit by recognizing a familiar format across different APIs.
 If it suits the API’s needs, using this standard benefits both designers and users alike.
 
-`Jooby` provides built-in support for `Problem Details`. There are two main entities to work with:
+`Jooby` provides built-in support for `Problem Details`.
 
-1. `HttpProblem` - representation of the `RFC 7807` model and the way to instantiate the problem.
+=== Set up ProblemDetails
 
-2. `ProblemDetailsHandler` - global error handler that catches all exceptions, transforms them into `Problem Details` compliant format and renders the response based on the `Accept` header value.
-It also sets the appropriate content-type in response (e.g. application/problem+json, application/problem+xml)
+To enable the `ProblemDetails`, simply add the following line to your configuration:
 
-=== Set up handler
-
-The bare minimal requirement is to set up an error handler:
-
-.Java
-[source,java,role="primary"]
+.application.conf
+[source, properties]
 ----
-import io.jooby.problem.ProblemDetailsHandler;
+problem.details.enabled = true
+----
 
-{
-  ...  
-  error(new ProblemDetailsHandler()          // <1>
-    .log4xxErrors()                          // <2>
-    .mute(StatusCode.UNAUTHORIZED)           // <3>
-  );
+This is the bare minimal configuration you need.
+It enables a global error handler that catches all exceptions, transforms them into Problem Details compliant format and renders the response based on the Accept header value. It also sets the appropriate content-type in response (e.g. application/problem+json, application/problem+xml)
+
+All supported settings include:
+
+.application.conf
+[source, properties]
+----
+problem.details {
+  enabled = true
+  log4xxErrors = true                                // <1>
+  muteCodes = [401, 403]                             // <2>
+  muteTypes = ["com.example.MyMutedException"]       // <3>
 }
 ----
 
-.Kotlin
-[source,kt,role="secondary"]
-----
-import io.jooby.problem.ProblemDetailsHandler
 
-{
-  ...  
-  error(new ProblemDetailsHandler()          // <1>
-    .log4xxErrors()                          // <2>
-    .mute(StatusCode.UNAUTHORIZED)           // <3>
-  )
-}
-----
+<1> By default, only server errors (5xx) will be logged. You can optionally enable the logging of client errors (4xx). If `DEBUG` logging level is enabled, the log will contain a stacktrace as well.
+<2> You can optionally mute some status codes completely.
+<3> You can optionally mute some exceptions logging completely.
 
-<1> Enable `Problem Details` handler.
-Keep in mind, order matters (WYSIWYG), so if you have some specific exception handlers, they should be placed above this line.
-<2> By default, only server errors (5xx) will be logged. You can optionally enable the logging of client errors (4xx). If `DEBUG` logging level is enabled, the log will contain a stacktrace as well.
-<3> You can optionally mute some status codes or exceptions logging completely.
 
 === Creating problems
+
+`HttpProblem` class represents the `RFC 7807` model. It is the main entity you need to work with to produce the problem.
 
 ==== Static helpers
 
@@ -70,6 +62,8 @@ Don't overuse it, the problem should have meaningful `title` and `detail` when p
 .Java
 [source,java,role="primary"]
 ----
+import io.jooby.problem.HttpProblem;
+
 get("/users/{userId}", ctx -> {
   var userId = ctx.path("userId").value();
   User user = userRepository.findUser(userId);
@@ -87,6 +81,8 @@ get("/users/{userId}", ctx -> {
 .Kotlin
 [source,kt,role="secondary"]
 ----
+import io.jooby.problem.HttpProblem
+
 get("/users/{userId}") { ctx ->
   val userId = ctx.path("userId").value()
   val user = userRepository.findUser(userId)
@@ -117,7 +113,7 @@ Resulting response:
 
 ==== Builder
 
-Use builder to create rich problem instance with all properties:
+Use builder to create a rich problem instance with all properties:
 
 [source,java]
 ----
@@ -190,8 +186,8 @@ It is basically another extension `errors` on a root level. Adding errors is str
 ----
 throw HttpProblem.builder()
   ...
-  .error(new HttpProblem.Error("First name cannot be blank", "#/firstName"))
-  .error(new HttpProblem.Error("Last name is required", "#/lastName"))
+  .error(new HttpProblem.Error("First name cannot be blank", "/firstName"))
+  .error(new HttpProblem.Error("Last name is required", "/lastName"))
   .build();
 ----
 
@@ -203,11 +199,11 @@ In response:
   "errors": [
     {
       "detail": "First name cannot be blank",
-      "pointer": "#/firstName"
+      "pointer": "/firstName"
     },
     {
       "detail": "Last name is required",
-      "pointer": "#/lastName"
+      "pointer": "/lastName"
     }
   ]
 }
@@ -261,8 +257,7 @@ public class OutOfStockProblem extends HttpProblem {
 
 === Custom Exception Handlers
 
-All the features described above should give you ability to rely solely on `ProblemDetailsHandler`.
-But, in case you still need custom exception handler for some reason, you still can do it:
+All the features described above should give you ability to rely solely on built-in global error handler. But, in case you still need custom exception handler for some reason, you still can do it:
 
 [source,java]
 ----
@@ -275,20 +270,16 @@ But, in case you still need custom exception handler for some reason, you still 
       
       ctx.getRouter().getErrorHandler().apply(ctx, problem, code);     // <2>
     });
-
-    // should always go below (WYSIWYG)
-    error(new ProblemDetailsHandler());                                // <3>
 }
 ----
 
 <1> Transform exception to `HttpProblem`
 <2> Propagate the problem to `ProblemDetailsHandler`. It will handle the rest.
-<3> `ProblemDetailsHandler` should always go below your custom exception handlers
 
 [IMPORTANT]
 ====
 Do not attempt to render `HttpProblem` manually, it is strongly discouraged.
 `HttpProblem` is derived from the `RuntimeException` to enable ease of `HttpProblem` throwing.
 Thus, thrown `HttpProblem` will also contain a stacktrace, if you render `HttpProblem` as is -
-it will be rendered together with stacktrace. It is  strongly advised not to expose the stacktrace to the client. Propagate the problem to `ProblemDetailsHandler` and let him take care of the rest. 
+it will be rendered together with stacktrace. It is  strongly advised not to expose the stacktrace to the client system. Propagate the problem to global error handler and let him take care of the rest. 
 ====

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -41,6 +41,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.jooby.problem.ProblemDetailsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1322,6 +1323,12 @@ public class Jooby implements Router, Registry {
     }
 
     return app;
+  }
+
+  public boolean problemDetailsEnabled() {
+    var config = getConfig();
+    return config.hasPath(ProblemDetailsHandler.ENABLE_KEY)
+           && config.getBoolean(ProblemDetailsHandler.ENABLE_KEY);
   }
 
   private static void configurePackage(Package pkg) {

--- a/jooby/src/main/java/io/jooby/Jooby.java
+++ b/jooby/src/main/java/io/jooby/Jooby.java
@@ -1325,10 +1325,15 @@ public class Jooby implements Router, Registry {
     return app;
   }
 
-  public boolean problemDetailsEnabled() {
+  /**
+   * Check if {@link ProblemDetailsHandler} is enabled as a global error handler
+   *
+   * @return boolean flag
+   */
+  public boolean problemDetailsIsEnabled() {
     var config = getConfig();
-    return config.hasPath(ProblemDetailsHandler.ENABLE_KEY)
-           && config.getBoolean(ProblemDetailsHandler.ENABLE_KEY);
+    return config.hasPath(ProblemDetailsHandler.ENABLED_KEY)
+           && config.getBoolean(ProblemDetailsHandler.ENABLED_KEY);
   }
 
   private static void configurePackage(Package pkg) {

--- a/jooby/src/main/java/io/jooby/internal/RouterImpl.java
+++ b/jooby/src/main/java/io/jooby/internal/RouterImpl.java
@@ -667,8 +667,17 @@ public class RouterImpl implements Router {
     return this;
   }
 
+  /**
+   * Define the global error handler.
+   * If ProblemDetails is enabled the {@link ProblemDetailsHandler} instantiated
+   * from configuration settings and returned. Otherwise, {@link DefaultErrorHandler} instance
+   * returned.
+   *
+   * @param app - Jooby application instance
+   * @return global error handler
+   */
   private ErrorHandler defineGlobalErrorHandler(Jooby app) {
-    if (app.problemDetailsEnabled()) {
+    if (app.problemDetailsIsEnabled()) {
       var problemDetailsConfig = app.getConfig().getConfig(ProblemDetailsHandler.ROOT_CONFIG_PATH);
       return ProblemDetailsHandler.fromConfig(problemDetailsConfig);
     } else {

--- a/jooby/src/main/java/io/jooby/problem/HttpProblem.java
+++ b/jooby/src/main/java/io/jooby/problem/HttpProblem.java
@@ -243,7 +243,7 @@ public class HttpProblem extends RuntimeException {
       return this;
     }
 
-    public Builder errors(final List<Error> errors) {
+    public Builder errors(final List<? extends Error> errors) {
       this.errors.addAll(errors);
       return this;
     }

--- a/jooby/src/main/java/io/jooby/problem/ProblemDetailsHandler.java
+++ b/jooby/src/main/java/io/jooby/problem/ProblemDetailsHandler.java
@@ -31,8 +31,12 @@ import static io.jooby.StatusCode.SERVER_ERROR_CODE;
  */
 public class ProblemDetailsHandler extends DefaultErrorHandler {
 
+  private static final String MUTE_CODES_KEY = "muteCodes";
+  private static final String MUTE_TYPES_KEY = "muteTypes";
+  private static final String LOG_4XX_ERRORS_KEY = "log4xxErrors";
+
   public static final String ROOT_CONFIG_PATH = "problem.details";
-  public static final String ENABLE_KEY = ROOT_CONFIG_PATH + ".enable";
+  public static final String ENABLED_KEY = ROOT_CONFIG_PATH + ".enabled";
 
   private boolean log4xxErrors;
 
@@ -54,7 +58,7 @@ public class ProblemDetailsHandler extends DefaultErrorHandler {
     }
 
     try {
-      HttpProblem problem = evaluateTheProblem(ctx, cause, code);
+      HttpProblem problem = evaluateTheProblem(cause, code);
 
       logProblem(ctx, problem, cause);
 
@@ -87,7 +91,7 @@ public class ProblemDetailsHandler extends DefaultErrorHandler {
     }
   }
 
-  private HttpProblem evaluateTheProblem(Context ctx, Throwable cause, StatusCode statusCode) {
+  private HttpProblem evaluateTheProblem(Throwable cause, StatusCode statusCode) {
     HttpProblem problem;
     if (cause instanceof HttpProblem httpProblem) {
       problem = httpProblem;
@@ -201,19 +205,17 @@ public class ProblemDetailsHandler extends DefaultErrorHandler {
   public static ProblemDetailsHandler fromConfig(Config config) {
     var handler = new ProblemDetailsHandler();
 
-    if(config.hasPath("log4xxErrors")) {
-      if(config.getBoolean("log4xxErrors")) {
-        handler.log4xxErrors();
-      }
+    if (config.hasPath(LOG_4XX_ERRORS_KEY) && config.getBoolean(LOG_4XX_ERRORS_KEY)) {
+      handler.log4xxErrors();
     }
 
-    if(config.hasPath("muteCodes")) {
-      config.getIntList("muteCodes")
+    if (config.hasPath(MUTE_CODES_KEY)) {
+      config.getIntList(MUTE_CODES_KEY)
           .forEach(code -> handler.mute(StatusCode.valueOf(code)));
     }
 
-    if(config.hasPath("muteTypes")) {
-      config.getStringList("muteTypes")
+    if (config.hasPath(MUTE_TYPES_KEY)) {
+      config.getStringList(MUTE_TYPES_KEY)
           .forEach(throwingConsumer(
               className -> handler.mute((Class<? extends Exception>) Class.forName(className))));
     }

--- a/jooby/src/main/java/io/jooby/validation/JsonPointer.java
+++ b/jooby/src/main/java/io/jooby/validation/JsonPointer.java
@@ -5,6 +5,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Transforms hibernate-validator (or avaje-validator) `propertyPath` into
+ * <a href="https://www.rfc-editor.org/rfc/rfc6901.html">JSON POINTER</a> format.
+ * For example:
+ * <p>"person.firstName" -> "/person/firstName"</p>
+ * <p>"persons[0].firstName" -> "/persons/0/firstName"</p>
+ *
+ * @author kliushnichenko
+ * @since 3.4.2
+ */
 public class JsonPointer {
   private static final Pattern ARRAY_PATTERN = Pattern.compile("(\\w+)\\[(\\d+)]");
 
@@ -14,7 +24,7 @@ public class JsonPointer {
 
   private static String toJsonPointer(String path) {
     if (path == null || path.isEmpty()) {
-      return "/";
+      return ""; // means the whole document
     }
 
     List<String> parts = List.of(path.split("\\."));

--- a/jooby/src/main/java/io/jooby/validation/JsonPointer.java
+++ b/jooby/src/main/java/io/jooby/validation/JsonPointer.java
@@ -1,0 +1,34 @@
+package io.jooby.validation;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class JsonPointer {
+  private static final Pattern ARRAY_PATTERN = Pattern.compile("(\\w+)\\[(\\d+)]");
+
+  public static String of(String propertyPath) {
+    return toJsonPointer(propertyPath);
+  }
+
+  private static String toJsonPointer(String path) {
+    if (path == null || path.isEmpty()) {
+      return "/";
+    }
+
+    List<String> parts = List.of(path.split("\\."));
+
+    return "/" + parts.stream()
+        .map(JsonPointer::handleArrayIndex)
+        .collect(Collectors.joining("/"));
+  }
+
+  private static String handleArrayIndex(String part) {
+    Matcher matcher = ARRAY_PATTERN.matcher(part);
+    if (matcher.matches()) {
+      return matcher.group(1) + "/" + matcher.group(2);
+    }
+    return part;
+  }
+}

--- a/jooby/src/main/java/io/jooby/validation/ValidationResult.java
+++ b/jooby/src/main/java/io/jooby/validation/ValidationResult.java
@@ -38,30 +38,17 @@ public class ValidationResult implements HttpProblemMappable {
         .build();
   }
 
-  private List<ProblemError> convertErrors() {
-    List<ProblemError> problemErrors = new LinkedList<>();
+  private List<HttpProblem.Error> convertErrors() {
+    List<HttpProblem.Error> problemErrors = new LinkedList<>();
     for (Error err : errors) {
       for (var msg : err.messages()) {
-        problemErrors.add(new ProblemError(msg, JsonPointer.of(err.field), err.type));
+        problemErrors.add(new HttpProblem.Error(msg, JsonPointer.of(err.field)));
       }
     }
     return problemErrors;
   }
 
   public record Error(String field, List<String> messages, ErrorType type) {
-  }
-
-  public static class ProblemError extends HttpProblem.Error {
-    private final ErrorType type;
-
-    public ProblemError(String detail, String pointer, ErrorType type) {
-      super(detail, pointer);
-      this.type = type;
-    }
-
-    public ErrorType getType() {
-      return type;
-    }
   }
 
   public enum ErrorType {

--- a/jooby/src/main/java/io/jooby/validation/ValidationResult.java
+++ b/jooby/src/main/java/io/jooby/validation/ValidationResult.java
@@ -5,13 +5,79 @@
  */
 package io.jooby.validation;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jooby.StatusCode;
+import io.jooby.problem.HttpProblem;
+import io.jooby.problem.HttpProblemMappable;
+
+import java.util.LinkedList;
 import java.util.List;
 
-public record ValidationResult(String title, int status, List<Error> errors) {
-  public record Error(String field, List<String> messages, ErrorType type) {}
+public class ValidationResult implements HttpProblemMappable {
+
+  private String title;
+  private int status;
+  private List<Error> errors;
+
+  public ValidationResult(){}
+
+  public ValidationResult(String title, int status, List<Error> errors) {
+    this.title = title;
+    this.status = status;
+    this.errors = errors;
+  }
+
+  @NonNull
+  @Override
+  public HttpProblem toHttpProblem() {
+    return HttpProblem.builder()
+        .title(title)
+        .status(StatusCode.valueOf(status))
+        .detail(errors.size() + " constraint violation(s) detected")
+        .errors(convertErrors())
+        .build();
+  }
+
+  private List<ProblemError> convertErrors() {
+    List<ProblemError> problemErrors = new LinkedList<>();
+    for (Error err : errors) {
+      for (var msg : err.messages()) {
+        problemErrors.add(new ProblemError(msg, JsonPointer.of(err.field), err.type));
+      }
+    }
+    return problemErrors;
+  }
+
+  public record Error(String field, List<String> messages, ErrorType type) {
+  }
+
+  public static class ProblemError extends HttpProblem.Error {
+    private final ErrorType type;
+
+    public ProblemError(String detail, String pointer, ErrorType type) {
+      super(detail, pointer);
+      this.type = type;
+    }
+
+    public ErrorType getType() {
+      return type;
+    }
+  }
 
   public enum ErrorType {
     FIELD,
     GLOBAL
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public List<Error> getErrors() {
+    return errors;
   }
 }

--- a/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/AvajeValidatorModule.java
+++ b/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/AvajeValidatorModule.java
@@ -5,12 +5,6 @@
  */
 package io.jooby.avaje.validator;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueType;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,6 +15,14 @@ import io.jooby.Extension;
 import io.jooby.Jooby;
 import io.jooby.StatusCode;
 import io.jooby.validation.BeanValidator;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Avaje Validator Module: https://jooby.io/modules/avaje-validator.
@@ -158,7 +160,9 @@ public class AvajeValidatorModule implements Extension {
     app.getServices().put(BeanValidator.class, new BeanValidatorImpl(validator));
 
     if (!disableDefaultViolationHandler) {
-      app.error(new ConstraintViolationHandler(statusCode, title, logException));
+      app.error(new ConstraintViolationHandler(
+          statusCode, title, logException, app.problemDetailsEnabled())
+      );
     }
   }
 

--- a/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/AvajeValidatorModule.java
+++ b/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/AvajeValidatorModule.java
@@ -48,6 +48,9 @@ import java.util.function.Function;
  * ConstraintViolationException} and transforms it into a {@link
  * io.jooby.validation.ValidationResult}
  *
+ * <p>When ProblemDetails is enabled {@link io.jooby.validation.ValidationResult} transformed
+ * to compliant response, see {@link io.jooby.problem.HttpProblem}
+ *
  * @author kliushnichenko
  * @author SentryMan
  * @since 3.3.1
@@ -161,7 +164,7 @@ public class AvajeValidatorModule implements Extension {
 
     if (!disableDefaultViolationHandler) {
       app.error(new ConstraintViolationHandler(
-          statusCode, title, logException, app.problemDetailsEnabled())
+          statusCode, title, logException, app.problemDetailsIsEnabled())
       );
     }
   }

--- a/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/ConstraintViolationHandler.java
+++ b/modules/jooby-avaje-validator/src/main/java/io/jooby/avaje/validator/ConstraintViolationHandler.java
@@ -5,17 +5,6 @@
  */
 package io.jooby.avaje.validator;
 
-import static io.jooby.validation.ValidationResult.ErrorType.FIELD;
-import static io.jooby.validation.ValidationResult.ErrorType.GLOBAL;
-import static java.util.stream.Collectors.groupingBy;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.avaje.validation.ConstraintViolation;
 import io.avaje.validation.ConstraintViolationException;
@@ -23,6 +12,16 @@ import io.jooby.Context;
 import io.jooby.ErrorHandler;
 import io.jooby.StatusCode;
 import io.jooby.validation.ValidationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.jooby.validation.ValidationResult.ErrorType.FIELD;
+import static io.jooby.validation.ValidationResult.ErrorType.GLOBAL;
+import static java.util.stream.Collectors.groupingBy;
 
 /**
  * Catches and transform {@link ConstraintViolationException} into {@link ValidationResult}
@@ -62,12 +61,17 @@ public class ConstraintViolationHandler implements ErrorHandler {
   private final StatusCode statusCode;
   private final String title;
   private final boolean logException;
+  private final boolean problemDetailsEnabled;
 
   public ConstraintViolationHandler(
-      @NonNull StatusCode statusCode, @NonNull String title, boolean logException) {
+      @NonNull StatusCode statusCode,
+      @NonNull String title,
+      boolean logException,
+      boolean problemDetailsEnabled) {
     this.statusCode = statusCode;
     this.title = title;
     this.logException = logException;
+    this.problemDetailsEnabled = problemDetailsEnabled;
   }
 
   @Override
@@ -82,7 +86,7 @@ public class ConstraintViolationHandler implements ErrorHandler {
       var errors = collectErrors(groupedByPath);
 
       var result = new ValidationResult(title, statusCode.value(), errors);
-      ctx.setResponseCode(statusCode).render(result);
+      renderOrPropagate(ctx, result, code);
     }
   }
 
@@ -102,5 +106,13 @@ public class ConstraintViolationHandler implements ErrorHandler {
 
   private List<String> extractMessages(List<ConstraintViolation> violations) {
     return violations.stream().map(ConstraintViolation::message).toList();
+  }
+
+  private void renderOrPropagate(Context ctx, ValidationResult result, StatusCode code) {
+    if (problemDetailsEnabled) {
+      ctx.getRouter().getErrorHandler().apply(ctx, result.toHttpProblem(), code);
+    } else {
+      ctx.setResponseCode(statusCode).render(result);
+    }
   }
 }

--- a/modules/jooby-hibernate-validator/src/main/java/io/jooby/hibernate/validator/HibernateValidatorModule.java
+++ b/modules/jooby-hibernate-validator/src/main/java/io/jooby/hibernate/validator/HibernateValidatorModule.java
@@ -9,7 +9,6 @@ import static jakarta.validation.Validation.byProvider;
 
 import java.util.function.Consumer;
 
-import io.jooby.problem.ProblemDetailsHandler;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 
@@ -44,7 +43,10 @@ import jakarta.validation.Validator;
  *
  * <p>The module also provides a built-in error handler that catches {@link
  * ConstraintViolationException} and transforms it into a {@link
- * io.jooby.validation.ValidationResult}
+ * io.jooby.validation.ValidationResult}.
+ *
+ * <p>When ProblemDetails is enabled {@link io.jooby.validation.ValidationResult} transformed
+ * to compliant response, see {@link io.jooby.problem.HttpProblem}
  *
  * @author kliushnichenko
  * @since 3.3.1
@@ -143,7 +145,7 @@ public class HibernateValidatorModule implements Extension {
         app.error(
             ConstraintViolationException.class,
             new ConstraintViolationHandler(
-                statusCode, title, logException, app.problemDetailsEnabled()
+                statusCode, title, logException, app.problemDetailsIsEnabled()
             )
         );
       }

--- a/modules/jooby-hibernate-validator/src/main/java/io/jooby/hibernate/validator/HibernateValidatorModule.java
+++ b/modules/jooby-hibernate-validator/src/main/java/io/jooby/hibernate/validator/HibernateValidatorModule.java
@@ -9,6 +9,7 @@ import static jakarta.validation.Validation.byProvider;
 
 import java.util.function.Consumer;
 
+import io.jooby.problem.ProblemDetailsHandler;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 
@@ -141,7 +142,10 @@ public class HibernateValidatorModule implements Extension {
       if (!disableDefaultViolationHandler) {
         app.error(
             ConstraintViolationException.class,
-            new ConstraintViolationHandler(statusCode, title, logException));
+            new ConstraintViolationHandler(
+                statusCode, title, logException, app.problemDetailsEnabled()
+            )
+        );
       }
     }
   }

--- a/tests/src/test/java/io/jooby/i3508/App3508.java
+++ b/tests/src/test/java/io/jooby/i3508/App3508.java
@@ -18,7 +18,7 @@ public class App3508 extends Jooby {
 
     if (withProblemDetails) {
       Config problemDetailsConfig = ConfigFactory.parseMap(
-          Map.of("problem.details.enable", true,
+          Map.of("problem.details.enabled", true,
               "problem.details.log4xxErrors", true)
       );
 

--- a/tests/src/test/java/io/jooby/i3508/App3508.java
+++ b/tests/src/test/java/io/jooby/i3508/App3508.java
@@ -5,12 +5,27 @@
  */
 package io.jooby.i3508;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import io.jooby.Extension;
 import io.jooby.Jooby;
 import io.jooby.jackson.JacksonModule;
 
+import java.util.Map;
+
 public class App3508 extends Jooby {
-  public App3508(Extension validator) {
+  public App3508(Extension validator, boolean withProblemDetails) {
+
+    if (withProblemDetails) {
+      Config problemDetailsConfig = ConfigFactory.parseMap(
+          Map.of("problem.details.enable", true,
+              "problem.details.log4xxErrors", true)
+      );
+
+      getEnvironment()
+          .setConfig(problemDetailsConfig.withFallback(getConfig()));
+    }
+
     install(new JacksonModule());
     install(validator);
 

--- a/tests/src/test/java/io/jooby/i3508/Controller3508.java
+++ b/tests/src/test/java/io/jooby/i3508/Controller3508.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import io.jooby.annotation.POST;
 import io.jooby.annotation.Path;
+import io.jooby.i3508.data.AvajeNewAccountRequest;
+import io.jooby.i3508.data.HbvNewAccountRequest;
 import io.jooby.i3508.data.NewAccountRequest;
 import io.jooby.i3508.data.Person;
 import jakarta.validation.Valid;
@@ -29,6 +31,8 @@ public class Controller3508 {
   @POST("/create-map-of-persons")
   public void createMapOfPersons(@Valid Map<String, Person> persons) {}
 
-  @POST("/create-new-account")
-  public void createNewAccount(@Valid NewAccountRequest request) {}
+  @POST("/create-new-hbv-account")
+  public void createNewAccount(@Valid HbvNewAccountRequest request) {}
+  @POST("/create-new-avaje-account")
+  public void createNewAccount(@Valid AvajeNewAccountRequest request) {}
 }

--- a/tests/src/test/java/io/jooby/i3508/Issue3508ProblemDetails.java
+++ b/tests/src/test/java/io/jooby/i3508/Issue3508ProblemDetails.java
@@ -15,6 +15,7 @@ import io.jooby.i3508.data.NewAccountRequest;
 import io.jooby.i3508.data.Person;
 import io.jooby.junit.ServerTest;
 import io.jooby.junit.ServerTestRunner;
+import io.jooby.problem.HttpProblem;
 import io.jooby.validation.ValidationResult;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -71,7 +72,7 @@ public class Issue3508ProblemDetails {
               request.setConfirmPassword("1234");
               request.setPerson(new Person(null, "Last Name"));
 
-              List<ValidationResult.ProblemError> actualErrors = spec(runner)
+              List<HttpProblem.Error> actualErrors = spec(runner)
                   .body(request)
                   .post(newAccEndpoint)
                   .then()
@@ -82,30 +83,25 @@ public class Issue3508ProblemDetails {
                   .body("detail", equalTo("5 constraint violation(s) detected"))
                   .extract()
                   .jsonPath()
-                  .getList("errors", ValidationResult.ProblemError.class);
+                  .getList("errors", HttpProblem.Error.class);
 
               var expectedErrors =
                   List.of(
-                      new ValidationResult.ProblemError(
+                      new HttpProblem.Error(
                           "Passwords should match",
-                          "/",
-                          ValidationResult.ErrorType.GLOBAL),
-                      new ValidationResult.ProblemError(
+                          ""),
+                      new HttpProblem.Error(
                           sizeLabel + " must be between 8 and 24",
-                          "/password",
-                          ValidationResult.ErrorType.FIELD),
-                      new ValidationResult.ProblemError(
+                          "/password"),
+                      new HttpProblem.Error(
                           "must not be empty",
-                          "/person/firstName",
-                          ValidationResult.ErrorType.FIELD),
-                      new ValidationResult.ProblemError(
+                          "/person/firstName"),
+                      new HttpProblem.Error(
                           sizeLabel + " must be between 8 and 24",
-                          "/confirmPassword",
-                          ValidationResult.ErrorType.FIELD),
-                      new ValidationResult.ProblemError(
+                          "/confirmPassword"),
+                      new HttpProblem.Error(
                           sizeLabel + " must be between 3 and 16",
-                          "/login",
-                          ValidationResult.ErrorType.FIELD));
+                          "/login"));
 
               Assertions.assertThat(expectedErrors)
                   .usingRecursiveComparison()

--- a/tests/src/test/java/io/jooby/i3508/Issue3508ProblemDetails.java
+++ b/tests/src/test/java/io/jooby/i3508/Issue3508ProblemDetails.java
@@ -1,0 +1,121 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.i3508;
+
+import io.jooby.Extension;
+import io.jooby.StatusCode;
+import io.jooby.avaje.validator.AvajeValidatorModule;
+import io.jooby.hibernate.validator.HibernateValidatorModule;
+import io.jooby.i3508.data.AvajeNewAccountRequest;
+import io.jooby.i3508.data.HbvNewAccountRequest;
+import io.jooby.i3508.data.NewAccountRequest;
+import io.jooby.i3508.data.Person;
+import io.jooby.junit.ServerTest;
+import io.jooby.junit.ServerTestRunner;
+import io.jooby.validation.ValidationResult;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.assertj.core.api.Assertions;
+
+import java.util.List;
+
+import static io.jooby.StatusCode.UNPROCESSABLE_ENTITY_CODE;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public class Issue3508ProblemDetails {
+  private static final StatusCode STATUS_CODE = StatusCode.UNPROCESSABLE_ENTITY;
+  public static final String DEFAULT_TITLE = "Validation failed";
+
+  protected static RequestSpecification GENERIC_SPEC = new RequestSpecBuilder()
+      .setContentType(ContentType.JSON)
+      .build();
+
+  static {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
+
+  @ServerTest
+  public void avajeValidatorTest(ServerTestRunner runner) {
+    validatorTest(
+        runner,
+        new AvajeValidatorModule().validationTitle(DEFAULT_TITLE).statusCode(STATUS_CODE),
+        new AvajeNewAccountRequest(),
+        "/create-new-avaje-account");
+  }
+
+  @ServerTest
+  public void hibernateValidatorTest(ServerTestRunner runner) {
+    validatorTest(
+        runner,
+        new HibernateValidatorModule().validationTitle(DEFAULT_TITLE)
+            .statusCode(STATUS_CODE),
+        new HbvNewAccountRequest(),
+        "/create-new-hbv-account");
+  }
+
+  private void validatorTest(
+      ServerTestRunner runner, Extension extension, NewAccountRequest request, String newAccEndpoint) {
+    var sizeLabel = extension instanceof HibernateValidatorModule ? "size" : "length";
+    runner
+        .use(() -> new App3508(extension, true))
+        .ready(
+            http -> {
+              request.setLogin("jk");
+              request.setPassword("123");
+              request.setConfirmPassword("1234");
+              request.setPerson(new Person(null, "Last Name"));
+
+              List<ValidationResult.ProblemError> actualErrors = spec(runner)
+                  .body(request)
+                  .post(newAccEndpoint)
+                  .then()
+                  .assertThat()
+                  .statusCode(UNPROCESSABLE_ENTITY_CODE)
+                  .body("title", equalTo(DEFAULT_TITLE))
+                  .body("status", equalTo(UNPROCESSABLE_ENTITY_CODE))
+                  .body("detail", equalTo("5 constraint violation(s) detected"))
+                  .extract()
+                  .jsonPath()
+                  .getList("errors", ValidationResult.ProblemError.class);
+
+              var expectedErrors =
+                  List.of(
+                      new ValidationResult.ProblemError(
+                          "Passwords should match",
+                          "/",
+                          ValidationResult.ErrorType.GLOBAL),
+                      new ValidationResult.ProblemError(
+                          sizeLabel + " must be between 8 and 24",
+                          "/password",
+                          ValidationResult.ErrorType.FIELD),
+                      new ValidationResult.ProblemError(
+                          "must not be empty",
+                          "/person/firstName",
+                          ValidationResult.ErrorType.FIELD),
+                      new ValidationResult.ProblemError(
+                          sizeLabel + " must be between 8 and 24",
+                          "/confirmPassword",
+                          ValidationResult.ErrorType.FIELD),
+                      new ValidationResult.ProblemError(
+                          sizeLabel + " must be between 3 and 16",
+                          "/login",
+                          ValidationResult.ErrorType.FIELD));
+
+              Assertions.assertThat(expectedErrors)
+                  .usingRecursiveComparison()
+                  .ignoringCollectionOrder()
+                  .isEqualTo(actualErrors);
+
+            });
+  }
+
+  private RequestSpecification spec(ServerTestRunner runner) {
+    return given().spec(GENERIC_SPEC).port(runner.getAllocatedPort());
+  }
+}

--- a/tests/src/test/java/io/jooby/problem/data/App.java
+++ b/tests/src/test/java/io/jooby/problem/data/App.java
@@ -25,7 +25,7 @@ public class App extends Jooby {
 
   {
     Config problemDetailsConfig = ConfigFactory.parseMap(
-        Map.of("problem.details.enable", true,
+        Map.of("problem.details.enabled", true,
             "problem.details.log4xxErrors", true,
             "problem.details.muteCodes", List.of(405, 406),
             "problem.details.muteTypes", List.of("io.jooby.exception.UnauthorizedException"))


### PR DESCRIPTION
While was working on problem details support in validation modules the general concept a bit changed.  
Enabling the `ProblemDetailsHandler` moved to the `hocon` configuration.

1. It greatly simplifies the integration of problem details in modules. Modules can now detect if `ProblemDetailsHandler` is enabled at an early stage of the module initiation. With the previous approach, it would have been much harder and might have led to implementing awkward solutions.

2. An additional benefit of the new approach is that `ProblemDetailsHandler` will be automatically registered as the last handler in the error handlers chain, so dev no longer need to worry about that.

So, to enable `ProblemDetailsHandler` the next config now required:
```hocon
problem.details {
  enable: true
  muteCodes: [401, 106]
  muteTypes: ['com.example.MyException']
}
```

@jknack pls share your thoughts, if you are Ok with the new approach I'll continue with docs update and some minor improvements
