### PR TITLE
fix misleading openapi application name

### DIFF
--- a/jooby/src/main/java/io/jooby/OpenAPIModule.java
+++ b/jooby/src/main/java/io/jooby/OpenAPIModule.java
@@ -180,9 +180,11 @@ public class OpenAPIModule implements Extension {
   public void install(@NonNull Jooby application) throws Exception {
     String dir = Optional.ofNullable(application.getBasePackage()).orElse("/").replace(".", "/");
 
-    String appname = application.getName().replace("Jooby", "openapi").replace("Kooby", "openapi");
+    String appName = application.getClass().getSimpleName()
+        .replace("Jooby", "openapi")
+        .replace("Kooby", "openapi");
     for (Format ext : format) {
-      String filename = String.format("/%s.%s", appname, ext.name().toLowerCase());
+      String filename = String.format("/%s.%s", appName, ext.name().toLowerCase());
       String openAPIFileLocation = Router.normalizePath(dir) + filename;
       application.assets(
           fullPath(openAPIPath, "/openapi." + ext.name().toLowerCase()), openAPIFileLocation);


### PR DESCRIPTION
closes https://github.com/jooby-project/jooby/issues/3559

my suggestion here is to simplify module logic and make it independent from `Jooby.getName()`, so it always matches the logic of `OpenApiGenerator.export()` relying on class name only.