### PR TITLE
annotation processors order note

### DIFF
--- a/docs/asciidoc/modules/avaje-inject.adoc
+++ b/docs/asciidoc/modules/avaje-inject.adoc
@@ -44,6 +44,11 @@ dependencies {
 }
 ----
 
+[NOTE]
+====
+Please note that the order of annotation processors is important. For example, if you're using `lombok` and `avaje-inject`, the correct order should be: `lombok` -> `avaje-inject` -> `jooby-apt`
+====
+
 3) Install Avaje Inject:
 
 .Installing Avaje Inject

--- a/docs/asciidoc/modules/avaje-inject.adoc
+++ b/docs/asciidoc/modules/avaje-inject.adoc
@@ -18,6 +18,8 @@
       <version>...</version>
       <configuration>
         <annotationProcessorPaths>
+          <!-- if using lombok, it must be placed before the avaje-inject-generator -->
+          <!-- avaje-inject-generator must be placed before the jooby-apt -->
           <path>
             <groupId>io.avaje</groupId>
             <artifactId>avaje-inject-generator</artifactId>

--- a/docs/asciidoc/modules/avaje-validator.adoc
+++ b/docs/asciidoc/modules/avaje-validator.adoc
@@ -47,6 +47,11 @@ dependencies {
 }
 ----
 
+[NOTE]
+====
+Please note that the order of annotation processors is important. For example, if you're using `lombok`, the correct order should be: `lombok` -> `avaje-validator`
+====
+
 3) Install
 
 .Java

--- a/docs/asciidoc/modules/avaje-validator.adoc
+++ b/docs/asciidoc/modules/avaje-validator.adoc
@@ -22,6 +22,7 @@ Bean validation via https://avaje.io/validator/[Avaje Validator].
       <version>...</version>
       <configuration>
         <annotationProcessorPaths>
+          <!-- if using lombok, it must be placed before the generator -->
           <path>
             <groupId>io.avaje</groupId>
             <artifactId>avaje-validator-generator</artifactId>

--- a/docs/asciidoc/mvc-api.adoc
+++ b/docs/asciidoc/mvc-api.adoc
@@ -939,6 +939,8 @@ on them (mostly annotations processors).
     <artifactId>maven-compiler-plugin</artifactId>
     <configuration>
       <annotationProcessorPaths>
+        <!-- if using lombok, it must be placed before the jooby-apt -->
+        <!-- if using avaje-inject, it must be placed after lombok, but before the jooby-apt -->
         <path>
           <groupId>io.jooby</groupId>
           <artifactId>jooby-apt</artifactId>

--- a/docs/asciidoc/mvc-api.adoc
+++ b/docs/asciidoc/mvc-api.adoc
@@ -982,3 +982,8 @@ tasks.withType(JavaCompile) {
     ]
 }
 ----
+
+[NOTE]
+====
+Please note that the order of annotation processors is important. For example, if you're using `lombok` and `avaje-inject`, the correct order should be: `lombok` -> `avaje-inject` -> `jooby-apt`
+====

--- a/modules/jooby-cli/src/main/resources/cli/pom.xml.hbs
+++ b/modules/jooby-cli/src/main/resources/cli/pom.xml.hbs
@@ -121,6 +121,8 @@
       {{#if apt}}
         <configuration>
           <annotationProcessorPaths>
+            <!-- if using lombok, it must be placed before the jooby-apt -->
+            <!-- if using avaje-inject, it must be placed after lombok, but before the jooby-apt -->
             <path>
               <groupId>io.jooby</groupId>
               <artifactId>jooby-apt</artifactId>


### PR DESCRIPTION
After `jooby-apt` rewrite the annotation-processors order becomes quite important. Added a note in the docs to save some brain cells for newbies.