### PR TITLE
generate test code to target/test-classes

### DIFF
--- a/modules/jooby-openapi/src/test/java/issues/Issue1582.java
+++ b/modules/jooby-openapi/src/test/java/issues/Issue1582.java
@@ -20,7 +20,7 @@ import io.jooby.openapi.OpenAPIGenerator;
 import io.swagger.v3.oas.models.info.Info;
 
 public class Issue1582 {
-  private Path outDir = Paths.get(System.getProperty("user.dir"), "target", "classes");
+  private Path outDir = Paths.get(System.getProperty("user.dir"), "target", "test-classes");
 
   @Test
   public void shouldGenerateOnOneLvelPackageLocation() throws IOException {


### PR DESCRIPTION
this will avoid publishing test code to Maven Central, as found while rebuilding releases for Reproducible Central:
https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/io/jooby/README.md

see more precisely https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/io/jooby/jooby-project-3.3.1.diffoscope