### PR TITLE
fix flyway baseline

### DIFF
--- a/modules/jooby-flyway/src/main/java/io/jooby/flyway/FlywayModule.java
+++ b/modules/jooby-flyway/src/main/java/io/jooby/flyway/FlywayModule.java
@@ -121,8 +121,10 @@ public class FlywayModule implements Extension {
         break;
       case "baseline":
         flyway.baseline();
+        break;
       case "repair":
         flyway.repair();
+        break;
       default:
         throw new IllegalArgumentException("Unknown flyway command: " + command);
     }


### PR DESCRIPTION
With configuration like: 
```
flyway.run=[baseline, migrate]
```
application will crash with message '_Unknown flyway command: baseline_' but still provide baseline to db. So we need a fix)