### PR TITLE
Fix Javadoc links on the site

### DIFF
--- a/docs/asciidoc/configuration.adoc
+++ b/docs/asciidoc/configuration.adoc
@@ -251,7 +251,7 @@ To skip/ignore Jooby loading and precedence mechanism, just instantiate and set 
 ----
 
 <1> Loads and parses configuration
-<2> Create a new environment with configuration and (http://optionally[optionally]) active names
+<2> Create a new environment with configuration and (optionally) active names
 <3> Set environment on Jooby instance
 
 IMPORTANT: Custom configuration is very flexible. You can reuse Jooby mechanism or provide your own.

--- a/docs/asciidoc/context.adoc
+++ b/docs/asciidoc/context.adoc
@@ -90,7 +90,7 @@ There are several parameter types: `header`, `cookie`, `path`, `query`, `form`, 
 `session` and `flash`. All them share a unified/type-safe API for accessing and manipulating their values.
 
 We are going to describe them briefly in the next sections, then go into specific features of the
-<<Value API>>.
+<<context-value-api,Value API>>.
 
 There is also a <<context-parameters-parameter-lookup,parameter lookup>> feature by which you can access a parameter from any combination
 of the above types with well-defined priority.
@@ -540,7 +540,7 @@ File upload are available ONLY for multipart requests.
 
 ==== Session
 
-Session parameters are available via javadoc::Context[session] or javadoc::Context[sessionOrNull]
+Session parameters are available via javadoc:Context[session] or javadoc:Context[sessionOrNull]
 methods. HTTP Session is covered in his own <<session, chapter>>, but here is a quick look:
 
 .Java
@@ -599,7 +599,7 @@ a javadoc:Session[] but the lifecycle is shorter: *data is kept for only one req
 <3> Display an existing flash attribute `success` or shows `Welcome!`
 
 Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie
-(its name defaults to `jooby.flash`) use the javadoc:Router[setFlashCookie, Cookie] method:
+(its name defaults to `jooby.flash`) use the javadoc:Router[setFlashCookie, io.jooby.Cookie] method:
 
 .Java
 [source,java,role="primary"]
@@ -626,7 +626,7 @@ Flash attributes are implemented using an `HTTP Cookie`. To customize the cookie
 ==== Parameter Lookup
 
 You can search for parameters in multiple sources with an explicitly defined priority using the
-javadoc:Context[lookup] or javadoc:Context[lookup, java.lang.String, ParamSource...] method:
+javadoc:Context[lookup] or javadoc:Context[lookup, java.lang.String, io.jooby.ParamSource...] method:
 
 .Java
 [source,java,role="primary"]

--- a/docs/asciidoc/dev-tools.adoc
+++ b/docs/asciidoc/dev-tools.adoc
@@ -143,7 +143,7 @@ joobyRun {
 <3> Source extensions. A change on these files trigger a compilation request, followed by a restart request.
 <4> Application port
 <5> How long to wait after last file change to restart. Default is: `500` milliseconds.
-<5> Use a single/fat class loader to run your application. This is required on complex project classpath where you start seeing weird reflection errors. This was the default mode in Jooby 2.x. The new model since 3.x uses a modular classloader which improves restart times and memory usage making it faster. Default is: `false`.
+<6> Use a single/fat class loader to run your application. This is required on complex project classpath where you start seeing weird reflection errors. This was the default mode in Jooby 2.x. The new model since 3.x uses a modular classloader which improves restart times and memory usage making it faster. Default is: `false`.
 
 For Maven and Gradle there are two variant `mvn jooby:testRun` and `./gradlew joobyTestRun` they work
 by expanding the classpath to uses the `test` scope or source set.

--- a/docs/asciidoc/error-handler.adoc
+++ b/docs/asciidoc/error-handler.adoc
@@ -1,7 +1,7 @@
 == Error Handler
 
 Jooby catches application exception using the javadoc:ErrorHandler[] class. The
-javadoc:ErrorHandler[DEFAULT] error handler produces simple HTML page or JSON based on the value
+javadoc:DefaultErrorHandler[] error handler produces simple HTML page or JSON based on the value
 of the `ACCEPT` header and log the exception.
 
 .HTML:
@@ -32,7 +32,7 @@ io.jooby.StatusCodeException: Not found
 	at java.lang.Thread.run(Thread.java:748)
 ----
 
-The javadoc:StatusCodeException[] works as generic exception that let you specify an status code.
+The javadoc:exception.StatusCodeException[] works as generic exception that let you specify an status code.
 
 ----
 throw new StatusCodeException(StatusCode.FORBIDDEN);

--- a/docs/asciidoc/execution-model.adoc
+++ b/docs/asciidoc/execution-model.adoc
@@ -354,7 +354,7 @@ worker executor is used when:
 
 Each web server provides a default *worker executor*:
 
-- Netty: The javadoc:netty.Netty[text=Netty server] implementation multiply the number of available processors
+- Netty: The javadoc:netty.NettyServer[text=Netty server, library=netty] implementation multiply the number of available processors
 (with a minimum of 2) by 8.
 
 ----
@@ -363,7 +363,7 @@ workerThreads = Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8
 
 For example `8` cores gives us `64` worker threads.
 
-- Undertow: The javadoc:utow.Utow[text=Undertow server] implementation multiply the number of available processors
+- Undertow: The javadoc:undertow.UndertowServer[text=Undertow server, library=undertow] implementation multiply the number of available processors
 by 8.
 
 ----
@@ -372,7 +372,7 @@ workerThreads = Runtime.getRuntime().availableProcessors() * 8
 
 For `8` cores gives us `64` worker threads.
 
-- Jetty: The javadoc:jetty.Jetty[text=Jetty server] implementation uses the default configuration
+- Jetty: The javadoc:jetty.JettyServer[text=Jetty server, library=jetty] implementation uses the default configuration
 with `200` worker threads.
 
 These are sensible defaults suggested by the server implementation. If you need to increase/decrease

--- a/docs/asciidoc/execution-model.adoc
+++ b/docs/asciidoc/execution-model.adoc
@@ -354,7 +354,7 @@ worker executor is used when:
 
 Each web server provides a default *worker executor*:
 
-- Netty: The javadoc:netty.NettyServer[text=Netty server, library=netty] implementation multiply the number of available processors
+- Netty: The javadoc:netty.NettyServer[text=Netty server, artifact=jooby-netty] implementation multiply the number of available processors
 (with a minimum of 2) by 8.
 
 ----
@@ -363,7 +363,7 @@ workerThreads = Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8
 
 For example `8` cores gives us `64` worker threads.
 
-- Undertow: The javadoc:undertow.UndertowServer[text=Undertow server, library=undertow] implementation multiply the number of available processors
+- Undertow: The javadoc:undertow.UndertowServer[text=Undertow server, artifact=jooby-undertow] implementation multiply the number of available processors
 by 8.
 
 ----
@@ -372,7 +372,7 @@ workerThreads = Runtime.getRuntime().availableProcessors() * 8
 
 For `8` cores gives us `64` worker threads.
 
-- Jetty: The javadoc:jetty.JettyServer[text=Jetty server, library=jetty] implementation uses the default configuration
+- Jetty: The javadoc:jetty.JettyServer[text=Jetty server, artifact=jooby-jetty] implementation uses the default configuration
 with `200` worker threads.
 
 These are sensible defaults suggested by the server implementation. If you need to increase/decrease

--- a/docs/asciidoc/handlers/access-log.adoc
+++ b/docs/asciidoc/handlers/access-log.adoc
@@ -1,12 +1,12 @@
 === AccessLogHandler
 
-The javadoc:AccessLogHandler[] logs incoming requests using the https://en.wikipedia.org/wiki/Common_Log_Format[NCSA format] (a.k.a common log format).
+The javadoc:handler.AccessLogHandler[] logs incoming requests using the https://en.wikipedia.org/wiki/Common_Log_Format[NCSA format] (a.k.a common log format).
 
 .Usage
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.AccessLogHandler;
+import io.jooby.handler.AccessLogHandler;
 ...
 {
   
@@ -21,7 +21,7 @@ import io.jooby.AccessLogHandler;
 .Kotlin
 [source, kotlin, role = "secondary"]
 ----
-import io.jooby.AccessLogHandler
+import io.jooby.handler.AccessLogHandler
 ...
 {
   use(AccessLogHandler())      <1>
@@ -50,8 +50,8 @@ Message is represented by:
 
 Extra request or response headers can be appended at the end using the available methods:
 
-- javadoc:AccessLogHandler[requestHeader, java.lang.String...]
-- javadoc:AccessLogHandler[responseHeader, java.lang.String...]
+- javadoc:handler.AccessLogHandler[requestHeader, java.lang.String...]
+- javadoc:handler.AccessLogHandler[responseHeader, java.lang.String...]
 
 [TIP]
 ====

--- a/docs/asciidoc/handlers/cors.adoc
+++ b/docs/asciidoc/handlers/cors.adoc
@@ -7,13 +7,13 @@ request when it requests a resource that has a different origin (domain, protoco
 its own origin.
 
 Jooby supports CORS out of the box. By default, **CORS requests will be rejected**.
-To enable processing of CORS requests, use the javadoc:CorsHandler[]:
+To enable processing of CORS requests, use the javadoc:handler.CorsHandler[]:
 
 .CorsExample
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.CorsHandler;
+import io.jooby.handler.CorsHandler;
 ...
 {
   
@@ -28,7 +28,7 @@ import io.jooby.CorsHandler;
 .Kotlin
 [source, kotlin, role = "secondary"]
 ----
-import io.jooby.CorsHandler
+import io.jooby.handler.CorsHandler
 ...
 {
   use(CorsHandler())      <1>
@@ -49,13 +49,14 @@ Default options are:
 - allowed headers: `X-Requested-With`, `Content-Type`, `Accept` and `Origin`
 - max age: `30m`;
 
-To customize default options use javadoc:Cors[]:
+To customize default options use javadoc:handler.Cors[]:
 
 .Cors options
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.CorsHandler;
+import io.jooby.handler.Cors;
+import io.jooby.handler.CorsHandler;
 ...
 {
   Cors cors = new Cors()
@@ -73,7 +74,7 @@ import io.jooby.CorsHandler;
 [source, kotlin, role = "secondary"]
 ----
 import io.jooby.Jooby
-import io.jooby.CorsHandler
+import io.jooby.handler.CorsHandler
 import io.jooby.cors
 ...
 {
@@ -110,7 +111,8 @@ cors {
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.CorsHandler;
+import io.jooby.handler.Cors;
+import io.jooby.handler.CorsHandler;
 ...
 {
   Cors cors = Cors.from(getConfig());  <1>
@@ -127,7 +129,7 @@ import io.jooby.CorsHandler;
 [source, kotlin, role = "secondary"]
 ----
 import io.jooby.Jooby
-import io.jooby.CorsHandler
+import io.jooby.handler.CorsHandler
 ...
 {
   val cors = Cors.from(config)         <1>

--- a/docs/asciidoc/handlers/csrf.adoc
+++ b/docs/asciidoc/handlers/csrf.adoc
@@ -1,6 +1,6 @@
 === CsrfHandler
 
-The javadoc:CsrfHandler[text="Cross Site Request Forgery Handler"] helps to protect from (CSRF) 
+The javadoc:handler.CsrfHandler[text="Cross Site Request Forgery Handler"] helps to protect from (CSRF) 
 attacks. Cross-site request forgeries are a type of malicious exploit whereby unauthorized commands
 are performed on behalf of an authenticated user.
 
@@ -20,10 +20,10 @@ field in the form so that the CSRF protection middleware can validate the reques
 </form>
 ----
 
-The `csrf` is a request attribute created by the javadoc:CsrfHandler[] handler and rendered by a
+The `csrf` is a request attribute created by the javadoc:handler.CsrfHandler[] handler and rendered by a
 template engine. Here `{{csrf}}` we use Handlebars template engine (as example).
 
-The javadoc:CsrfHandler[] handler, will automatically verify that the token in the request input 
+The javadoc:handler.CsrfHandler[] handler, will automatically verify that the token in the request input 
 matches the token stored in the session.
 
 The token defaults name is `csrf` and can be provided as:
@@ -34,5 +34,5 @@ The token defaults name is `csrf` and can be provided as:
 
 Configuration methods:
 
-- javadoc:CsrfHandler["setTokenGenerator", java.util.Function]: Set a custom token generator. Defaults uses a random UUID.
-- javadoc:CsrfHandler["setRequestFilter", java.util.Predicate]: Set a custom request filter. Defaults is to process `POST`, `PUT`, `PATCH` and `DELETE`.
+- javadoc:handler.CsrfHandler["setTokenGenerator", java.util.function.Function]: Set a custom token generator. Defaults uses a random UUID.
+- javadoc:handler.CsrfHandler["setRequestFilter", java.util.function.Predicate]: Set a custom request filter. Defaults is to process `POST`, `PUT`, `PATCH` and `DELETE`.

--- a/docs/asciidoc/handlers/head.adoc
+++ b/docs/asciidoc/handlers/head.adoc
@@ -5,13 +5,13 @@ Jooby doesn't support `HTTP HEAD` requests by default. To support them you have 
 - Use the built-in `HeadHandler`
 - Write your own head handler
 
-The javadoc:HeadHandler[] supports `HEAD` requests over existing `GET` handlers.
+The javadoc:handler.HeadHandler[] supports `HEAD` requests over existing `GET` handlers.
 
 .Head Example
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.HeadHandler;
+import io.jooby.handler.HeadHandler;
 ...
 {
   

--- a/docs/asciidoc/handlers/ssl.adoc
+++ b/docs/asciidoc/handlers/ssl.adoc
@@ -85,9 +85,8 @@ import io.jooby.handler.SSHandler
 
 For more information about SSL, please check the <<server-https-support, configure SSL>> section.
 
-// code review comment, this referenced doc doesn't exist
 [TIP]
 ====
 If you run behind a reverse proxy that has been configured to send the X-Forwarded-* header,
-please consider to add the link:proxy-peer-address.adoc[] to your pipeline.
+please consider to add the <<router-options-trust-proxy, trust proxy>> to your pipeline.
 ====

--- a/docs/asciidoc/handlers/ssl.adoc
+++ b/docs/asciidoc/handlers/ssl.adoc
@@ -1,12 +1,12 @@
 === SSLHandler
 
-The javadoc:SSLHandler[] forces client to use HTTPS by redirecting non-HTTPS calls to the HTTPS version.
+The javadoc:handler.SSLHandler[] forces client to use HTTPS by redirecting non-HTTPS calls to the HTTPS version.
 
 .Force SSL
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.SSLHandler;
+import io.jooby.handler.SSLHandler;
 ...
 {
   
@@ -24,7 +24,7 @@ import io.jooby.SSLHandler;
 [source, kotlin, role = "secondary"]
 ----
 import io.jooby.Jooby
-import io.jooby.SSHandler
+import io.jooby.handler.SSHandler
 ...
 {
   serverOptions {
@@ -42,7 +42,7 @@ import io.jooby.SSHandler
 <1> Install SSLHandler
 
 The SSL Handler recreates the HTTPs URL version using the `Host` header, if you are behind a proxy
-you will need to use the `X-Forwarded-Host` header. To do that set the <<router-trust-proxy, trust proxy>> option.
+you will need to use the `X-Forwarded-Host` header. To do that set the <<router-options-trust-proxy, trust proxy>> option.
 
 Optionally, you can specify the host to use:
 
@@ -50,7 +50,7 @@ Optionally, you can specify the host to use:
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.SSLHandler;
+import io.jooby.handler.SSLHandler;
 ...
 {
   
@@ -68,7 +68,7 @@ import io.jooby.SSLHandler;
 [source, kotlin, role = "secondary"]
 ----
 import io.jooby.Jooby
-import io.jooby.SSHandler
+import io.jooby.handler.SSHandler
 ...
 {
   serverOptions {
@@ -85,6 +85,7 @@ import io.jooby.SSHandler
 
 For more information about SSL, please check the <<server-https-support, configure SSL>> section.
 
+// code review comment, this referenced doc doesn't exist
 [TIP]
 ====
 If you run behind a reverse proxy that has been configured to send the X-Forwarded-* header,

--- a/docs/asciidoc/handlers/trace.adoc
+++ b/docs/asciidoc/handlers/trace.adoc
@@ -5,13 +5,13 @@ Jooby doesn't support `HTTP Trace` requests by default. To support them you have
 - Use the built-in `TraceHandler`
 - Write your own trace handler
 
-The javadoc:TraceHandler[] supports `TRACE` requests over existing handlers.
+The javadoc:handler.TraceHandler[] supports `TRACE` requests over existing handlers.
 
 .Head Example
 [source, java, role = "primary"]
 ----
 import io.jooby.Jooby;
-import io.jooby.TraceHandler;
+import io.jooby.handler.TraceHandler;
 ...
 {
   
@@ -27,7 +27,7 @@ import io.jooby.TraceHandler;
 [source, kotlin, role = "secondary"]
 ----
 import io.jooby.Jooby
-import io.jooby.TraceHandler
+import io.jooby.handler.TraceHandler
 ...
 {
   use(TraceHandler())      <1>

--- a/docs/asciidoc/modules/camel.adoc
+++ b/docs/asciidoc/modules/camel.adoc
@@ -158,7 +158,7 @@ class MyRoutes: RouteBuilder() {
 
 [IMPORTANT]
 ====
-  Keep in mind Camel beans are singleton by default, regardless of what dependency injection
+Keep in mind Camel beans are singleton by default, regardless of what dependency injection
 framework you choose.
 ====
 

--- a/docs/asciidoc/modules/db-scheduler.adoc
+++ b/docs/asciidoc/modules/db-scheduler.adoc
@@ -40,7 +40,7 @@ import io.jooby.dbscheduler.DbSchedulerModule
 === Tasks
 
 Tasks are created as described in https://github.com/kagkarlsson/db-scheduler[db-scheduler documentation]. Optionally,
-you can annotate a method with the javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", package="jooby.dbscheduler"] annotation:
+you can annotate a method with the javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", module="jooby.dbscheduler"] annotation:
 
 .Sample Job
 [source, java, role="primary"]
@@ -91,7 +91,7 @@ A task method must follow these rules:
 
 === Scheduled
 
-The javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", package="jooby.dbscheduler"] annotation supports simple and cron triggers as well as property references:
+The javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", module="jooby.dbscheduler"] annotation supports simple and cron triggers as well as property references:
 
 .Same as .fixedDelay(Duration) with duration.
 ----
@@ -127,7 +127,7 @@ The `mytask.trigger` must be defined in your application property file. It could
 
 === Configuration
 
-Configuration from properties files is fully supported, just need to add javadoc:dbscheduler.DbSchedulerProperties[artifact="jooby-db-scheduler", package="jooby.dbscheduler"]
+Configuration from properties files is fully supported, just need to add javadoc:dbscheduler.DbSchedulerProperties[artifact="jooby-db-scheduler", module="jooby.dbscheduler"]
 properties to your application configuration file:
 
 .Options

--- a/docs/asciidoc/modules/db-scheduler.adoc
+++ b/docs/asciidoc/modules/db-scheduler.adoc
@@ -40,7 +40,7 @@ import io.jooby.dbscheduler.DbSchedulerModule
 === Tasks
 
 Tasks are created as described in https://github.com/kagkarlsson/db-scheduler[db-scheduler documentation]. Optionally,
-you can annotate a method with the javadoc:dbscheduler.Scheduled[] annotation:
+you can annotate a method with the javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", package="jooby.dbscheduler"] annotation:
 
 .Sample Job
 [source, java, role="primary"]
@@ -91,7 +91,7 @@ A task method must follow these rules:
 
 === Scheduled
 
-The javadoc:dbscheduler.Scheduled[] annotation supports simple and cron triggers as well as property references:
+The javadoc:dbscheduler.Scheduled[artifact="jooby-db-scheduler", package="jooby.dbscheduler"] annotation supports simple and cron triggers as well as property references:
 
 .Same as .fixedDelay(Duration) with duration.
 ----
@@ -127,8 +127,8 @@ The `mytask.trigger` must be defined in your application property file. It could
 
 === Configuration
 
-Configuration from properties files is fully supported, just need to add javadoc:dbscheduler.DbSchedulerProperties[] properties to your
-application configuration file:
+Configuration from properties files is fully supported, just need to add javadoc:dbscheduler.DbSchedulerProperties[artifact="jooby-db-scheduler", package="jooby.dbscheduler"]
+properties to your application configuration file:
 
 .Options
 [source, properties]

--- a/docs/asciidoc/modules/ebean.adoc
+++ b/docs/asciidoc/modules/ebean.adoc
@@ -103,7 +103,7 @@ import io.jooby.ebean.EbeanModule
 
 === Transactional Request
 
-The javadoc:ebean.TransactionalRequest[] decorator takes care of a start/commit/rollback a
+The javadoc:ebean.TransactionalRequest[artifact=jooby-ebean] decorator takes care of a start/commit/rollback a
 transaction per HTTP request.
 
 .TransactionalRequest
@@ -294,7 +294,7 @@ Advanced/Custom configuration is supported programmatically or using property fi
 }
 ----
 
-<1> Manually creates a database config or use the one provided by Jooby: javadoc:ebean.EbeanModule[create, io.jooby.Jooby, java.lang.String].
+<1> Manually creates a database config or use the one provided by Jooby: javadoc:ebean.EbeanModule[create, io.jooby.Jooby, java.lang.String, artifact=jooby-ebean].
 <2> Install Ebean with custom database config
 
 .Configuration

--- a/docs/asciidoc/modules/graphql.adoc
+++ b/docs/asciidoc/modules/graphql.adoc
@@ -254,4 +254,5 @@ https://github.com/prisma-labs/graphql-playground[GraphQL Playground] should be 
 
 === Starter
 
+// Code review question: should this remain 2.x?
 Checkout the starter/demo project for GraphQL: https://github.com/jooby-project/jooby/tree/2.x/starters/graphql-starter[GraphQL Starter].

--- a/docs/asciidoc/modules/graphql.adoc
+++ b/docs/asciidoc/modules/graphql.adoc
@@ -251,8 +251,3 @@ import io.jooby.graphql.GraphQLPlaygroundModule
 <3> Install GraphQL Playground
 
 https://github.com/prisma-labs/graphql-playground[GraphQL Playground] should be up and running at `/graphql`.
-
-=== Starter
-
-// Code review question: should this remain 2.x?
-Checkout the starter/demo project for GraphQL: https://github.com/jooby-project/jooby/tree/2.x/starters/graphql-starter[GraphQL Starter].

--- a/docs/asciidoc/modules/hibernate.adoc
+++ b/docs/asciidoc/modules/hibernate.adoc
@@ -102,7 +102,7 @@ import io.jooby.hibernate.HibernateModule
 
 === Entity Discovering
 
-By default the javadoc:hibernate.HibernateModule[] module detects all the persistent entities under javadoc:Jooby[getBasePackage, text = "base/root package"]. The module provides two
+By default the javadoc:hibernate.HibernateModule[artifact="jooby-hibernate"] module detects all the persistent entities under javadoc:Jooby[getBasePackage, text = "base/root package"]. The module provides two
 options for more explicit control:
 
 - List persistent classes at creation time:
@@ -119,7 +119,7 @@ options for more explicit control:
 
 === Transactional Request
 
-The javadoc:hibernate.TransactionalRequest[] filter takes care of a lifecycle of an `EntityManager`/`StatelessSession` per HTTP request.
+The javadoc:hibernate.TransactionalRequest[artifact="jooby-hibernate"] filter takes care of a lifecycle of an `EntityManager`/`StatelessSession` per HTTP request.
 The filter creates, bind, begin/commit/rollback transaction and finally close it, so route handler
 doesn't have to deal with that boring lines of code.
 
@@ -232,12 +232,12 @@ the same `EntityManager`/`StatelessSession`. It is a simple way of managed simpl
 
 [NOTE]
 ====
-The javadoc:hibernate.TransactionalRequest[] doesn't extend session to the rendering phase (json, html, etc.).
+The javadoc:hibernate.TransactionalRequest[artifact="jooby-hibernate"] doesn't extend session to the rendering phase (json, html, etc.).
 The route handler needs to make sure all the information required by the rendering phase is available.
 Otherwise, you are going to see `LazyInitializationException`.
 ====
 
-There is a javadoc:hibernate.SessionRequest[] filter that works identically but leaves transaction
+There is a javadoc:hibernate.SessionRequest[artifact="jooby-hibernate"] filter that works identically but leaves transaction
 management to you, so no transaction is started/committed or rollback during a HTTP request.
 
 ==== @Transactional
@@ -460,7 +460,7 @@ Neither can it be used together with `SessionRequest` or `TransactionalRequest`:
 
 Schema creation is controlled by the `hibernate.hbm2ddl.auto` property. The Hibernate module configure this property using the following rules:
 
-- When the javadoc:flyway.FlywayModule[] module is present, the value of `hibernate.hbm2ddl.auto` is set to `none`
+- When the javadoc:flyway.FlywayModule[artifact="jooby-flyway"] module is present, the value of `hibernate.hbm2ddl.auto` is set to `none`
 - When `application.env` property is set to `dev` or `test`, the value of `hibernate.hbm2ddl.auto` is set to `update`
 - Otherwise is set to `none`
 
@@ -474,7 +474,7 @@ Advanced Hibernate configuration is supported from application configuration pro
 hibernate.hbm2ddl.auto = create
 ----
 
-Or by providing a custom javadoc:HibernateConfigurer[] instance. The javadoc:HibernateConfigurer[] 
+Or by providing a custom javadoc:hibernate.HibernateConfigurer[artifact="jooby-hibernate"] instance. The javadoc:hibernate.HibernateConfigurer[artifact="jooby-hibernate"] 
 let you hook and customize Hibernate bootstrap process:
 
 .HibernateConfigurer:
@@ -534,7 +534,7 @@ public class MyConfigurer extends HibernateConfigurer {
 }
 ----
 
-Something similar is possible for custom Session using a javadoc:hibernate.SessionProvider[]:
+Something similar is possible for custom Session using a javadoc:hibernate.SessionProvider[artifact="jooby-hibernate"]:
 
 .SessionProvider
 [source, java]

--- a/docs/asciidoc/modules/hikari.adoc
+++ b/docs/asciidoc/modules/hikari.adoc
@@ -59,7 +59,7 @@ import io.jooby.hikari.HikariModule
 
 === Database configuration
 
-By default the javadoc:hikari.Hikari[] module expects to find database properties as application
+By default the javadoc:hikari.HikariModule[text="Hikari", artifact="jooby-hikari"] module expects to find database properties as application
 configuration properties under the `db` key prefix. The next example shows how to overrides the
 database prefix:
 

--- a/docs/asciidoc/modules/jackson.adoc
+++ b/docs/asciidoc/modules/jackson.adoc
@@ -159,7 +159,7 @@ import io.jooby.json.JacksonModule
 
 === Provisioning Jackson Modules
 
-Jackson module can be provided by a link:/#dependency-injection[dependency injection] framework.
+Jackson module can be provided by a link:/#extensions-and-services-dependency-injection[dependency injection] framework.
 
 .Provisioning Modules
 [source, java, role="primary"]

--- a/docs/asciidoc/modules/jdbi.adoc
+++ b/docs/asciidoc/modules/jdbi.adoc
@@ -81,7 +81,7 @@ Handle must be explicitly closed, we did that with `try-with-resources` statemen
 
 === Transactional Request
 
-The javadoc:jdbi.TransactionalRequest[] decorator takes care of a lifecycle of a `Handle` per HTTP request.
+The javadoc:jdbi.TransactionalRequest[artifact="jooby-jdbi"] decorator takes care of a lifecycle of a `Handle` per HTTP request.
 The decorator creates, bind, begin/commit/rollback transaction and finally close it, so route handler
 doesn't have to deal with that boring lines of code.
 
@@ -254,7 +254,7 @@ import io.jooby.annotation.Transactional
 
 === SQL Objects
 
-Provisioning of custom SQL objects is available javadoc:jdbi.JdbiMdule[sqlObjects, java.lang.Class] method.
+Provisioning of custom SQL objects is available javadoc:jdbi.JdbiModule[sqlObjects, java.lang.Class..., artifact="jooby-jdbi"] method.
 
 .SQLObjects
 [source, java, role = "primary"]

--- a/docs/asciidoc/modules/jwt-session-store.adoc
+++ b/docs/asciidoc/modules/jwt-session-store.adoc
@@ -1,9 +1,9 @@
 === JWT Session
 
-The javadoc:JWTSession[] session store works it also a stateless session that
+The javadoc:jwt.JwtSessionStore[artifact="jooby-jwt"] session store works it also a stateless session that
 uses https://jwt.io[JSON Web Token] standard to decode/encode data.
 
-To use the javadoc:JWTSession[] session store you need to add the `jooby-jwt` dependency:
+To use the javadoc:jwt.JwtSessionStore[artifact="jooby-jwt"] session store you need to add the `jooby-jwt` dependency:
 
 [dependency, artifactId="jooby-jwt"]
 .

--- a/docs/asciidoc/modules/modules.adoc
+++ b/docs/asciidoc/modules/modules.adoc
@@ -32,7 +32,7 @@ Available modules are listed next.
    * link:/modules/hibernate-validator[Hibernate Validator]: Hibernate Validator module.
 
 === Development Tools
-   * link:#hot-reload[Jooby Run]: Run and hot reload your application. 
+   * link:/#development[Jooby Run]: Run and hot reload your application. 
    * link:/modules/whoops[Whoops]: Pretty page stacktrace reporter.
    * link:/modules/metrics[Metrics]: Application metrics from the excellent metrics library.
 
@@ -69,5 +69,3 @@ Available modules are listed next.
 === Scheduler
    * link:/modules/db-scheduler[DbScheduler]: Db scheduler module.
    * link:/modules/quartz[Quartz]: Quartz scheduler module.
-
-.

--- a/docs/asciidoc/modules/pac4j.adoc
+++ b/docs/asciidoc/modules/pac4j.adoc
@@ -356,7 +356,3 @@ import org.pac4j.core.config.Config
   install(Pac4jModule(pa4j))
 }
 ----
-
-=== Starter
-
-Checkout the starter/demo project for Pac4j that let you choose between multiple login clients: https://github.com/jooby-project/jooby/tree/2.x/starters/pac4j-starter[Pac4j Starter]. 

--- a/docs/asciidoc/modules/pac4j.adoc
+++ b/docs/asciidoc/modules/pac4j.adoc
@@ -326,7 +326,7 @@ This last example ask application registry (dependency injection framework usual
 
 === Advanced Usage
 
-You can customize default options by using the javadoc:pac4j.Pac4jOptions[] and/or providing your
+You can customize default options by using the javadoc:pac4j.Pac4jOptions[artifact="jooby-pac4j"] and/or providing your
 own Pac4j configuration.
 
 .Java

--- a/docs/asciidoc/modules/quartz.adoc
+++ b/docs/asciidoc/modules/quartz.adoc
@@ -66,13 +66,13 @@ class SampleJob: Job {                             <1>
 ----
 
 <1> Implements `org.quartz.Job`
-<2> Creates a trigger using the javadoc:quartz.Scheduled[] annotation
+<2> Creates a trigger using the javadoc:quartz.Scheduled[artifact="jooby-quartz"] annotation
 
 === Jobs
 
 A Job must implements `org.quartz.Job` interface or `org.quartz.InterruptableJob` as described in
 http://www.quartz-scheduler.org/documentation[Quartz documentation] or if you prefer just annotates
-an arbitrary method with the javadoc:quartz.Scheduled[] annotation:
+an arbitrary method with the javadoc:quartz.Scheduled[artifact="jooby-quartz"] annotation:
 
 .Without Job interface
 [source, java, role="primary"]
@@ -205,7 +205,7 @@ public class MyJob {
 
 === Triggers
 
-The javadoc:quartz.Scheduled[] annotation supports simple and cron triggers as well as property references:
+The javadoc:quartz.Scheduled[artifact="jooby-quartz"] annotation supports simple and cron triggers as well as property references:
 
 .Run every hour, repeat for ever:
 ----

--- a/docs/asciidoc/modules/redis.adoc
+++ b/docs/asciidoc/modules/redis.adoc
@@ -177,6 +177,6 @@ import io.lettuce.core.RedisClient
 
 More Options:
 
-- javadoc:redis.RedisSessionStore[setTimeout, java.time.Duraction]: Set session timeout. Default is: `30 minutes`
-- javadoc:redis.RedisSessionStore[setNamespace, java.lang.String]: Set key prefix. Default is: `sessions`
-- javadoc:redis.RedisSessionStore[setToken, io.jooby.SessionToken]: Set session token. Default is a cookie token: `jooby.sid`
+- javadoc:redis.RedisSessionStore[setTimeout, java.time.Duration, artifact="jooby-redis"]: Set session timeout. Default is: `30 minutes`
+- javadoc:redis.RedisSessionStore[setNamespace, java.lang.String, artifact="jooby-redis"]: Set key prefix. Default is: `sessions`
+- javadoc:redis.RedisSessionStore[setToken, io.jooby.SessionToken, artifact="jooby-redis"]: Set session token. Default is a cookie token: `jooby.sid`

--- a/docs/asciidoc/modules/thymeleaf.adoc
+++ b/docs/asciidoc/modules/thymeleaf.adoc
@@ -103,5 +103,5 @@ import io.jooby.thymeleaf.ThymeleafModule
 
 [TIP]
 ====
-There is a builder function to create a `TemplateEngine`: javadoc:thymeleaf.ThymeleafModule[create].
+There is a builder function to create a `TemplateEngine`: javadoc:thymeleaf.ThymeleafModule[create, artifact="jooby-thymeleaf"].
 ====

--- a/docs/asciidoc/mvc-api.adoc
+++ b/docs/asciidoc/mvc-api.adoc
@@ -672,7 +672,7 @@ details please checkout the <<responses-nonblocking, non-blocking responses>> se
 
 === Execution model
 
-The MVC routes follows the execution model described in <<Execution Model>>. To run application
+The MVC routes follows the execution model described in <<execution-model, Execution Model>>. To run application
 logic in the javadoc:ExecutionMode[EVENT_LOOP]:
 
 .EventLoop MVC route

--- a/docs/asciidoc/responses.adoc
+++ b/docs/asciidoc/responses.adoc
@@ -672,7 +672,7 @@ suspend fun Context.doSomething(): String {
 A coroutine works like any of the other non-blocking types. You start Jooby using the **event loop**
 or **default mode**, Jooby creates a coroutine context to execute it.
 
-Jooby uses the *worker executor* to creates a coroutine context. As described in <<worker-executor, worker executor section>>
+Jooby uses the *worker executor* to creates a coroutine context. As described in <<execution-model-worker-executor, worker executor section>>
 this is provided by the web server implementation unless you provided your own.
 
 .Coroutines with custom executor:
@@ -695,7 +695,7 @@ this is provided by the web server implementation unless you provided your own.
 <2> Call a suspending function
 <3> Produces a response
 
-Coroutines always run in the <<worker-executor, worker executor>>. There is an experimental API where
+Coroutines always run in the <<execution-model-worker-executor, worker executor>>. There is an experimental API where
 coroutines run in the *caller thread*(event loop in this case) until a suspending function is found.
 
 Jooby allows you to use this experimental API by setting the `coroutineStart` option:
@@ -773,10 +773,10 @@ Family of send methods include:
 
 - javadoc:Context[send, byte[\]]
 - javadoc:Route[consumes, io.jooby.MediaType...]
-- javadoc:Context[send, java.nio.Buffer]
+// Code review comment: is this supposed to be jooby databuffer or nio bytebuffer
+- javadoc:Context[send, java.nio.ByteBuffer]
 - javadoc:Context[send, java.lang.String]
 - javadoc:Context[send, java.nio.file.Path]
-- javadoc:Context[send, java.io.File]
 - javadoc:Context[send, java.nio.channels.FileChannel]
 - javadoc:Context[send, io.jooby.FileDownload]
 - javadoc:Context[send, io.jooby.StatusCode]

--- a/docs/asciidoc/responses.adoc
+++ b/docs/asciidoc/responses.adoc
@@ -772,11 +772,15 @@ side effects ignoring the output of the route handler.
 Family of send methods include:
 
 - javadoc:Context[send, byte[\]]
-- javadoc:Route[consumes, io.jooby.MediaType...]
-// Code review comment: is this supposed to be jooby databuffer or nio bytebuffer
-- javadoc:Context[send, java.nio.ByteBuffer]
-- javadoc:Context[send, java.lang.String]
-- javadoc:Context[send, java.nio.file.Path]
-- javadoc:Context[send, java.nio.channels.FileChannel]
+- javadoc:Context[send, byte[\]...]
+- javadoc:Context[send, io.jooby.buffer.DataBuffer]
 - javadoc:Context[send, io.jooby.FileDownload]
 - javadoc:Context[send, io.jooby.StatusCode]
+- javadoc:Context[send, java.io.InputStream]
+- javadoc:Context[send, java.lang.String]
+- javadoc:Context[send, java.lang.String, java.nio.charset.Charset]
+- javadoc:Context[send, java.nio.ByteBuffer]
+- javadoc:Context[send, java.nio.ByteBuffer[\]]
+- javadoc:Context[send, java.nio.channels.FileChannel]
+- javadoc:Context[send, java.nio.channels.ReadableByteChannel]
+- javadoc:Context[send, java.nio.file.Path]

--- a/docs/asciidoc/routing.adoc
+++ b/docs/asciidoc/routing.adoc
@@ -980,7 +980,7 @@ Output:
 
 ==== Scoped Filter
 
-The javadoc:Router[route, java.lang.Runnable] and javadoc:Router[path, java.lang.String, java.lang.Runnable] operators
+The javadoc:Router[routes, java.lang.Runnable] and javadoc:Router[path, java.lang.String, java.lang.Runnable] operators
 are used to group one or more routes.
   
 A `scoped filter` looks like:
@@ -1035,7 +1035,7 @@ A `scoped filter` looks like:
 
 Output:
 
-<1> Introduce a new scope via `route` operator
+<1> Introduce a new scope via `routes` operator
 <2> `/4`  => `9`
 <3> `/1`  => `2`
 
@@ -1043,7 +1043,7 @@ It is a normal `filter` inside of one of the group operators.
 
 === Grouping routes
 
-As showed previously, the javadoc:Router[route, java.lang.Runnable] operator push a new route `scope`
+As showed previously, the javadoc:Router[routes, java.lang.Runnable] operator push a new route `scope`
 and allows you to selectively apply one or more routes.
 
 .Route operator
@@ -1222,7 +1222,7 @@ is responsible for assembly all the resources and services required by imported 
 ==== Install
 
 Alternatively, you can install a standalone application into another one using the
-javadoc:Jooby[install, io.jooby.Jooby] operator:
+javadoc:Jooby[install, io.jooby.SneakyThrows.Supplier] operator:
 
 .Installing
 [source, java, role="primary"]

--- a/docs/asciidoc/servers.adoc
+++ b/docs/asciidoc/servers.adoc
@@ -2,9 +2,9 @@
 
 There are three server implementations:
 
-- javadoc:JettyServer[]
-- javadoc:NettyServer[]
-- javadoc:UndertowServer[]
+- javadoc:jetty.JettyServer[artifact=jooby-jetty]
+- javadoc:netty.NettyServer[artifact=jooby-netty]
+- javadoc:undertow.UndertowServer[artifact=jooby-undertow]
 
 Servers are automatically registered based on their presence on the project classpath.
 
@@ -341,7 +341,7 @@ To use a valid PKCS12 certificate:
 
 <1> Creates SslOptions using PKCS12 certificates path
 
-Certificate (.p12 location can be file system or class path locations.
+Certificate (.p12) location can be file system or class path locations.
 
 Optionally you can define the SSL options in your application configuration file:
 

--- a/docs/asciidoc/session.adoc
+++ b/docs/asciidoc/session.adoc
@@ -11,7 +11,7 @@ about current user, etc.
 A session attribute must be a String or a primitive. The session doesn't allow storing of arbitrary 
 objects. It's intended as a simple mechanism to store basic data (not an object graph).
 
-Jooby provides the following javadoc::SessionStore[]:
+Jooby provides the following javadoc:SessionStore[]:
 
 - In-Memory sessions - which you should combine with an a sticky sessions proxy if you plan to run multiple instances.
 - Cookie sessions signed with a secret key
@@ -56,7 +56,7 @@ Default session store uses memory to save session data. This store:
 <2> Set a session attribute
 <3> Get a session attribute
 
-Session token/ID is retrieved it from request cookie. Default session cookie is javadoc::SessionToken[SID, text=jooby.sid]. To customize cookie details:
+Session token/ID is retrieved it from request cookie. Default session cookie is javadoc:SessionToken[SID, text=jooby.sid]. To customize cookie details:
 
 .In-Memory Session with Custom Cookie
 [source,java,role="primary"]

--- a/docs/asciidoc/static-files.adoc
+++ b/docs/asciidoc/static-files.adoc
@@ -1,6 +1,7 @@
 == Static Files
 
-Static files are available via javadoc:Router[assets, java.lang.String] route. The `assets` route
+// Not sure on this one
+Static files are available via javadoc:Router[assets, java.lang.String, java.nio.file.Path] route. The `assets` route
 supports classpath and file-system resources.
 
 .Classpath resources:
@@ -130,7 +131,7 @@ SPAs mode never generates a `NOT FOUND (404)` response, unresolved assets fallba
 
 === Options
 
-The javadoc:AssetHandler[] automatically handles `E-Tag` and `Last-Modified` headers. You can
+The javadoc:handler.AssetHandler[] automatically handles `E-Tag` and `Last-Modified` headers. You can
 control these headers programmatically:
 
 .Asset handler options:
@@ -173,11 +174,11 @@ The `maxAge` option set a `Cache-Control` header:
 }
 ----
 
-There is also a javadoc:AssetHandler[setNoCache] method that explicitly forbids web browsers
+There is also a javadoc:handler.AssetHandler[setNoCache] method that explicitly forbids web browsers
 to cache assets.
 
 You can use different cache configurations for different assets based on asset name if you
-specify a function via javadoc:AssetHandler[cacheControl, java.util.Function]:
+specify a function via javadoc:handler.AssetHandler[cacheControl, java.util.Function]:
 
 .Per-asset cache control:
 [source, java, role="primary"]

--- a/docs/asciidoc/testing.adoc
+++ b/docs/asciidoc/testing.adoc
@@ -68,7 +68,7 @@ class TestApp {
 
 Simple and easy {love}!
 
-The javadoc:MockRouter[] returns the value produced by the route handler. It is possible to get
+The javadoc:test.MockRouter[artifact=jooby-test] returns the value produced by the route handler. It is possible to get
 access and check response metadata:
 
 .App
@@ -128,7 +128,7 @@ class TestApp {
 }
 ----
 
-For more complex route context interaction or responses, you can pass in a javadoc:MockContext[]:
+For more complex route context interaction or responses, you can pass in a javadoc:test.MockContext[artifact=jooby-test]:
 
 .App
 [source,java,role="primary"]
@@ -245,14 +245,14 @@ For MVC routes you might prefer to write a unit test using a mock library. No ne
 
 ==== Options
 
-- javadoc:MockRouter[setFullExecution]: the javadoc:MockRouter[] class ONLY execute the route
-handler. For executing the entire pipeline use: javadoc:MockRouter[setFullExecution].
+- javadoc:test.MockRouter[setFullExecution, boolean, artifact=jooby-test]: the javadoc:test.MockRouter[artifact=jooby-test] class ONLY execute the route
+handler. For executing the entire pipeline use: javadoc:test.MockRouter[setFullExecution, boolean, artifact=jooby-test].
 
-- javadoc:Jooby[setLateInit]: extension modules usually run at the time they are installed it. 
-This might not be ideally for unit tests. To delay extension initialization use the javadoc:Jooby[setLateInit] mode.
+- javadoc:Jooby[setLateInit, boolean]: extension modules usually run at the time they are installed it. 
+This might not be ideally for unit tests. To delay extension initialization use the javadoc:Jooby[setLateInit, boolean] mode.
 
-Unit testing is simple and easy in Jooby. The javadoc:MockRouter[] let you execute the route function,
-while the javadoc:MockContext[] allows you to create an light-weight and mutable context where
+Unit testing is simple and easy in Jooby. The javadoc:test.MockRouter[artifact=jooby-test] let you execute the route function,
+while the javadoc:test.MockContext[artifact=jooby-test] allows you to create an light-weight and mutable context where
 you can set HTTP parameters, body, headers, etc.
 
 === Integration Testing
@@ -343,9 +343,9 @@ The example uses https://square.github.io/okhttp/[OkHttp] client, but you are fr
 
 Simple and easy {love}!
 
-The javadoc:JoobyTest[] takes care of start and stop the application.
+The javadoc:test.JoobyTest[artifact=jooby-test] takes care of start and stop the application.
 
-The default port is: `8911`. Application port can be configured directly using the javadoc:JoobyTest[port] method:
+The default port is: `8911`. Application port can be configured directly using the javadoc:test.JoobyTest[port, artifact=jooby-test] method:
 
 `@JoobyTest(value = App.class, port = 9999)`
 
@@ -391,7 +391,7 @@ Here is the list of available injectable values:
 
 These values can be injected via parameter or instance fields.
 
-The javadoc:JoobyTest[] annotation starts the application using the `test` environment name. You can
+The javadoc:test.JoobyTest[artifact=jooby-test] annotation starts the application using the `test` environment name. You can
 creates a `conf/application.test.conf` file to override any other values for testing purpose.
 
 ==== Arguments

--- a/docs/asciidoc/value-api.adoc
+++ b/docs/asciidoc/value-api.adoc
@@ -247,9 +247,9 @@ Structured data decoder supports `dot` and `bracket` notation:
 
 Structured data decoder is able to reconstruct a POJO (Plain Old Java Object) from:
 
-- <<query, Query>> encoded as https://tools.ietf.org/html/rfc3986#section-2[RFC 3986]
-- <<formdata, Formdata>> encoded as `application/x-www-form-urlencoded`
-- <<multipart, Multipart>> encoded as `multipart/form-data`
+- <<context-parameters-query, Query>> encoded as https://tools.ietf.org/html/rfc3986#section-2[RFC 3986]
+- <<context-parameters-formdata, Formdata>> encoded as `application/x-www-form-urlencoded`
+- <<context-parameters-multipart, Multipart>> encoded as `multipart/form-data`
 
 We are going to use a `Group` and `Member` objects to demonstrate how the decoder works:
 

--- a/docs/asciidoc/websocket.adoc
+++ b/docs/asciidoc/websocket.adoc
@@ -89,7 +89,7 @@ to modify the HTTP context or produces a response from it:
 
 === Structured data
 
-Structure data is supported using the Value API and the javadoc:WebSocket[render] method:
+Structure data is supported using the Value API and the javadoc:WebSocket[render, java.lang.Object] method:
 
 .JSON example:
 

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -22,8 +22,8 @@ public class JavadocProcessor extends InlineMacroProcessor {
 
   @Override
   public PhraseNode process(StructuralNode parent, String clazz, Map<String, Object> attributes) {
-    StringBuilder link =
-        new StringBuilder("https://www.javadoc.io/doc/io.jooby/jooby/latest/io.jooby/io/jooby/");
+    StringBuilder link = generateLink(attributes);
+
     StringBuilder text = new StringBuilder();
     String[] names = clazz.split("\\.");
     List<String> pkg = new ArrayList<>();
@@ -92,5 +92,19 @@ public class JavadocProcessor extends InlineMacroProcessor {
     options.put("type", ":link");
     options.put("target", link.toString());
     return createPhraseNode(parent, "anchor", text.toString(), attributes, options);
+  }
+
+  private static StringBuilder generateLink(Map<String, Object> attributes) {
+    String library = (String) attributes.get("library");
+    StringBuilder link = new StringBuilder("https://www.javadoc.io/doc/io.jooby/jooby");
+    if (library != null) {
+      link.append("-").append(library);
+    }
+    link.append("/latest/io.jooby");
+    if (library != null) {
+      link.append('.').append(library);
+    }
+    link.append("/io/jooby/");
+    return link;
   }
 }

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -59,12 +59,14 @@ public class JavadocProcessor extends InlineMacroProcessor {
       int index = 2;
       while (attributes.get(String.valueOf(index)) != null) {
         String qualifiedType = attributes.get(String.valueOf(index)).toString();
-        link.append(qualifiedType.replace("[]", ":A").replace("&#8230;&#8203;", "..."));
+        link.append(qualifiedType.replace("[]", "%5B%5D").replace("&#8230;&#8203;", "..."));
 
         int start = qualifiedType.lastIndexOf('.');
         String simpleName = start > 0 ? qualifiedType.substring(start + 1) : qualifiedType;
 
-        text.append(simpleName);
+        // Code review comment: this feels like a hack but I can't get it to work otherwise
+        // even when replacing with the escaped version "[\]"
+        text.append(simpleName.replace("[]", "&#91;&#93;"));
 
         index += 1;
 
@@ -95,7 +97,6 @@ public class JavadocProcessor extends InlineMacroProcessor {
   }
 
   private static StringBuilder generateLink(Map<String, Object> attributes) {
-
     String artifact = (String) attributes.getOrDefault("artifact", "jooby");
     return new StringBuilder("https://www.javadoc.io/doc/io.jooby/")
         .append(artifact)

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -98,10 +98,14 @@ public class JavadocProcessor extends InlineMacroProcessor {
 
   private static StringBuilder generateLink(Map<String, Object> attributes) {
     String artifact = (String) attributes.getOrDefault("artifact", "jooby");
+    String packageName = (String) attributes.get("package");
+    if (packageName == null) {
+      packageName = artifact.replace('-', '.');
+    }
     return new StringBuilder("https://www.javadoc.io/doc/io.jooby/")
         .append(artifact)
         .append("/latest/io.")
-        .append(artifact.replace('-', '.'))
+        .append(packageName)
         .append("/io/jooby/");
   }
 }

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -64,8 +64,6 @@ public class JavadocProcessor extends InlineMacroProcessor {
         int start = qualifiedType.lastIndexOf('.');
         String simpleName = start > 0 ? qualifiedType.substring(start + 1) : qualifiedType;
 
-        // Code review comment: this feels like a hack but I can't get it to work otherwise
-        // even when replacing with the escaped version "[\]"
         text.append(simpleName.replace("[]", "&#91;&#93;"));
 
         index += 1;
@@ -98,14 +96,14 @@ public class JavadocProcessor extends InlineMacroProcessor {
 
   private static StringBuilder generateLink(Map<String, Object> attributes) {
     String artifact = (String) attributes.getOrDefault("artifact", "jooby");
-    String packageName = (String) attributes.get("package");
-    if (packageName == null) {
-      packageName = artifact.replace('-', '.');
+    String module = (String) attributes.get("module");
+    if (module == null) {
+      module = artifact.replace('-', '.');
     }
     return new StringBuilder("https://www.javadoc.io/doc/io.jooby/")
         .append(artifact)
         .append("/latest/io.")
-        .append(packageName)
+        .append(module)
         .append("/io/jooby/");
   }
 }

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -9,10 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import org.asciidoctor.ast.ContentNode;
 import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
@@ -38,10 +35,10 @@ public class JavadocProcessor extends InlineMacroProcessor {
         pkg.add(name);
       }
     }
-    if (pkg.size() > 0) {
-      link.append(pkg.stream().collect(Collectors.joining("/"))).append("/");
+    if (!pkg.isEmpty()) {
+      link.append(String.join("/", pkg)).append("/");
     }
-    String classname = nameList.stream().collect(Collectors.joining("."));
+    String classname = String.join(".", nameList);
     link.append(classname).append(".html");
 
     String arg1 = (String) attributes.get("1");
@@ -57,7 +54,7 @@ public class JavadocProcessor extends InlineMacroProcessor {
       }
     }
     if (method != null) {
-      link.append("#").append(method).append("-");
+      link.append("#").append(method).append("(");
       text.append(method).append("(");
       int index = 2;
       while (attributes.get(String.valueOf(index)) != null) {
@@ -72,11 +69,11 @@ public class JavadocProcessor extends InlineMacroProcessor {
         index += 1;
 
         if (attributes.get(String.valueOf(index)) != null) {
-          link.append("-");
+          link.append(",");
           text.append(",");
         }
       }
-      link.append("-");
+      link.append(")");
       String label = (String) attributes.get("text");
       if (label != null) {
         text.setLength(0);
@@ -86,9 +83,9 @@ public class JavadocProcessor extends InlineMacroProcessor {
       }
     } else if (variable != null) {
       link.append("#").append(variable);
-      text.append(attributes.getOrDefault("text", Optional.ofNullable(arg1).orElse(classname)));
+      text.append(attributes.getOrDefault("text", arg1));
     } else {
-      text.append(attributes.getOrDefault("text", Optional.ofNullable(arg1).orElse(classname)));
+      text.append(attributes.getOrDefault("text", arg1 != null ? arg1 : classname));
     }
 
     Map<String, Object> options = new HashMap<>();

--- a/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
+++ b/docs/src/main/java/io/jooby/adoc/JavadocProcessor.java
@@ -95,16 +95,12 @@ public class JavadocProcessor extends InlineMacroProcessor {
   }
 
   private static StringBuilder generateLink(Map<String, Object> attributes) {
-    String library = (String) attributes.get("library");
-    StringBuilder link = new StringBuilder("https://www.javadoc.io/doc/io.jooby/jooby");
-    if (library != null) {
-      link.append("-").append(library);
-    }
-    link.append("/latest/io.jooby");
-    if (library != null) {
-      link.append('.').append(library);
-    }
-    link.append("/io/jooby/");
-    return link;
+
+    String artifact = (String) attributes.getOrDefault("artifact", "jooby");
+    return new StringBuilder("https://www.javadoc.io/doc/io.jooby/")
+        .append(artifact)
+        .append("/latest/io.")
+        .append(artifact.replace('-', '.'))
+        .append("/io/jooby/");
   }
 }


### PR DESCRIPTION
I was having a look over the Jooby documentation on [jooby.io](https://jooby.io/) and noticed that when linking to methods in the javadoc the links weren't working as expected. For example in the [Context](https://jooby.io/#context) section there is a link to the `Context#locales()` method, the generated link for this is
`https://www.javadoc.io/doc/io.jooby/jooby/latest/io.jooby/io/jooby/Context.html#locales--`
when it needs to be
`https://www.javadoc.io/doc/io.jooby/jooby/latest/io.jooby/io/jooby/Context.html#locales()`

I have updated the JavadocProcessor to handle this as well as handling links to jooby javadoc from other artifacts (for example when linking to the netty server implementation in the [Worker Executor](https://jooby.io/#execution-model-worker-executor) section)

I've had to introduce another attribute, `module`, as well for the processor when the maven artifact doesn't line up with the declared module. This is only used in the [DB Scheduler](https://jooby.io/modules/db-scheduler/) section for now but if the documentation was updated to include javadoc links to artifacts such as `jooby-awssdk-v[1|2]` or `jooby-commons-email` then it would be used there as well.

Other minor fixes have also been applied where noticed.