### PR TITLE
Fix anchor links being overwritten

### DIFF
--- a/docs/asciidoc/packaging/packaging.adoc
+++ b/docs/asciidoc/packaging/packaging.adoc
@@ -9,7 +9,7 @@ application.
 
 [TIP]
 ====
-The https://jooby.io/#getting-started[jooby-cli] takes care of configures everything for single jar
+The link:/#getting-started[jooby-cli] takes care of configures everything for single jar
 distribution. Next example shows how to do it in case you created your application manually.
 ====
 

--- a/docs/src/main/java/io/jooby/adoc/DocPostprocessor.java
+++ b/docs/src/main/java/io/jooby/adoc/DocPostprocessor.java
@@ -1,0 +1,125 @@
+package io.jooby.adoc;
+
+import static java.util.function.Predicate.not;
+
+import java.util.LinkedHashSet;
+import java.util.UUID;
+import org.asciidoctor.extension.Postprocessor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Document.OutputSettings;
+import org.jsoup.nodes.Element;
+
+public class DocPostprocessor extends Postprocessor {
+
+  @Override
+  public String process(org.asciidoctor.ast.Document document, String output) {
+    try {
+      Document doc = Jsoup.parse(output, "UTF-8");
+
+      headerIds(doc);
+      languageTab(doc);
+      clipboard(doc);
+      externalLink(doc);
+
+      OutputSettings settings = new OutputSettings();
+      settings.prettyPrint(false);
+      settings.indentAmount(0);
+      settings.outline(false);
+      return doc.outputSettings(settings).outerHtml();
+    } catch (NullPointerException x) {
+      throw new IllegalStateException("File: " + document.getDoctitle(), x);
+    }
+  }
+
+  private static void externalLink(Document doc) {
+    doc.select("a[href^=http://], a[href^=https://]")
+        .forEach(a -> a.attr("target", "_blank"));
+  }
+
+  private static void languageTab(Document doc) {
+    for (Element primary : doc.select(".listingblock.primary")) {
+      Element secondary = primary.nextElementSibling();
+      String secondaryTitle = secondary.selectFirst(".title").text().trim();
+      Element primaryContent = primary.selectFirst(".content");
+      Element secondaryContent = secondary.selectFirst(".content");
+      secondary.remove();
+      secondaryContent.remove();
+
+      Element title = primary.selectFirst(".title");
+
+      Element tabs = doc.createElement("div").attr("class", "switch");
+      Element tab1 = tabs.appendElement("div");
+      tab1.attr("class", "switch--item option-1 selected");
+      if (secondaryTitle.equalsIgnoreCase("Kotlin")) {
+        tab1.text("Java");
+      } else {
+        tab1.text(title.text());
+      }
+
+      if (title.text().trim().equalsIgnoreCase(tab1.text().trim())) {
+        title.remove();
+      }
+
+      Element tab2 = tabs.appendElement("div");
+      tab2.attr("class", "switch--item option-2");
+      tab2.text(secondaryTitle);
+      tabs.appendTo(primary);
+      primaryContent.addClass("option-1");
+      primaryContent.appendTo(primary);
+      secondaryContent.appendTo(primary);
+      secondaryContent.addClass("hidden").addClass("option-2");
+    }
+  }
+
+  private static void headerIds(Document doc) {
+    headerIds(doc, 2);
+    headerIds(doc, 3);
+    headerIds(doc, 4);
+    headerIds(doc, 5);
+  }
+
+  private static void headerIds(Document doc, int level) {
+    doc.select("h" + level).stream()
+        .filter(not(DocPostprocessor::isDiscrete))
+        .forEach(h -> {
+          String id = h.attr("id");
+          LinkedHashSet<String> name = new LinkedHashSet<>();
+          int parent = level - 1;
+          Element p = h.parents().select("h" + parent).first();
+          if (p != null && !isDiscrete(p)) {
+            String parentId = p.attr("id");
+            if (!parentId.isEmpty()) {
+              name.add(parentId);
+            }
+          }
+          name.add(id.replaceAll("([a-zA-Z0-9-]+)-\\d+$", "$1"));
+          String newId = String.join("-", name);
+          if (!id.equals(newId)) {
+            h.attr("id", newId);
+            h.select("a").stream()
+                .filter(a -> a.attr("href").equals("#" + id) && !a.attr("class").isEmpty())
+                .forEach(a -> a.attr("href", "#" + newId));
+          }
+        });
+  }
+
+  private static boolean isDiscrete(Element e) {
+    return e.hasClass("discrete");
+  }
+
+  private static void clipboard(Document doc) {
+    for (Element code : doc.select("code.hljs")) {
+      String id = "x" + Long.toHexString(UUID.randomUUID().getMostSignificantBits());
+      code.attr("id", id);
+      Element button = code.parent().appendElement("button");
+      button.addClass("clipboard");
+      button.attr("data-clipboard-target", "#" + id);
+      Element img = button.appendElement("img");
+      img.attr("src", "/images/clippy.svg");
+      img.attr("class", "clippy");
+      img.attr("width", "13");
+      img.attr("alt", "Copy to clipboard");
+    }
+  }
+}

--- a/docs/src/main/java/io/jooby/adoc/JoobyExtensionRegistry.java
+++ b/docs/src/main/java/io/jooby/adoc/JoobyExtensionRegistry.java
@@ -13,5 +13,6 @@ public class JoobyExtensionRegistry implements ExtensionRegistry {
   public void register(Asciidoctor asciidoctor) {
     asciidoctor.javaExtensionRegistry().block("dependency", DependencyProcessor.class);
     asciidoctor.javaExtensionRegistry().inlineMacro("javadoc", JavadocProcessor.class);
+    asciidoctor.javaExtensionRegistry().postprocessor(DocPostprocessor.class);
   }
 }


### PR DESCRIPTION
I noticed that the subsection [MVC API - Execution Model](https://jooby.io/#mvc-api-execution-model) was being used as the anchor link in the content for the [Execution Model](https://jooby.io/#execution-model) heading.

I think this is due to the `tocItems` method updating all links in the documents when the id changes rather than just those within it's element
https://github.com/jooby-project/jooby/blob/5e345b59719ad18317ada7e2a7928e164d611e07/docs/src/main/java/io/jooby/adoc/DocGenerator.java#L411-L420

I have updated this method to use `h` rather than `doc` and from what I can tell from a manual pass through, all links seem to work.

I've also moved the post processing functionality to make use of the inbuilt AsciiDoctorJ [post processing extension](https://docs.asciidoctor.org/asciidoctorj/latest/extensions/postprocessor/), this should make the generation process slightly more efficient as it cuts down on the amount of file reads/writes being performed. As this is a separate change that is only tangentially related by being in the same area I can move it to it's own PR if wanted.