### PR TITLE
Add cast of lambda constructor to jooby-apt to fix ambiguous compiler error  #3756

### DIFF
--- a/modules/jooby-apt/src/main/resources/io/jooby/internal/apt/Source.java
+++ b/modules/jooby-apt/src/main/resources/io/jooby/internal/apt/Source.java
@@ -9,7 +9,7 @@ ${constructors}
     }
 
     public ${generatedClassName}(java.util.function.Supplier<${className}> provider) {
-        this(ctx -> provider.get());
+        this(ctx -> (${className}) provider.get());
     }
 
     public ${generatedClassName}(java.util.function.Function<io.jooby.Context, ${className}> factory) {

--- a/tests/src/test/java/io/jooby/i3756/C3756.java
+++ b/tests/src/test/java/io/jooby/i3756/C3756.java
@@ -1,0 +1,25 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.i3756;
+
+import io.jooby.annotation.GET;
+import io.jooby.annotation.Path;
+
+@Path("/C3756")
+public class C3756 {
+  private final S3756 s3756;
+
+  public C3756(S3756 s3756) {
+    super();
+    this.s3756 = s3756;
+  }
+
+  @GET
+  public String handle() {
+    s3756.accept("hello");
+    return "hello";
+  }
+}

--- a/tests/src/test/java/io/jooby/i3756/S3756.java
+++ b/tests/src/test/java/io/jooby/i3756/S3756.java
@@ -1,0 +1,11 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby.i3756;
+
+public interface S3756 {
+
+  void accept(String s);
+}


### PR DESCRIPTION
Let me know if you want the PR to target main or 3.x

This just adds the test module.

```
[ERROR] /Users/agent/projects/jooby/modules/jooby-apt-tests/target/generated-test-sources/test-annotations/tests/i3756/C3756_.java:[16,9] reference to C3756_ is ambiguous
[ERROR]   both constructor C3756_(tests.i3756.S3756) in tests.i3756.C3756_ and constructor C3756_(java.util.function.Function<io.jooby.Context,tests.i3756.C3756>) in tests.i3756.C3756_ match
```
