### PR TITLE
Fix typos in Quartz module job operations description

### DIFF
--- a/docs/asciidoc/modules/quartz.adoc
+++ b/docs/asciidoc/modules/quartz.adoc
@@ -322,7 +322,7 @@ Programmatic configuration is supported by providing your own `Scheduler`:
 ==== Disable Jobs at Startup
 
 Another nice feature of Quartz module is the ability to turn on/off jobs at start-up time. The turn
-on/off job is implementing by pausing (job off) and then resume (job ob) operations of scheduler.
+on/off job is implementing by pausing (job off) and then resume (job on) operations of scheduler.
 
 .Pausing Job at startup time
 [source, properties]


### PR DESCRIPTION
Corrected typos in the Quartz module documentation regarding job operations.