### PR TITLE
add missing form() with default value

### DIFF
--- a/jooby/src/main/java/io/jooby/Context.java
+++ b/jooby/src/main/java/io/jooby/Context.java
@@ -818,6 +818,19 @@ public interface Context extends Registry {
   Value form(@NonNull String name);
 
   /**
+   * Get a form field that matches the given name.
+   *
+   * <p>File upload retrieval is available using {@link Context#file(String)}.
+   *
+   * <p>Only for <code>multipart/form-data</code> request.
+   *
+   * @param name Field name.
+   * @param defaultValue Default value.
+   * @return Multipart value.
+   */
+  Value form(@NonNull String name, @NonNull String defaultValue);
+
+  /**
    * Convert form data to the given type.
    *
    * <p>Only for <code>application/x-www-form-urlencoded</code> or <code>multipart/form-data</code>

--- a/jooby/src/main/java/io/jooby/DefaultContext.java
+++ b/jooby/src/main/java/io/jooby/DefaultContext.java
@@ -453,6 +453,11 @@ public interface DefaultContext extends Context {
   }
 
   @Override
+  default Value form(@NonNull String name, @NonNull String defaultValue) {
+    return form().getOrDefault(name, defaultValue);
+  }
+
+  @Override
   default <T> T form(@NonNull Class<T> type) {
     return form().to(type);
   }

--- a/jooby/src/main/java/io/jooby/ForwardingContext.java
+++ b/jooby/src/main/java/io/jooby/ForwardingContext.java
@@ -1002,6 +1002,11 @@ public class ForwardingContext implements Context {
   }
 
   @Override
+  public Value form(@NonNull String name, @NonNull String defaultValue) {
+    return ctx.form(name, defaultValue);
+  }
+
+  @Override
   public <T> T form(@NonNull Class<T> type) {
     return ctx.form(type);
   }

--- a/modules/jooby-apt/src/test/java/tests/i3761/C3761.java
+++ b/modules/jooby-apt/src/test/java/tests/i3761/C3761.java
@@ -5,6 +5,7 @@
  */
 package tests.i3761;
 
+import io.jooby.annotation.FormParam;
 import io.jooby.annotation.GET;
 import io.jooby.annotation.Path;
 import io.jooby.annotation.QueryParam;
@@ -30,5 +31,10 @@ public class C3761 {
   @GET("/stringVal")
   public String string(@QueryParam("Hello") String stringVal) {
     return stringVal;
+  }
+
+  @GET("/boolVal")
+  public boolean bool(@FormParam("false") boolean boolVal) {
+    return boolVal;
   }
 }

--- a/modules/jooby-apt/src/test/java/tests/i3761/C3761Jakarta.java
+++ b/modules/jooby-apt/src/test/java/tests/i3761/C3761Jakarta.java
@@ -9,6 +9,7 @@ import io.jooby.annotation.GET;
 import io.jooby.annotation.Path;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.FormParam;
 
 @Path("/3761")
 public class C3761Jakarta {
@@ -31,5 +32,10 @@ public class C3761Jakarta {
   @GET("/stringVal")
   public String string(@QueryParam("stringVal") @DefaultValue("Hello") String stringVal) {
     return stringVal;
+  }
+
+  @GET("/boolVal")
+  public boolean bool(@FormParam("boolVal") @DefaultValue("false") boolean boolVal) {
+    return boolVal;
   }
 }

--- a/modules/jooby-apt/src/test/java/tests/i3761/Issue3761.java
+++ b/modules/jooby-apt/src/test/java/tests/i3761/Issue3761.java
@@ -30,5 +30,7 @@ public class Issue3761 {
         source.contains("return c.emptySet(ctx.query(\"emptySet\", \"\").value());"));
     assertTrue(
         source.contains("return c.string(ctx.query(\"stringVal\", \"Hello\").value());"));
+    assertTrue(
+        source.contains("return c.bool(ctx.form(\"boolVal\", \"false\").booleanValue());"));
   }
 }


### PR DESCRIPTION
added support of `ctx.form(paramName, defaultValue)`. It was missing, so the default value of the `@FormParam("default")` breaks the compilation