### PR TITLE
fix(undertow): resolve buffer already freed exception during shutdown

### DIFF
--- a/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowGrpcExchange.java
+++ b/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowGrpcExchange.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.xnio.IoUtils;
 import org.xnio.channels.StreamSinkChannel;
 
 import io.jooby.rpc.grpc.GrpcExchange;
@@ -144,19 +145,19 @@ public class UndertowGrpcExchange implements GrpcExchange {
                     try {
                       if (ch.flush()) {
                         ch.suspendWrites();
-                        exchange.endExchange();
+                        endExchange();
                       }
                     } catch (IOException ignored) {
                       ch.suspendWrites();
-                      exchange.endExchange();
+                      endExchange();
                     }
                   });
           responseChannel.resumeWrites();
         } else {
-          exchange.endExchange();
+          endExchange();
         }
       } catch (IOException e) {
-        exchange.endExchange();
+        endExchange();
       }
 
     } else {
@@ -169,5 +170,10 @@ public class UndertowGrpcExchange implements GrpcExchange {
       }
       exchange.endExchange();
     }
+  }
+
+  private void endExchange() {
+    IoUtils.safeClose(responseChannel);
+    IoUtils.safeClose(exchange.getRequestChannel());
   }
 }

--- a/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowGrpcInputBridge.java
+++ b/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowGrpcInputBridge.java
@@ -55,7 +55,6 @@ public class UndertowGrpcInputBridge
   public void cancel() {
     demand.set(0);
     IoUtils.safeClose(channel);
-    exchange.endExchange();
   }
 
   @Override
@@ -90,7 +89,6 @@ public class UndertowGrpcInputBridge
     } catch (Throwable t) {
       subscriber.onError(t);
       IoUtils.safeClose(channel);
-      exchange.endExchange();
     }
   }
 }


### PR DESCRIPTION
Fixes an `IllegalStateException: UT000091: Buffer has already been freed` that occurs during server teardown in gRPC tests.

When raw request or response channels are acquired, Undertow shifts the exchange lifecycle management to the channels. Explicitly invoking `exchange.endExchange()` prematurely frees the pooled ByteBuffers. During server shutdown, the HTTP/2 `FrameCloseListener` attempts to gracefully close the connection and release the same buffers, resulting in a race condition and the subsequent exception.

Removed explicit `exchange.endExchange()` calls when streams are active in `UndertowGrpcExchange` and `UndertowGrpcInputBridge`. Replaced them with XNIO's `IoUtils.safeClose(channel)`, allowing Undertow's internal state machine to naturally flush, close, and terminate the exchange.