### PR TITLE
undertow: 2.4.0.Final

### DIFF
--- a/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowHandler.java
+++ b/modules/jooby-undertow/src/main/java/io/jooby/internal/undertow/UndertowHandler.java
@@ -52,7 +52,7 @@ public class UndertowHandler implements HttpHandler {
     if (context.isHttpGet()) {
       router.match(context).execute(context);
     } else {
-      // possibly  HTTP body
+      // possibly HTTP body
       HeaderMap headers = exchange.getRequestHeaders();
       long len = parseLen(headers.getFirst(Headers.CONTENT_LENGTH));
       String chunked = headers.getFirst(Headers.TRANSFER_ENCODING);

--- a/tests/src/test/java/io/jooby/i2525/Issue2525.java
+++ b/tests/src/test/java/io/jooby/i2525/Issue2525.java
@@ -7,6 +7,8 @@ package io.jooby.i2525;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
+
 import io.jooby.jackson.Jackson2Module;
 import io.jooby.junit.ServerTest;
 import io.jooby.junit.ServerTestRunner;
@@ -36,8 +38,16 @@ public class Issue2525 {
                   rsp -> {
                     assertEquals("[]", rsp.body().string());
                   });
+              Map<String, Object> queryParams =
+                  Map.of(
+                      "foo[0][a]", 10,
+                      "foo[0][b]", 20,
+                      "foo[1][a]", 30,
+                      "foo[1][b]", 40,
+                      "something", "else");
               http.get(
-                  "/2525?foo[0][a]=10&foo[0][b]=20&foo[1][a]=30&foo[1][b]=40&something=else",
+                  "/2525",
+                  queryParams,
                   rsp -> {
                     assertEquals("[{\"a\":10,\"b\":20},{\"a\":30,\"b\":40}]", rsp.body().string());
                   });

--- a/tests/src/test/java/io/jooby/i3863/AbstractTrpcProtocolTest.java
+++ b/tests/src/test/java/io/jooby/i3863/AbstractTrpcProtocolTest.java
@@ -68,8 +68,10 @@ public abstract class AbstractTrpcProtocolTest {
                   });
 
               // Search (Multi-Argument Tuple)
+              Map<String, Object> queryMap = Map.of("input", "[\"Pulp Fiction\", 1994]");
               http.get(
-                  "/trpc/movies.search?input=[\"Pulp Fiction\", 1994]",
+                  "/trpc/movies.search",
+                  queryMap,
                   rsp -> {
                     assertThat(rsp.code()).isEqualTo(200);
                     assertThat(rsp.body().string())
@@ -195,8 +197,10 @@ public abstract class AbstractTrpcProtocolTest {
         .ready(
             http -> {
               // Validating a nullable parameter is accepted (Integer)
+              Map<String, Object> input = Map.of("input", "[\"The Godfather\", null]");
               http.get(
-                  "/trpc/movies.search?input=[\"The Godfather\", null]",
+                  "/trpc/movies.search",
+                  input,
                   rsp -> {
                     assertThat(rsp.code()).isEqualTo(200);
                     assertThat(rsp.body().string()).contains("\"The Godfather\"");


### PR DESCRIPTION
- encode query parameters
- fix #3948