### PR TITLE
[bug] Args passed to runApp are ignored by Typesafe Config when anoth…

### DIFF
--- a/jooby/src/main/java/io/jooby/Environment.java
+++ b/jooby/src/main/java/io/jooby/Environment.java
@@ -17,6 +17,7 @@ import org.jspecify.annotations.Nullable;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
 
 /**
  * Application environment contains configuration object and active environment names.
@@ -239,7 +240,17 @@ public class Environment {
    * @return Configuration object.
    */
   public static Config systemProperties() {
-    return ConfigFactory.systemProperties();
+    var systemPropertiesCopy = new Properties();
+    for (var entry : System.getProperties().entrySet()) {
+      // Java 11 introduces 'java.version.date', but we don't want that to
+      // overwrite 'java.version'
+      if (!entry.getKey().toString().startsWith("java.version.")) {
+        systemPropertiesCopy.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return ConfigFactory.parseProperties(
+        systemPropertiesCopy,
+        ConfigParseOptions.defaults().setOriginDescription("system properties"));
   }
 
   /**

--- a/jooby/src/test/java/io/jooby/EnvironmentTest.java
+++ b/jooby/src/test/java/io/jooby/EnvironmentTest.java
@@ -276,7 +276,6 @@ public class EnvironmentTest {
   @Test
   public void testSystemPropertiesAndEnv() {
     Config props = Environment.systemProperties();
-    System.out.println(props.getAnyRef("java.version"));
     assertEquals(System.getProperty("java.version"), props.getString("java.version"));
 
     Config env = Environment.systemEnv();

--- a/jooby/src/test/java/io/jooby/Issue3950.java
+++ b/jooby/src/test/java/io/jooby/Issue3950.java
@@ -1,0 +1,36 @@
+/*
+ * Jooby https://jooby.io
+ * Apache License Version 2.0 https://jooby.io/LICENSE.txt
+ * Copyright 2014 Edgar Espina
+ */
+package io.jooby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+public class Issue3950 {
+
+  @Test
+  void shouldLoadSystemPropertiesAfterFreeze() {
+    // Not here before
+    assertFalse(ConfigFactory.systemProperties().hasPath("auth_client_secret"));
+    ConfigFactory.load(ConfigFactory.parseMap(Map.of("bd", Map.of("url", "localhost"))));
+    // Not there after
+    assertFalse(ConfigFactory.systemProperties().hasPath("auth_client_secret"));
+
+    System.setProperty("auth_client_secret", "xxx");
+
+    var env = Environment.loadEnvironment(new EnvironmentOptions());
+    var config = env.getConfig();
+    // Sync from environment
+    assertEquals("xxx", config.getString("auth_client_secret"));
+    // But still not there on config system properties
+    assertFalse(ConfigFactory.systemProperties().hasPath("auth_client_secret"));
+  }
+}


### PR DESCRIPTION
…er config was previously loaded fix #3950