### PR TITLE
persistent openapi specification

### DIFF
--- a/docs/asciidoc/modules/openapi.adoc
+++ b/docs/asciidoc/modules/openapi.adoc
@@ -133,9 +133,17 @@ To avoid this behaviour you can specify maven build phase which suits your needs
 |Copy the generated OpenAPI spec to the given file in the project repository. The format is
 determined by the file extension: `.yaml`, `.yml` or `.json`. Example:
 
+.Maven:
+
     <copyOpenApiSpecTo>${project.basedir}/docs/openapi.yaml</copyOpenApiSpecTo>
 
-|`===
+.Gradle:
+
+    {
+      copyOpenApiSpecTo = file("$projectDir/docs/openapi.yaml")
+    }
+
+|===
 
 === Usage
 

--- a/docs/asciidoc/modules/openapi.adoc
+++ b/docs/asciidoc/modules/openapi.adoc
@@ -128,7 +128,14 @@ To avoid this behaviour you can specify maven build phase which suits your needs
 |`openapi.yaml`
 |Set openAPI template file path.
 
-|===
+|`copyOpenApiSpecTo`
+|
+|Copy the generated OpenAPI spec to the given file in the project repository. The format is
+determined by the file extension: `.yaml`, `.yml` or `.json`. Example:
+
+    <copyOpenApiSpecTo>${project.basedir}/docs/openapi.yaml</copyOpenApiSpecTo>
+
+|`===
 
 === Usage
 

--- a/modules/jooby-gradle-plugin/src/main/java/io/jooby/gradle/OpenAPITask.java
+++ b/modules/jooby-gradle-plugin/src/main/java/io/jooby/gradle/OpenAPITask.java
@@ -15,8 +15,13 @@ import org.gradle.api.tasks.TaskAction;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,6 +49,8 @@ public class OpenAPITask extends BaseTask {
 
   private String javadoc;
 
+  private File copyOpenApiSpecTo;
+
   /**
    * Creates an OpenAPI task.
    */
@@ -58,7 +65,7 @@ public class OpenAPITask extends BaseTask {
   public void generate() throws Throwable {
     List<Project> projects = getProjects();
 
-    String mainClass = Optional.ofNullable(this.mainClass)
+    String mainClass = ofNullable(this.mainClass)
         .orElseGet(() -> computeMainClassName(projects));
     var sources = projects.stream()
         .flatMap(project -> {
@@ -94,10 +101,48 @@ public class OpenAPITask extends BaseTask {
     OpenAPI result = tool.generate(mainClass);
 
     var adocPath = ofNullable(adoc).orElse(List.of()).stream().map(File::toPath).toList();
+    var written = new ArrayList<Path>();
     for (var format : OpenAPIGenerator.Format.values()) {
-      tool.export(result, format, Map.of("adoc", adocPath))
-          .forEach(output -> getLogger().info("  writing: " + output));
+      written.addAll(tool.export(result, format, Map.of("adoc", adocPath)));
     }
+    written.forEach(output -> getLogger().info("  writing: " + output));
+
+    if (copyOpenApiSpecTo != null) {
+      var destination = copyOpenApiSpecTo.toPath();
+      copySpec(written, destination);
+      getLogger().info("  copying: " + destination);
+    }
+  }
+
+  static void copySpec(List<Path> written, Path destination) throws IOException {
+    var format = specFormat(destination);
+    var source =
+        written.stream()
+            .filter(path -> path.getFileName().toString().endsWith("." + format.extension()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IOException(
+                        String.format(
+                            "OpenAPI %s output not found for copyOpenApiSpecTo: %s",
+                            format.name(), destination)));
+    var parent = destination.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  static OpenAPIGenerator.Format specFormat(Path destination) {
+    var name = destination.getFileName().toString().toLowerCase(Locale.ROOT);
+    if (name.endsWith(".json")) {
+      return OpenAPIGenerator.Format.JSON;
+    }
+    if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+      return OpenAPIGenerator.Format.YAML;
+    }
+    throw new IllegalArgumentException(
+        "copyOpenApiSpecTo must end with .yaml, .yml or .json: " + destination);
   }
 
   /**
@@ -241,6 +286,36 @@ public class OpenAPITask extends BaseTask {
    */
   public void setAdoc(List<File> adoc) {
     this.adoc = adoc;
+  }
+
+  /**
+   * Copy the generated OpenAPI spec to the given file. The format is determined by the file
+   * extension: <code>.yaml</code>, <code>.yml</code> or <code>.json</code>.
+   *
+   * @return Destination file.
+   */
+  @Input
+  @org.gradle.api.tasks.Optional
+  public @Nullable File getCopyOpenApiSpecTo() {
+    return copyOpenApiSpecTo;
+  }
+
+  /**
+   * Copy the generated OpenAPI spec to the given file. The format is determined by the file
+   * extension: <code>.yaml</code>, <code>.yml</code> or <code>.json</code>.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * openAPI {
+   *   copyOpenApiSpecTo = file("$projectDir/docs/openapi.yaml")
+   * }
+   * }</pre>
+   *
+   * @param copyOpenApiSpecTo Destination file.
+   */
+  public void setCopyOpenApiSpecTo(@Nullable File copyOpenApiSpecTo) {
+    this.copyOpenApiSpecTo = copyOpenApiSpecTo;
   }
 
   private Optional<String> trim(String value) {

--- a/modules/jooby-maven-plugin/src/main/java/io/jooby/maven/OpenAPIMojo.java
+++ b/modules/jooby-maven-plugin/src/main/java/io/jooby/maven/OpenAPIMojo.java
@@ -10,9 +10,14 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_CLASSE
 import static org.apache.maven.plugins.annotations.ResolutionScope.COMPILE_PLUS_RUNTIME;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -53,6 +58,9 @@ public class OpenAPIMojo extends BaseMojo {
 
   @Parameter private List<File> adoc;
 
+  @Parameter(property = "openAPI.copyOpenApiSpecTo")
+  private File copyOpenApiSpecTo;
+
   @Override
   protected void doExecute(List<MavenProject> projects, String mainClass) throws Exception {
     ClassLoader classLoader = createClassLoader(projects);
@@ -84,10 +92,48 @@ public class OpenAPIMojo extends BaseMojo {
     var result = tool.generate(mainClass);
 
     var adocPath = ofNullable(adoc).orElse(List.of()).stream().map(File::toPath).toList();
+    var written = new ArrayList<Path>();
     for (var format : OpenAPIGenerator.Format.values()) {
-      tool.export(result, format, Map.of("adoc", adocPath))
-          .forEach(output -> getLog().info("  writing: " + output));
+      written.addAll(tool.export(result, format, Map.of("adoc", adocPath)));
     }
+    written.forEach(output -> getLog().info("  writing: " + output));
+
+    if (copyOpenApiSpecTo != null) {
+      var destination = copyOpenApiSpecTo.toPath();
+      copySpec(written, destination);
+      getLog().info("  copying: " + destination);
+    }
+  }
+
+  public static void copySpec(List<Path> written, Path destination) throws IOException {
+    var format = specFormat(destination);
+    var source =
+        written.stream()
+            .filter(path -> path.getFileName().toString().endsWith("." + format.extension()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IOException(
+                        String.format(
+                            "OpenAPI %s output not found for copyOpenApiSpecTo: %s",
+                            format.name(), destination)));
+    var parent = destination.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  public static OpenAPIGenerator.Format specFormat(Path destination) {
+    var name = destination.getFileName().toString().toLowerCase(Locale.ROOT);
+    if (name.endsWith(".json")) {
+      return OpenAPIGenerator.Format.JSON;
+    }
+    if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+      return OpenAPIGenerator.Format.YAML;
+    }
+    throw new IllegalArgumentException(
+        "copyOpenApiSpecTo must end with .yaml, .yml or .json: " + destination);
   }
 
   private Optional<String> trim(String value) {
@@ -185,5 +231,31 @@ public class OpenAPIMojo extends BaseMojo {
    */
   public String getJavadoc() {
     return javadoc;
+  }
+
+  /**
+   * Copy the generated OpenAPI spec to the given file. The format is determined by the file
+   * extension: <code>.yaml</code>, <code>.yml</code> or <code>.json</code>.
+   *
+   * @return Destination file.
+   */
+  public @Nullable File getCopyOpenApiSpecTo() {
+    return copyOpenApiSpecTo;
+  }
+
+  /**
+   * Copy the generated OpenAPI spec to the given file. The format is determined by the file
+   * extension: <code>.yaml</code>, <code>.yml</code> or <code>.json</code>.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * <copyOpenApiSpecTo>${project.basedir}/docs/openapi.yaml</copyOpenApiSpecTo>
+   * }</pre>
+   *
+   * @param copyOpenApiSpecTo Destination file.
+   */
+  public void setCopyOpenApiSpecTo(@Nullable File copyOpenApiSpecTo) {
+    this.copyOpenApiSpecTo = copyOpenApiSpecTo;
   }
 }

--- a/modules/jooby-maven-plugin/src/test/java/io/jooby/maven/OpenAPIMojoTest.java
+++ b/modules/jooby-maven-plugin/src/test/java/io/jooby/maven/OpenAPIMojoTest.java
@@ -1,0 +1,57 @@
+package io.jooby.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.jooby.openapi.OpenAPIGenerator;
+
+public class OpenAPIMojoTest {
+
+  @Test
+  public void specFormat() {
+    assertEquals(
+        OpenAPIGenerator.Format.YAML, OpenAPIMojo.specFormat(Path.of("docs/openapi.yaml")));
+    assertEquals(
+        OpenAPIGenerator.Format.YAML, OpenAPIMojo.specFormat(Path.of("docs/openapi.yml")));
+    assertEquals(
+        OpenAPIGenerator.Format.JSON, OpenAPIMojo.specFormat(Path.of("docs/openapi.json")));
+    assertThrows(
+        IllegalArgumentException.class, () -> OpenAPIMojo.specFormat(Path.of("docs/openapi.txt")));
+  }
+
+  @Test
+  public void copyYamlSpec(@TempDir Path tempDir) throws Exception {
+    var outputDir = tempDir.resolve("classes/myapp");
+    Files.createDirectories(outputDir);
+    var source = outputDir.resolve("App.yaml");
+    Files.writeString(source, "openapi: 3.0.1");
+
+    var destination = tempDir.resolve("docs/openapi.yml");
+    OpenAPIMojo.copySpec(List.of(source), destination);
+
+    assertTrue(Files.isRegularFile(destination));
+    assertEquals(Files.readString(source), Files.readString(destination));
+  }
+
+  @Test
+  public void copyJsonSpec(@TempDir Path tempDir) throws Exception {
+    var outputDir = tempDir.resolve("classes/myapp");
+    Files.createDirectories(outputDir);
+    var source = outputDir.resolve("App.json");
+    Files.writeString(source, "{\"openapi\":\"3.0.1\"}");
+
+    var destination = tempDir.resolve("docs/openapi.json");
+    OpenAPIMojo.copySpec(List.of(source), destination);
+
+    assertTrue(Files.isRegularFile(destination));
+    assertEquals(Files.readString(source), Files.readString(destination));
+  }
+}


### PR DESCRIPTION
Sometimes it is useful to have your OpenAPI spec persisted in the repository (in addition to what we have in the jar). Especially nowadays, within an agentic engineering approach.

So, introducing an optional property, `copyOpenApiSpecTo` to the Maven plugin generating the spec.
Works only if the property is present; it copies the same output to the specified path.